### PR TITLE
Allow users to manage their own bookings

### DIFF
--- a/messages.pot
+++ b/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-05-25 13:42+0000\n"
+"POT-Creation-Date: 2025-05-25 15:34+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,11 +17,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.17.0\n"
 
-#: app.py:112
+#: app.py:130
 msgid "Please log in to access this page."
 msgstr ""
 
-#: app.py:1829
+#: app.py:2020
 msgid "Flask app starting..."
 msgstr ""
 
@@ -68,203 +68,211 @@ msgid "View Resources"
 msgstr ""
 
 #: templates/admin_maps.html:28 templates/index.html:27
-#: templates/log_view.html:48 templates/login.html:16
-#: templates/map_view.html:140 templates/new_booking.html:27
-#: templates/profile.html:52 templates/resources.html:27
-#: templates/user_management.html:28
+#: templates/log_view.html:48 templates/login.html:15
+#: templates/my_bookings.html:3 templates/my_bookings.html:11
+#: templates/new_booking.html:27 templates/profile.html:52
+#: templates/resources.html:27 templates/user_management.html:28
+msgid "My Bookings"
+msgstr ""
+
+#: templates/admin_maps.html:29 templates/index.html:28
+#: templates/log_view.html:49 templates/login.html:17
+#: templates/map_view.html:140 templates/new_booking.html:28
+#: templates/profile.html:53 templates/resources.html:28
+#: templates/user_management.html:29
 msgid "Admin Maps"
 msgstr ""
 
-#: templates/admin_maps.html:29 templates/log_view.html:49
-#: templates/profile.html:53 templates/user_management.html:29
-#: templates/user_management.html:37
+#: templates/admin_maps.html:30 templates/log_view.html:50
+#: templates/profile.html:54 templates/user_management.html:30
+#: templates/user_management.html:38
 msgid "User Management"
 msgstr ""
 
-#: templates/admin_maps.html:30 templates/log_view.html:50
-#: templates/log_view.html:57 templates/profile.html:54
-#: templates/user_management.html:30
+#: templates/admin_maps.html:31 templates/log_view.html:51
+#: templates/log_view.html:58 templates/profile.html:55
+#: templates/user_management.html:31
 msgid "Audit Logs"
 msgstr ""
 
-#: templates/admin_maps.html:37
+#: templates/admin_maps.html:38
 msgid "Floor Map Management"
 msgstr ""
 
-#: templates/admin_maps.html:40
+#: templates/admin_maps.html:41
 msgid "Upload New Floor Map"
 msgstr ""
 
-#: templates/admin_maps.html:43
+#: templates/admin_maps.html:44
 msgid "Map Name:"
 msgstr ""
 
-#: templates/admin_maps.html:47
+#: templates/admin_maps.html:48
 msgid "Map Image File:"
 msgstr ""
 
-#: templates/admin_maps.html:50
+#: templates/admin_maps.html:51
 msgid "Upload Map"
 msgstr ""
 
-#: templates/admin_maps.html:58
+#: templates/admin_maps.html:59
 msgid "Existing Floor Maps"
 msgstr ""
 
-#: templates/admin_maps.html:62
+#: templates/admin_maps.html:63
 msgid "Loading maps..."
 msgstr ""
 
-#: templates/admin_maps.html:69
+#: templates/admin_maps.html:70
 msgid "Define Areas on Selected Map"
 msgstr ""
 
-#: templates/admin_maps.html:73
+#: templates/admin_maps.html:74
 msgid "Selected Map"
 msgstr ""
 
-#: templates/admin_maps.html:77
+#: templates/admin_maps.html:78
 msgid "Assign Area to Resource"
 msgstr ""
 
-#: templates/admin_maps.html:79
+#: templates/admin_maps.html:80
 msgid "Select Resource:"
 msgstr ""
 
-#: templates/admin_maps.html:85 templates/admin_maps.html:168
+#: templates/admin_maps.html:86 templates/admin_maps.html:169
 msgid "Booking Permission:"
 msgstr ""
 
-#: templates/admin_maps.html:87
+#: templates/admin_maps.html:88
 msgid "Default (Requires Login, No Admin Restriction)"
 msgstr ""
 
-#: templates/admin_maps.html:88 templates/admin_maps.html:171
+#: templates/admin_maps.html:89 templates/admin_maps.html:172
 msgid "Admin Only"
 msgstr ""
 
-#: templates/admin_maps.html:93
+#: templates/admin_maps.html:94
 msgid "Authorized Specific Users (Optional):"
 msgstr ""
 
-#: templates/admin_maps.html:96
+#: templates/admin_maps.html:97
 msgid "Loading users..."
 msgstr ""
 
-#: templates/admin_maps.html:101 templates/admin_maps.html:184
+#: templates/admin_maps.html:102 templates/admin_maps.html:185
 msgid "Authorized Roles (Optional):"
 msgstr ""
 
-#: templates/admin_maps.html:103 templates/admin_maps.html:187
-#: templates/user_management.html:93
+#: templates/admin_maps.html:104 templates/admin_maps.html:188
+#: templates/user_management.html:94
 msgid "Loading roles..."
 msgstr ""
 
-#: templates/admin_maps.html:108
+#: templates/admin_maps.html:109
 msgid "Coordinates Type: Rectangle (fixed for now)"
 msgstr ""
 
-#: templates/admin_maps.html:112
+#: templates/admin_maps.html:113
 msgid "X:"
 msgstr ""
 
-#: templates/admin_maps.html:116
+#: templates/admin_maps.html:117
 msgid "Y:"
 msgstr ""
 
-#: templates/admin_maps.html:120
+#: templates/admin_maps.html:121
 msgid "Width:"
 msgstr ""
 
-#: templates/admin_maps.html:124
+#: templates/admin_maps.html:125
 msgid "Height:"
 msgstr ""
 
-#: templates/admin_maps.html:128
+#: templates/admin_maps.html:129
 msgid "Save Area for Resource"
 msgstr ""
 
-#: templates/admin_maps.html:133
+#: templates/admin_maps.html:134
 msgid "Edit Selected Area"
 msgstr ""
 
-#: templates/admin_maps.html:134
+#: templates/admin_maps.html:135
 msgid "Delete Selected Area Mapping"
 msgstr ""
 
-#: templates/admin_maps.html:139
+#: templates/admin_maps.html:140
 msgid ""
 "Select a resource from the dropdown above to see its status or publish "
 "actions."
 msgstr ""
 
-#: templates/admin_maps.html:140
+#: templates/admin_maps.html:141
 msgid "Delete Resource"
 msgstr ""
 
-#: templates/admin_maps.html:148
+#: templates/admin_maps.html:149
 msgid "Edit Resource Details"
 msgstr ""
 
-#: templates/admin_maps.html:152
+#: templates/admin_maps.html:153
 msgid "Name:"
 msgstr ""
 
-#: templates/admin_maps.html:155
+#: templates/admin_maps.html:156
 msgid "Capacity:"
 msgstr ""
 
-#: templates/admin_maps.html:158
+#: templates/admin_maps.html:159
 msgid "Equipment:"
 msgstr ""
 
-#: templates/admin_maps.html:159
+#: templates/admin_maps.html:160
 msgid "e.g., Projector, Whiteboard"
 msgstr ""
 
-#: templates/admin_maps.html:161
+#: templates/admin_maps.html:162
 msgid "Status:"
 msgstr ""
 
-#: templates/admin_maps.html:163
+#: templates/admin_maps.html:164
 msgid "Draft"
 msgstr ""
 
-#: templates/admin_maps.html:164
+#: templates/admin_maps.html:165
 msgid "Published"
 msgstr ""
 
-#: templates/admin_maps.html:165
+#: templates/admin_maps.html:166
 msgid "Archived"
 msgstr ""
 
-#: templates/admin_maps.html:170
+#: templates/admin_maps.html:171
 msgid "Default (All Authenticated Users unless specified below)"
 msgstr ""
 
-#: templates/admin_maps.html:176
+#: templates/admin_maps.html:177
 msgid "Authorized Specific Users (Optional)"
 msgstr ""
 
-#: templates/admin_maps.html:177
+#: templates/admin_maps.html:178
 msgid "If specified, only these users (and admins) can book."
 msgstr ""
 
-#: templates/admin_maps.html:185
+#: templates/admin_maps.html:186
 msgid ""
 "If specified, only users with these roles can book. This complements "
 "user-specific permissions."
 msgstr ""
 
-#: templates/admin_maps.html:191
+#: templates/admin_maps.html:192 templates/my_bookings.html:55
 msgid "Save Changes"
 msgstr ""
 
-#: templates/admin_maps.html:199 templates/index.html:46
-#: templates/log_view.html:100 templates/login.html:43
-#: templates/map_view.html:184 templates/new_booking.html:84
-#: templates/profile.html:70 templates/resources.html:102
-#: templates/user_management.html:154
+#: templates/admin_maps.html:200 templates/index.html:47
+#: templates/log_view.html:103 templates/login.html:44
+#: templates/map_view.html:184 templates/new_booking.html:85
+#: templates/profile.html:71 templates/resources.html:103
+#: templates/user_management.html:155
 msgid "&copy; 2024 Smart Resource Booking"
 msgstr ""
 
@@ -272,116 +280,124 @@ msgstr ""
 msgid "Smart Resource Booking - Dashboard"
 msgstr ""
 
-#: templates/index.html:32
+#: templates/index.html:33
 msgid "Welcome to Smart Resource Booking"
 msgstr ""
 
-#: templates/index.html:33
+#: templates/index.html:34
 msgid "Your smart solution for managing and booking resources efficiently."
 msgstr ""
 
-#: templates/index.html:35
+#: templates/index.html:36
 msgid "Available Resources (Now)"
 msgstr ""
 
-#: templates/index.html:40
+#: templates/index.html:41
 msgid "Quick Actions"
 msgstr ""
 
-#: templates/index.html:42
+#: templates/index.html:43
 msgid "Book a Room"
 msgstr ""
 
-#: templates/index.html:48
+#: templates/index.html:49
 msgid "Accessibility"
 msgstr ""
 
-#: templates/index.html:49
+#: templates/index.html:50
 msgid "Toggle High Contrast"
 msgstr ""
 
-#: templates/index.html:50
+#: templates/index.html:51
 msgid "Increase Font Size (A+)"
 msgstr ""
 
-#: templates/index.html:51
+#: templates/index.html:52
 msgid "Decrease Font Size (A-)"
 msgstr ""
 
-#: templates/index.html:52
+#: templates/index.html:53
 msgid "Reset Font Size"
+msgstr ""
+
+#: templates/index.html:55
+msgid "Language:"
+msgstr ""
+
+#: templates/index.html:57
+msgid "English"
 msgstr ""
 
 #: templates/log_view.html:6
 msgid "Audit Logs - Smart Resource Booking"
 msgstr ""
 
-#: templates/log_view.html:61
+#: templates/log_view.html:62
 msgid "Filters"
 msgstr ""
 
-#: templates/log_view.html:62
+#: templates/log_view.html:63
 msgid "Start Date:"
 msgstr ""
 
-#: templates/log_view.html:65
+#: templates/log_view.html:66
 msgid "End Date:"
 msgstr ""
 
-#: templates/log_view.html:68 templates/login.html:23 templates/profile.html:63
-#: templates/user_management.html:68
+#: templates/log_view.html:69 templates/login.html:24 templates/profile.html:64
+#: templates/user_management.html:69
 msgid "Username:"
 msgstr ""
 
-#: templates/log_view.html:69
+#: templates/log_view.html:70
 msgid "Filter by Username"
 msgstr ""
 
-#: templates/log_view.html:71
+#: templates/log_view.html:72
 msgid "Action Type:"
 msgstr ""
 
-#: templates/log_view.html:72
+#: templates/log_view.html:73
 msgid "Filter by Action"
 msgstr ""
 
-#: templates/log_view.html:74
+#: templates/log_view.html:75
 msgid "Apply Filters"
 msgstr ""
 
-#: templates/log_view.html:75
+#: templates/log_view.html:76
 msgid "Clear Filters"
 msgstr ""
 
-#: templates/log_view.html:81
+#: templates/log_view.html:82
 msgid "Timestamp"
 msgstr ""
 
-#: templates/log_view.html:82
+#: templates/log_view.html:83
 msgid "User ID"
 msgstr ""
 
-#: templates/log_view.html:83 templates/user_management.html:45
+#: templates/log_view.html:84 templates/user_management.html:46
 msgid "Username"
 msgstr ""
 
-#: templates/log_view.html:84
+#: templates/log_view.html:85
 msgid "Action"
 msgstr ""
 
-#: templates/log_view.html:85
+#: templates/log_view.html:86
 msgid "Details"
 msgstr ""
 
-#: templates/log_view.html:93
+#: templates/log_view.html:94
 msgid "Previous"
 msgstr ""
 
-#: templates/log_view.html:94
+#: templates/log_view.html:95
 msgid "Page 1 of 1"
 msgstr ""
 
-#: templates/log_view.html:95
+#: templates/log_view.html:96
 msgid "Next"
 msgstr ""
 
@@ -389,19 +405,19 @@ msgstr ""
 msgid "Login - Smart Resource Booking"
 msgstr ""
 
-#: templates/login.html:15 templates/login.html:20 templates/login.html:30
+#: templates/login.html:16 templates/login.html:21 templates/login.html:31
 msgid "Login"
 msgstr ""
 
-#: templates/login.html:27 templates/user_management.html:76
+#: templates/login.html:28 templates/user_management.html:77
 msgid "Password:"
 msgstr ""
 
-#: templates/login.html:34
+#: templates/login.html:35
 msgid "OR"
 msgstr ""
 
-#: templates/login.html:36
+#: templates/login.html:37
 msgid "Sign in with Google"
 msgstr ""
 
@@ -429,11 +445,11 @@ msgstr ""
 msgid "Book Resource"
 msgstr ""
 
-#: templates/map_view.html:165 templates/new_booking.html:36
+#: templates/map_view.html:165 templates/new_booking.html:37
 msgid "Resource:"
 msgstr ""
 
-#: templates/map_view.html:166 templates/new_booking.html:42
+#: templates/map_view.html:166 templates/new_booking.html:43
 msgid "Date:"
 msgstr ""
 
@@ -445,47 +461,83 @@ msgstr ""
 msgid "Confirm Booking"
 msgstr ""
 
+#: templates/my_bookings.html:18
+msgid "Loading your bookings..."
+msgstr ""
+
+#: templates/my_bookings.html:27
+msgid "Title"
+msgstr ""
+
+#: templates/my_bookings.html:28
+msgid "Starts"
+msgstr ""
+
+#: templates/my_bookings.html:29
+msgid "Ends"
+msgstr ""
+
+#: templates/my_bookings.html:31
+msgid "Update Title"
+msgstr ""
+
+#: templates/my_bookings.html:32
+msgid "Cancel Booking"
+msgstr ""
+
+#: templates/my_bookings.html:42
+msgid "Update Booking Title"
+msgstr ""
+
+#: templates/my_bookings.html:48
+msgid "New Title"
+msgstr ""
+
+#: templates/my_bookings.html:54
+msgid "Close"
+msgstr ""
+
 #: templates/new_booking.html:6
 msgid "Smart Resource Booking - New Booking"
 msgstr ""
 
-#: templates/new_booking.html:32
+#: templates/new_booking.html:33
 msgid "Create New Booking"
 msgstr ""
 
-#: templates/new_booking.html:38
+#: templates/new_booking.html:39
 msgid "Loading resources..."
 msgstr ""
 
-#: templates/new_booking.html:48
+#: templates/new_booking.html:49
 msgid "Quick Time Options"
 msgstr ""
 
-#: templates/new_booking.html:51
+#: templates/new_booking.html:52
 msgid "Morning (8-12 AM)"
 msgstr ""
 
-#: templates/new_booking.html:55
+#: templates/new_booking.html:56
 msgid "Afternoon (1-5 PM)"
 msgstr ""
 
-#: templates/new_booking.html:59
+#: templates/new_booking.html:60
 msgid "Full day (8AM-5PM)"
 msgstr ""
 
-#: templates/new_booking.html:63
+#: templates/new_booking.html:64
 msgid "Manual Time"
 msgstr ""
 
-#: templates/new_booking.html:70
+#: templates/new_booking.html:71
 msgid "Start Time:"
 msgstr ""
 
-#: templates/new_booking.html:74
+#: templates/new_booking.html:75
 msgid "End Time:"
 msgstr ""
 
-#: templates/new_booking.html:79
+#: templates/new_booking.html:80
 msgid "Find Availability"
 msgstr ""
 
@@ -493,11 +545,11 @@ msgstr ""
 msgid "User Profile - Smart Resource Booking"
 msgstr ""
 
-#: templates/profile.html:60
+#: templates/profile.html:61
 msgid "User Profile"
 msgstr ""
 
-#: templates/profile.html:64 templates/user_management.html:72
+#: templates/profile.html:65 templates/user_management.html:73
 msgid "Email:"
 msgstr ""
 
@@ -505,43 +557,43 @@ msgstr ""
 msgid "Smart Resource Booking - Resource Availability"
 msgstr ""
 
-#: templates/resources.html:32
+#: templates/resources.html:33
 msgid "Resource Availability"
 msgstr ""
 
-#: templates/resources.html:34
+#: templates/resources.html:35
 msgid "Select Date:"
 msgstr ""
 
-#: templates/resources.html:38
+#: templates/resources.html:39
 msgid "Select Room:"
 msgstr ""
 
-#: templates/resources.html:41
+#: templates/resources.html:42
 msgid "Loading rooms..."
 msgstr ""
 
-#: templates/resources.html:48
+#: templates/resources.html:49
 msgid "Time Slot"
 msgstr ""
 
-#: templates/resources.html:49
+#: templates/resources.html:50
 msgid "Status"
 msgstr ""
 
-#: templates/resources.html:55 templates/resources.html:59
-#: templates/resources.html:63 templates/resources.html:67
-#: templates/resources.html:71 templates/resources.html:75
-#: templates/resources.html:79 templates/resources.html:83
-#: templates/resources.html:87
+#: templates/resources.html:56 templates/resources.html:60
+#: templates/resources.html:64 templates/resources.html:68
+#: templates/resources.html:72 templates/resources.html:76
+#: templates/resources.html:80 templates/resources.html:84
+#: templates/resources.html:88
 msgid "Available"
 msgstr ""
 
-#: templates/resources.html:93
+#: templates/resources.html:94
 msgid "View by Floor Map"
 msgstr ""
 
-#: templates/resources.html:97
+#: templates/resources.html:98
 msgid "Loading floor maps..."
 msgstr ""
 
@@ -549,91 +601,91 @@ msgstr ""
 msgid "User Management - Smart Resource Booking"
 msgstr ""
 
-#: templates/user_management.html:38 templates/user_management.html:63
+#: templates/user_management.html:39 templates/user_management.html:64
 msgid "Add New User"
 msgstr ""
 
-#: templates/user_management.html:44 templates/user_management.html:113
+#: templates/user_management.html:45 templates/user_management.html:114
 msgid "ID"
 msgstr ""
 
-#: templates/user_management.html:46
+#: templates/user_management.html:47
 msgid "Email"
 msgstr ""
 
-#: templates/user_management.html:47
+#: templates/user_management.html:48
 msgid "Admin Status"
 msgstr ""
 
-#: templates/user_management.html:48
+#: templates/user_management.html:49
 msgid "Roles"
 msgstr ""
 
-#: templates/user_management.html:49
+#: templates/user_management.html:50
 msgid "Google Connected"
 msgstr ""
 
-#: templates/user_management.html:50 templates/user_management.html:117
+#: templates/user_management.html:51 templates/user_management.html:118
 msgid "Actions"
 msgstr ""
 
-#: templates/user_management.html:78
+#: templates/user_management.html:79
 msgid "(Leave blank if not changing for an existing user)"
 msgstr ""
 
-#: templates/user_management.html:81
+#: templates/user_management.html:82
 msgid "Confirm Password:"
 msgstr ""
 
-#: templates/user_management.html:86
+#: templates/user_management.html:87
 msgid "Is Admin"
 msgstr ""
 
-#: templates/user_management.html:90
+#: templates/user_management.html:91
 msgid "Assign Roles:"
 msgstr ""
 
-#: templates/user_management.html:97
+#: templates/user_management.html:98
 msgid "Save User"
 msgstr ""
 
-#: templates/user_management.html:106
+#: templates/user_management.html:107
 msgid "Role Management"
 msgstr ""
 
-#: templates/user_management.html:107 templates/user_management.html:130
+#: templates/user_management.html:108 templates/user_management.html:131
 msgid "Add New Role"
 msgstr ""
 
-#: templates/user_management.html:114
+#: templates/user_management.html:115
 msgid "Name"
 msgstr ""
 
-#: templates/user_management.html:115
+#: templates/user_management.html:116
 msgid "Description"
 msgstr ""
 
-#: templates/user_management.html:116
+#: templates/user_management.html:117
 msgid "Permissions"
 msgstr ""
 
-#: templates/user_management.html:135
+#: templates/user_management.html:136
 msgid "Role Name:"
 msgstr ""
 
-#: templates/user_management.html:139
+#: templates/user_management.html:140
 msgid "Description:"
 msgstr ""
 
-#: templates/user_management.html:143
+#: templates/user_management.html:144
 msgid "Permissions:"
 msgstr ""
 
-#: templates/user_management.html:144
+#: templates/user_management.html:145
 msgid "Comma-separated permissions, e.g., edit_resource,view_logs"
 msgstr ""
 
-#: templates/user_management.html:147
+#: templates/user_management.html:148
 msgid "Save Role"
 msgstr ""
 

--- a/static/js/my_bookings.js
+++ b/static/js/my_bookings.js
@@ -1,0 +1,134 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const bookingsListDiv = document.getElementById('my-bookings-list');
+    const bookingItemTemplate = document.getElementById('booking-item-template');
+    const statusDiv = document.getElementById('my-bookings-status');
+
+    const updateModal = new bootstrap.Modal(document.getElementById('update-booking-modal'));
+    const updateModalElement = document.getElementById('update-booking-modal');
+    const updateBookingModalLabel = document.getElementById('updateBookingModalLabel');
+    const modalBookingIdInput = document.getElementById('modal-booking-id');
+    const newBookingTitleInput = document.getElementById('new-booking-title');
+    const saveBookingTitleBtn = document.getElementById('save-booking-title-btn');
+    const updateModalStatusDiv = document.getElementById('update-modal-status');
+
+    // Helper to display status messages (could be moved to script.js if used globally)
+    function showStatusMessage(element, message, type = 'info') {
+        element.textContent = message;
+        element.className = `alert alert-${type}`;
+        element.style.display = 'block';
+    }
+
+    function hideStatusMessage(element) {
+        element.style.display = 'none';
+    }
+    
+    async function fetchAndDisplayBookings() {
+        showLoading(statusDiv, 'Loading your bookings...');
+        try {
+            const bookings = await apiCall('/api/bookings/my_bookings', 'GET');
+            bookingsListDiv.innerHTML = ''; // Clear loading message or previous bookings
+
+            if (bookings.length === 0) {
+                showStatusMessage(statusDiv, 'You have no bookings.', 'info');
+                return;
+            }
+
+            bookings.forEach(booking => {
+                const bookingItemClone = bookingItemTemplate.content.cloneNode(true);
+                const bookingItemDiv = bookingItemClone.querySelector('.booking-item');
+
+                bookingItemDiv.dataset.bookingId = booking.id; // Store booking ID on the item div
+
+                bookingItemClone.querySelector('.resource-name').textContent = booking.resource_name;
+                const titleSpan = bookingItemClone.querySelector('.booking-title');
+                titleSpan.textContent = booking.title || 'N/A';
+                titleSpan.dataset.originalTitle = booking.title || ''; // Store original title
+
+                bookingItemClone.querySelector('.start-time').textContent = new Date(booking.start_time).toLocaleString();
+                bookingItemClone.querySelector('.end-time').textContent = new Date(booking.end_time).toLocaleString();
+                
+                const updateBtn = bookingItemClone.querySelector('.update-booking-btn');
+                updateBtn.dataset.bookingId = booking.id;
+                
+                const cancelBtn = bookingItemClone.querySelector('.cancel-booking-btn');
+                cancelBtn.dataset.bookingId = booking.id;
+
+                bookingsListDiv.appendChild(bookingItemClone);
+            });
+            hideStatusMessage(statusDiv);
+        } catch (error) {
+            console.error('Error fetching bookings:', error);
+            showError(statusDiv, error.message || 'Failed to load bookings. Please try again.');
+        }
+    }
+
+    // Event listener for dynamically created buttons
+    bookingsListDiv.addEventListener('click', async (event) => {
+        const target = event.target;
+
+        if (target.classList.contains('cancel-booking-btn')) {
+            const bookingId = target.dataset.bookingId;
+            if (confirm(`Are you sure you want to cancel booking ID ${bookingId}?`)) {
+                showLoading(statusDiv, `Cancelling booking ${bookingId}...`);
+                try {
+                    await apiCall(`/api/bookings/${bookingId}`, 'DELETE');
+                    showSuccess(statusDiv, `Booking ${bookingId} cancelled successfully.`);
+                    // Remove the booking item from the UI
+                    target.closest('.booking-item').remove();
+                    if (bookingsListDiv.children.length === 0) {
+                        showStatusMessage(statusDiv, 'You have no bookings remaining.', 'info');
+                    }
+                } catch (error) {
+                    console.error('Error cancelling booking:', error);
+                    showError(statusDiv, error.message || `Failed to cancel booking ${bookingId}.`);
+                }
+            }
+        }
+
+        if (target.classList.contains('update-booking-btn')) {
+            const bookingId = target.dataset.bookingId;
+            const bookingItemDiv = target.closest('.booking-item');
+            const currentTitle = bookingItemDiv.querySelector('.booking-title').dataset.originalTitle;
+            const resourceName = bookingItemDiv.querySelector('.resource-name').textContent;
+
+            modalBookingIdInput.value = bookingId;
+            newBookingTitleInput.value = currentTitle;
+            updateBookingModalLabel.textContent = `Update Booking Title for: ${resourceName}`;
+            hideStatusMessage(updateModalStatusDiv);
+            updateModal.show();
+        }
+    });
+
+    // Handle modal form submission for updating title
+    saveBookingTitleBtn.addEventListener('click', async () => {
+        const bookingId = modalBookingIdInput.value;
+        const newTitle = newBookingTitleInput.value.trim();
+
+        if (!newTitle) {
+            showStatusMessage(updateModalStatusDiv, 'Title cannot be empty.', 'danger');
+            return;
+        }
+        showLoading(updateModalStatusDiv, 'Saving changes...');
+
+        try {
+            const updatedBooking = await apiCall(`/api/bookings/${bookingId}`, 'PUT', { title: newTitle });
+            
+            // Update the UI
+            const bookingItemDiv = bookingsListDiv.querySelector(`.booking-item[data-booking-id="${bookingId}"]`);
+            if (bookingItemDiv) {
+                const titleSpan = bookingItemDiv.querySelector('.booking-title');
+                titleSpan.textContent = updatedBooking.title;
+                titleSpan.dataset.originalTitle = updatedBooking.title;
+            }
+            
+            showSuccess(statusDiv, `Booking ${bookingId} title updated successfully.`);
+            updateModal.hide();
+        } catch (error) {
+            console.error('Error updating booking title:', error);
+            showError(updateModalStatusDiv, error.message || 'Failed to update title.');
+        }
+    });
+    
+    // Initial fetch of bookings
+    fetchAndDisplayBookings();
+});

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -121,6 +121,7 @@ async function updateAuthLink() {
     const userDropdownButton = document.getElementById('user-dropdown-button');
     const userDropdownMenu = document.getElementById('user-dropdown-menu');
     const logoutLinkDropdown = document.getElementById('logout-link-dropdown');
+    const myBookingsNavLink = document.getElementById('my-bookings-nav-link'); // Added
 
     const loginUrl = document.body.dataset.loginUrl || '/login';
 
@@ -141,6 +142,7 @@ async function updateAuthLink() {
             authLinkContainer.style.display = 'list-item';
         }
         if (adminMapsNavLink) adminMapsNavLink.style.display = 'none';
+        if (myBookingsNavLink) myBookingsNavLink.style.display = 'none'; // Added
     }
 
     try {
@@ -166,6 +168,9 @@ async function updateAuthLink() {
             if (authLinkContainer) authLinkContainer.style.display = 'none';
             if (adminMapsNavLink) {
                 adminMapsNavLink.style.display = data.user.is_admin ? 'list-item' : 'none';
+            }
+            if (myBookingsNavLink) { // Added
+                myBookingsNavLink.style.display = 'list-item'; // Show if logged in
             }
 
             if (logoutLinkDropdown) {

--- a/templates/admin_maps.html
+++ b/templates/admin_maps.html
@@ -25,6 +25,7 @@
                 <li><a href="{{ url_for('serve_index') }}">{{ _('Home') }}</a></li>
                 <li><a href="{{ url_for('serve_new_booking') }}">{{ _('New Booking') }}</a></li>
                 <li><a href="{{ url_for('serve_resources') }}">{{ _('View Resources') }}</a></li>
+                <li id="my-bookings-nav-link" style="display:none;"><a href="{{ url_for('serve_my_bookings_page') }}">{{ _('My Bookings') }}</a></li>
                 <li id="admin-maps-nav-link" style="display:none;"><a href="{{ url_for('serve_admin_maps') }}">{{ _('Admin Maps') }}</a></li>
                 <li id="user-management-nav-link" style="display:none;"><a href="{{ url_for('serve_user_management_page') }}">{{ _('User Management') }}</a></li>
                 <li id="log-nav-link" style="display:none;"><a href="{{ url_for('serve_audit_log_page') }}">{{ _('Audit Logs') }}</a></li>

--- a/templates/index.html
+++ b/templates/index.html
@@ -24,6 +24,7 @@
             <li><a href="{{ url_for('serve_index') }}">{{ _('Home') }}</a></li>
             <li><a href="{{ url_for('serve_new_booking') }}">{{ _('New Booking') }}</a></li>
             <li><a href="{{ url_for('serve_resources') }}">{{ _('View Resources') }}</a></li>
+            <li id="my-bookings-nav-link" style="display:none;"><a href="{{ url_for('serve_my_bookings_page') }}">{{ _('My Bookings') }}</a></li>
             <li id="admin-maps-nav-link" style="display:none;"><a href="{{ url_for('serve_admin_maps') }}">{{ _('Admin Maps') }}</a></li>
             <li id="auth-link-container" style="display:none;"><!-- Login link if not logged in --></li> 
         </ul>

--- a/templates/log_view.html
+++ b/templates/log_view.html
@@ -45,6 +45,7 @@
                 <li><a href="{{ url_for('serve_index') }}">{{ _('Home') }}</a></li>
                 <li><a href="{{ url_for('serve_new_booking') }}">{{ _('New Booking') }}</a></li>
                 <li><a href="{{ url_for('serve_resources') }}">{{ _('View Resources') }}</a></li>
+                <li id="my-bookings-nav-link" style="display:none;"><a href="{{ url_for('serve_my_bookings_page') }}">{{ _('My Bookings') }}</a></li>
                 <li id="admin-maps-nav-link" style="display:none;"><a href="{{ url_for('serve_admin_maps') }}">{{ _('Admin Maps') }}</a></li>
                 <li id="user-management-nav-link" style="display:none;"><a href="{{ url_for('serve_user_management_page') }}">{{ _('User Management') }}</a></li>
                 <li id="log-nav-link" style="display:none;"><a href="{{ url_for('serve_audit_log_page') }}">{{ _('Audit Logs') }}</a></li>

--- a/templates/login.html
+++ b/templates/login.html
@@ -12,6 +12,7 @@
             <li><a href="{{ url_for('serve_index') }}">{{ _('Home') }}</a></li>
             <li><a href="{{ url_for('serve_new_booking') }}">{{ _('New Booking') }}</a></li>
             <li><a href="{{ url_for('serve_resources') }}">{{ _('View Resources') }}</a></li>
+            <li id="my-bookings-nav-link" style="display:none;"><a href="{{ url_for('serve_my_bookings_page') }}">{{ _('My Bookings') }}</a></li>
             <li id="auth-link-container"><a href="{{ url_for('serve_login') }}">{{ _('Login') }}</a></li>
             <li id="admin-maps-nav-link" style="display:none;"><a href="{{ url_for('serve_admin_maps') }}">{{ _('Admin Maps') }}</a></li>
         </ul>

--- a/templates/my_bookings.html
+++ b/templates/my_bookings.html
@@ -1,0 +1,67 @@
+{% extends "base.html" %}
+
+{% block title %}{{ _('My Bookings') }} - {{ super() }}{% endblock %}
+
+{% block header %}
+    {% include 'header_nav.html' %}
+{% endblock %}
+
+{% block content %}
+<main class="container mt-4">
+    <h2>{{ _('My Bookings') }}</h2>
+    <hr>
+
+    <div id="my-bookings-status" class="alert" style="display:none;"></div>
+
+    <div id="my-bookings-list">
+        <!-- Bookings will be loaded here by JavaScript -->
+        <p>{{ _('Loading your bookings...') }}</p>
+    </div>
+
+    <!-- Template for a single booking item (hidden, used by JS) -->
+    <template id="booking-item-template">
+        <div class="card mb-3 booking-item">
+            <div class="card-body">
+                <h5 class="card-title resource-name"></h5>
+                <p class="card-text">
+                    <strong>{{ _('Title') }}:</strong> <span class="booking-title"></span><br>
+                    <strong>{{ _('Starts') }}:</strong> <span class="start-time"></span><br>
+                    <strong>{{ _('Ends') }}:</strong> <span class="end-time"></span>
+                </p>
+                <button class="btn btn-sm btn-primary update-booking-btn" data-booking-id="">{{ _('Update Title') }}</button>
+                <button class="btn btn-sm btn-danger cancel-booking-btn" data-booking-id="">{{ _('Cancel Booking') }}</button>
+            </div>
+        </div>
+    </template>
+
+    <!-- Modal for Updating Booking Title -->
+    <div class="modal fade" id="update-booking-modal" tabindex="-1" aria-labelledby="updateBookingModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="updateBookingModalLabel">{{ _('Update Booking Title') }}</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <input type="hidden" id="modal-booking-id" value="">
+                    <div class="mb-3">
+                        <label for="new-booking-title" class="form-label">{{ _('New Title') }}:</label>
+                        <input type="text" class="form-control" id="new-booking-title" required>
+                    </div>
+                    <div id="update-modal-status" class="alert" style="display:none;"></div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ _('Close') }}</button>
+                    <button type="button" class="btn btn-primary" id="save-booking-title-btn">{{ _('Save Changes') }}</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+</main>
+{% endblock %}
+
+{% block scripts %}
+    {{ super() }}
+    <script src="{{ url_for('static', filename='js/my_bookings.js') }}" defer></script>
+{% endblock %}

--- a/templates/new_booking.html
+++ b/templates/new_booking.html
@@ -24,6 +24,7 @@
             <li><a href="{{ url_for('serve_index') }}">{{ _('Home') }}</a></li>
             <li><a href="{{ url_for('serve_new_booking') }}">{{ _('New Booking') }}</a></li>
             <li><a href="{{ url_for('serve_resources') }}">{{ _('View Resources') }}</a></li>
+            <li id="my-bookings-nav-link" style="display:none;"><a href="{{ url_for('serve_my_bookings_page') }}">{{ _('My Bookings') }}</a></li>
             <li id="admin-maps-nav-link" style="display:none;"><a href="{{ url_for('serve_admin_maps') }}">{{ _('Admin Maps') }}</a></li>
             <li id="auth-link-container" style="display:none;"><!-- Login link if not logged in --></li> 
         </ul>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -49,6 +49,7 @@
             <li><a href="{{ url_for('serve_index') }}">{{ _('Home') }}</a></li>
             <li><a href="{{ url_for('serve_new_booking') }}">{{ _('New Booking') }}</a></li>
             <li><a href="{{ url_for('serve_resources') }}">{{ _('View Resources') }}</a></li>
+            <li id="my-bookings-nav-link" style="display:none;"><a href="{{ url_for('serve_my_bookings_page') }}">{{ _('My Bookings') }}</a></li>
             <li id="admin-maps-nav-link" style="display:none;"><a href="{{ url_for('serve_admin_maps') }}">{{ _('Admin Maps') }}</a></li>
             <li id="user-management-nav-link" style="display:none;"><a href="{{ url_for('serve_user_management_page') }}">{{ _('User Management') }}</a></li>
             <li id="log-nav-link" style="display:none;"><a href="{{ url_for('serve_audit_log_page') }}">{{ _('Audit Logs') }}</a></li>

--- a/templates/resources.html
+++ b/templates/resources.html
@@ -24,6 +24,7 @@
             <li><a href="{{ url_for('serve_index') }}">{{ _('Home') }}</a></li>
             <li><a href="{{ url_for('serve_new_booking') }}">{{ _('New Booking') }}</a></li>
             <li><a href="{{ url_for('serve_resources') }}">{{ _('View Resources') }}</a></li>
+            <li id="my-bookings-nav-link" style="display:none;"><a href="{{ url_for('serve_my_bookings_page') }}">{{ _('My Bookings') }}</a></li>
             <li id="admin-maps-nav-link" style="display:none;"><a href="{{ url_for('serve_admin_maps') }}">{{ _('Admin Maps') }}</a></li>
             <li id="auth-link-container" style="display:none;"><!-- Login link if not logged in --></li> 
         </ul>

--- a/templates/user_management.html
+++ b/templates/user_management.html
@@ -25,6 +25,7 @@
                 <li><a href="{{ url_for('serve_index') }}">{{ _('Home') }}</a></li>
                 <li><a href="{{ url_for('serve_new_booking') }}">{{ _('New Booking') }}</a></li>
                 <li><a href="{{ url_for('serve_resources') }}">{{ _('View Resources') }}</a></li>
+                <li id="my-bookings-nav-link" style="display:none;"><a href="{{ url_for('serve_my_bookings_page') }}">{{ _('My Bookings') }}</a></li>
                 <li id="admin-maps-nav-link" style="display:none;"><a href="{{ url_for('serve_admin_maps') }}">{{ _('Admin Maps') }}</a></li>
                 <li id="user-management-nav-link" style="display:none;"><a href="{{ url_for('serve_user_management_page') }}">{{ _('User Management') }}</a></li>
                 <li id="log-nav-link" style="display:none;"><a href="{{ url_for('serve_audit_log_page') }}">{{ _('Audit Logs') }}</a></li>

--- a/translations/en/LC_MESSAGES/messages.po
+++ b/translations/en/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-05-25 13:42+0000\n"
+"POT-Creation-Date: 2025-05-25 15:34+0000\n"
 "PO-Revision-Date: 2025-05-25 13:42+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en\n"
@@ -18,11 +18,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.17.0\n"
 
-#: app.py:112
+#: app.py:130
 msgid "Please log in to access this page."
 msgstr ""
 
-#: app.py:1829
+#: app.py:2020
 msgid "Flask app starting..."
 msgstr ""
 
@@ -69,203 +69,211 @@ msgid "View Resources"
 msgstr ""
 
 #: templates/admin_maps.html:28 templates/index.html:27
-#: templates/log_view.html:48 templates/login.html:16
-#: templates/map_view.html:140 templates/new_booking.html:27
-#: templates/profile.html:52 templates/resources.html:27
-#: templates/user_management.html:28
+#: templates/log_view.html:48 templates/login.html:15
+#: templates/my_bookings.html:3 templates/my_bookings.html:11
+#: templates/new_booking.html:27 templates/profile.html:52
+#: templates/resources.html:27 templates/user_management.html:28
+msgid "My Bookings"
+msgstr "My Bookings"
+
+#: templates/admin_maps.html:29 templates/index.html:28
+#: templates/log_view.html:49 templates/login.html:17
+#: templates/map_view.html:140 templates/new_booking.html:28
+#: templates/profile.html:53 templates/resources.html:28
+#: templates/user_management.html:29
 msgid "Admin Maps"
 msgstr ""
 
-#: templates/admin_maps.html:29 templates/log_view.html:49
-#: templates/profile.html:53 templates/user_management.html:29
-#: templates/user_management.html:37
+#: templates/admin_maps.html:30 templates/log_view.html:50
+#: templates/profile.html:54 templates/user_management.html:30
+#: templates/user_management.html:38
 msgid "User Management"
 msgstr ""
 
-#: templates/admin_maps.html:30 templates/log_view.html:50
-#: templates/log_view.html:57 templates/profile.html:54
-#: templates/user_management.html:30
+#: templates/admin_maps.html:31 templates/log_view.html:51
+#: templates/log_view.html:58 templates/profile.html:55
+#: templates/user_management.html:31
 msgid "Audit Logs"
 msgstr ""
 
-#: templates/admin_maps.html:37
+#: templates/admin_maps.html:38
 msgid "Floor Map Management"
 msgstr ""
 
-#: templates/admin_maps.html:40
+#: templates/admin_maps.html:41
 msgid "Upload New Floor Map"
 msgstr ""
 
-#: templates/admin_maps.html:43
+#: templates/admin_maps.html:44
 msgid "Map Name:"
 msgstr ""
 
-#: templates/admin_maps.html:47
+#: templates/admin_maps.html:48
 msgid "Map Image File:"
 msgstr ""
 
-#: templates/admin_maps.html:50
+#: templates/admin_maps.html:51
 msgid "Upload Map"
 msgstr ""
 
-#: templates/admin_maps.html:58
+#: templates/admin_maps.html:59
 msgid "Existing Floor Maps"
 msgstr ""
 
-#: templates/admin_maps.html:62
+#: templates/admin_maps.html:63
 msgid "Loading maps..."
 msgstr ""
 
-#: templates/admin_maps.html:69
+#: templates/admin_maps.html:70
 msgid "Define Areas on Selected Map"
 msgstr ""
 
-#: templates/admin_maps.html:73
+#: templates/admin_maps.html:74
 msgid "Selected Map"
 msgstr ""
 
-#: templates/admin_maps.html:77
+#: templates/admin_maps.html:78
 msgid "Assign Area to Resource"
 msgstr ""
 
-#: templates/admin_maps.html:79
+#: templates/admin_maps.html:80
 msgid "Select Resource:"
 msgstr ""
 
-#: templates/admin_maps.html:85 templates/admin_maps.html:168
+#: templates/admin_maps.html:86 templates/admin_maps.html:169
 msgid "Booking Permission:"
 msgstr ""
 
-#: templates/admin_maps.html:87
+#: templates/admin_maps.html:88
 msgid "Default (Requires Login, No Admin Restriction)"
 msgstr ""
 
-#: templates/admin_maps.html:88 templates/admin_maps.html:171
+#: templates/admin_maps.html:89 templates/admin_maps.html:172
 msgid "Admin Only"
 msgstr ""
 
-#: templates/admin_maps.html:93
+#: templates/admin_maps.html:94
 msgid "Authorized Specific Users (Optional):"
 msgstr ""
 
-#: templates/admin_maps.html:96
+#: templates/admin_maps.html:97
 msgid "Loading users..."
 msgstr ""
 
-#: templates/admin_maps.html:101 templates/admin_maps.html:184
+#: templates/admin_maps.html:102 templates/admin_maps.html:185
 msgid "Authorized Roles (Optional):"
 msgstr ""
 
-#: templates/admin_maps.html:103 templates/admin_maps.html:187
-#: templates/user_management.html:93
+#: templates/admin_maps.html:104 templates/admin_maps.html:188
+#: templates/user_management.html:94
 msgid "Loading roles..."
 msgstr ""
 
-#: templates/admin_maps.html:108
+#: templates/admin_maps.html:109
 msgid "Coordinates Type: Rectangle (fixed for now)"
 msgstr ""
 
-#: templates/admin_maps.html:112
+#: templates/admin_maps.html:113
 msgid "X:"
 msgstr ""
 
-#: templates/admin_maps.html:116
+#: templates/admin_maps.html:117
 msgid "Y:"
 msgstr ""
 
-#: templates/admin_maps.html:120
+#: templates/admin_maps.html:121
 msgid "Width:"
 msgstr ""
 
-#: templates/admin_maps.html:124
+#: templates/admin_maps.html:125
 msgid "Height:"
 msgstr ""
 
-#: templates/admin_maps.html:128
+#: templates/admin_maps.html:129
 msgid "Save Area for Resource"
 msgstr ""
 
-#: templates/admin_maps.html:133
+#: templates/admin_maps.html:134
 msgid "Edit Selected Area"
 msgstr ""
 
-#: templates/admin_maps.html:134
+#: templates/admin_maps.html:135
 msgid "Delete Selected Area Mapping"
 msgstr ""
 
-#: templates/admin_maps.html:139
+#: templates/admin_maps.html:140
 msgid ""
 "Select a resource from the dropdown above to see its status or publish "
 "actions."
 msgstr ""
 
-#: templates/admin_maps.html:140
+#: templates/admin_maps.html:141
 msgid "Delete Resource"
 msgstr ""
 
-#: templates/admin_maps.html:148
+#: templates/admin_maps.html:149
 msgid "Edit Resource Details"
 msgstr ""
 
-#: templates/admin_maps.html:152
+#: templates/admin_maps.html:153
 msgid "Name:"
 msgstr ""
 
-#: templates/admin_maps.html:155
+#: templates/admin_maps.html:156
 msgid "Capacity:"
 msgstr ""
 
-#: templates/admin_maps.html:158
+#: templates/admin_maps.html:159
 msgid "Equipment:"
 msgstr ""
 
-#: templates/admin_maps.html:159
+#: templates/admin_maps.html:160
 msgid "e.g., Projector, Whiteboard"
 msgstr ""
 
-#: templates/admin_maps.html:161
+#: templates/admin_maps.html:162
 msgid "Status:"
 msgstr ""
 
-#: templates/admin_maps.html:163
+#: templates/admin_maps.html:164
 msgid "Draft"
 msgstr ""
 
-#: templates/admin_maps.html:164
+#: templates/admin_maps.html:165
 msgid "Published"
 msgstr ""
 
-#: templates/admin_maps.html:165
+#: templates/admin_maps.html:166
 msgid "Archived"
 msgstr ""
 
-#: templates/admin_maps.html:170
+#: templates/admin_maps.html:171
 msgid "Default (All Authenticated Users unless specified below)"
 msgstr ""
 
-#: templates/admin_maps.html:176
+#: templates/admin_maps.html:177
 msgid "Authorized Specific Users (Optional)"
 msgstr ""
 
-#: templates/admin_maps.html:177
+#: templates/admin_maps.html:178
 msgid "If specified, only these users (and admins) can book."
 msgstr ""
 
-#: templates/admin_maps.html:185
+#: templates/admin_maps.html:186
 msgid ""
 "If specified, only users with these roles can book. This complements "
 "user-specific permissions."
 msgstr ""
 
-#: templates/admin_maps.html:191
+#: templates/admin_maps.html:192 templates/my_bookings.html:55
 msgid "Save Changes"
 msgstr ""
 
-#: templates/admin_maps.html:199 templates/index.html:46
-#: templates/log_view.html:100 templates/login.html:43
-#: templates/map_view.html:184 templates/new_booking.html:84
-#: templates/profile.html:70 templates/resources.html:102
-#: templates/user_management.html:154
+#: templates/admin_maps.html:200 templates/index.html:47
+#: templates/log_view.html:103 templates/login.html:44
+#: templates/map_view.html:184 templates/new_booking.html:85
+#: templates/profile.html:71 templates/resources.html:103
+#: templates/user_management.html:155
 msgid "&copy; 2024 Smart Resource Booking"
 msgstr ""
 
@@ -273,116 +281,124 @@ msgstr ""
 msgid "Smart Resource Booking - Dashboard"
 msgstr ""
 
-#: templates/index.html:32
+#: templates/index.html:33
 msgid "Welcome to Smart Resource Booking"
 msgstr ""
 
-#: templates/index.html:33
+#: templates/index.html:34
 msgid "Your smart solution for managing and booking resources efficiently."
 msgstr ""
 
-#: templates/index.html:35
+#: templates/index.html:36
 msgid "Available Resources (Now)"
 msgstr ""
 
-#: templates/index.html:40
+#: templates/index.html:41
 msgid "Quick Actions"
 msgstr ""
 
-#: templates/index.html:42
+#: templates/index.html:43
 msgid "Book a Room"
 msgstr ""
 
-#: templates/index.html:48
+#: templates/index.html:49
 msgid "Accessibility"
 msgstr ""
 
-#: templates/index.html:49
+#: templates/index.html:50
 msgid "Toggle High Contrast"
 msgstr ""
 
-#: templates/index.html:50
+#: templates/index.html:51
 msgid "Increase Font Size (A+)"
 msgstr ""
 
-#: templates/index.html:51
+#: templates/index.html:52
 msgid "Decrease Font Size (A-)"
 msgstr ""
 
-#: templates/index.html:52
+#: templates/index.html:53
 msgid "Reset Font Size"
+msgstr ""
+
+#: templates/index.html:55
+msgid "Language:"
+msgstr ""
+
+#: templates/index.html:57
+msgid "English"
 msgstr ""
 
 #: templates/log_view.html:6
 msgid "Audit Logs - Smart Resource Booking"
 msgstr ""
 
-#: templates/log_view.html:61
+#: templates/log_view.html:62
 msgid "Filters"
 msgstr ""
 
-#: templates/log_view.html:62
+#: templates/log_view.html:63
 msgid "Start Date:"
 msgstr ""
 
-#: templates/log_view.html:65
+#: templates/log_view.html:66
 msgid "End Date:"
 msgstr ""
 
-#: templates/log_view.html:68 templates/login.html:23 templates/profile.html:63
-#: templates/user_management.html:68
+#: templates/log_view.html:69 templates/login.html:24 templates/profile.html:64
+#: templates/user_management.html:69
 msgid "Username:"
 msgstr ""
 
-#: templates/log_view.html:69
+#: templates/log_view.html:70
 msgid "Filter by Username"
 msgstr ""
 
-#: templates/log_view.html:71
+#: templates/log_view.html:72
 msgid "Action Type:"
 msgstr ""
 
-#: templates/log_view.html:72
+#: templates/log_view.html:73
 msgid "Filter by Action"
 msgstr ""
 
-#: templates/log_view.html:74
+#: templates/log_view.html:75
 msgid "Apply Filters"
 msgstr ""
 
-#: templates/log_view.html:75
+#: templates/log_view.html:76
 msgid "Clear Filters"
 msgstr ""
 
-#: templates/log_view.html:81
+#: templates/log_view.html:82
 msgid "Timestamp"
 msgstr ""
 
-#: templates/log_view.html:82
+#: templates/log_view.html:83
 msgid "User ID"
 msgstr ""
 
-#: templates/log_view.html:83 templates/user_management.html:45
+#: templates/log_view.html:84 templates/user_management.html:46
 msgid "Username"
 msgstr ""
 
-#: templates/log_view.html:84
+#: templates/log_view.html:85
 msgid "Action"
 msgstr ""
 
-#: templates/log_view.html:85
+#: templates/log_view.html:86
 msgid "Details"
 msgstr ""
 
-#: templates/log_view.html:93
+#: templates/log_view.html:94
 msgid "Previous"
 msgstr ""
 
-#: templates/log_view.html:94
+#: templates/log_view.html:95
 msgid "Page 1 of 1"
 msgstr ""
 
-#: templates/log_view.html:95
+#: templates/log_view.html:96
 msgid "Next"
 msgstr ""
 
@@ -390,19 +406,19 @@ msgstr ""
 msgid "Login - Smart Resource Booking"
 msgstr ""
 
-#: templates/login.html:15 templates/login.html:20 templates/login.html:30
+#: templates/login.html:16 templates/login.html:21 templates/login.html:31
 msgid "Login"
 msgstr ""
 
-#: templates/login.html:27 templates/user_management.html:76
+#: templates/login.html:28 templates/user_management.html:77
 msgid "Password:"
 msgstr ""
 
-#: templates/login.html:34
+#: templates/login.html:35
 msgid "OR"
 msgstr ""
 
-#: templates/login.html:36
+#: templates/login.html:37
 msgid "Sign in with Google"
 msgstr ""
 
@@ -430,11 +446,11 @@ msgstr ""
 msgid "Book Resource"
 msgstr ""
 
-#: templates/map_view.html:165 templates/new_booking.html:36
+#: templates/map_view.html:165 templates/new_booking.html:37
 msgid "Resource:"
 msgstr ""
 
-#: templates/map_view.html:166 templates/new_booking.html:42
+#: templates/map_view.html:166 templates/new_booking.html:43
 msgid "Date:"
 msgstr ""
 
@@ -446,47 +462,83 @@ msgstr ""
 msgid "Confirm Booking"
 msgstr ""
 
+#: templates/my_bookings.html:18
+msgid "Loading your bookings..."
+msgstr ""
+
+#: templates/my_bookings.html:27
+msgid "Title"
+msgstr ""
+
+#: templates/my_bookings.html:28
+msgid "Starts"
+msgstr ""
+
+#: templates/my_bookings.html:29
+msgid "Ends"
+msgstr ""
+
+#: templates/my_bookings.html:31
+msgid "Update Title"
+msgstr ""
+
+#: templates/my_bookings.html:32
+msgid "Cancel Booking"
+msgstr ""
+
+#: templates/my_bookings.html:42
+msgid "Update Booking Title"
+msgstr ""
+
+#: templates/my_bookings.html:48
+msgid "New Title"
+msgstr ""
+
+#: templates/my_bookings.html:54
+msgid "Close"
+msgstr ""
+
 #: templates/new_booking.html:6
 msgid "Smart Resource Booking - New Booking"
 msgstr ""
 
-#: templates/new_booking.html:32
+#: templates/new_booking.html:33
 msgid "Create New Booking"
 msgstr ""
 
-#: templates/new_booking.html:38
+#: templates/new_booking.html:39
 msgid "Loading resources..."
 msgstr ""
 
-#: templates/new_booking.html:48
+#: templates/new_booking.html:49
 msgid "Quick Time Options"
 msgstr ""
 
-#: templates/new_booking.html:51
+#: templates/new_booking.html:52
 msgid "Morning (8-12 AM)"
 msgstr ""
 
-#: templates/new_booking.html:55
+#: templates/new_booking.html:56
 msgid "Afternoon (1-5 PM)"
 msgstr ""
 
-#: templates/new_booking.html:59
+#: templates/new_booking.html:60
 msgid "Full day (8AM-5PM)"
 msgstr ""
 
-#: templates/new_booking.html:63
+#: templates/new_booking.html:64
 msgid "Manual Time"
 msgstr ""
 
-#: templates/new_booking.html:70
+#: templates/new_booking.html:71
 msgid "Start Time:"
 msgstr ""
 
-#: templates/new_booking.html:74
+#: templates/new_booking.html:75
 msgid "End Time:"
 msgstr ""
 
-#: templates/new_booking.html:79
+#: templates/new_booking.html:80
 msgid "Find Availability"
 msgstr ""
 
@@ -494,11 +546,11 @@ msgstr ""
 msgid "User Profile - Smart Resource Booking"
 msgstr ""
 
-#: templates/profile.html:60
+#: templates/profile.html:61
 msgid "User Profile"
 msgstr ""
 
-#: templates/profile.html:64 templates/user_management.html:72
+#: templates/profile.html:65 templates/user_management.html:73
 msgid "Email:"
 msgstr ""
 
@@ -506,43 +558,43 @@ msgstr ""
 msgid "Smart Resource Booking - Resource Availability"
 msgstr ""
 
-#: templates/resources.html:32
+#: templates/resources.html:33
 msgid "Resource Availability"
 msgstr ""
 
-#: templates/resources.html:34
+#: templates/resources.html:35
 msgid "Select Date:"
 msgstr ""
 
-#: templates/resources.html:38
+#: templates/resources.html:39
 msgid "Select Room:"
 msgstr ""
 
-#: templates/resources.html:41
+#: templates/resources.html:42
 msgid "Loading rooms..."
 msgstr ""
 
-#: templates/resources.html:48
+#: templates/resources.html:49
 msgid "Time Slot"
 msgstr ""
 
-#: templates/resources.html:49
+#: templates/resources.html:50
 msgid "Status"
 msgstr ""
 
-#: templates/resources.html:55 templates/resources.html:59
-#: templates/resources.html:63 templates/resources.html:67
-#: templates/resources.html:71 templates/resources.html:75
-#: templates/resources.html:79 templates/resources.html:83
-#: templates/resources.html:87
+#: templates/resources.html:56 templates/resources.html:60
+#: templates/resources.html:64 templates/resources.html:68
+#: templates/resources.html:72 templates/resources.html:76
+#: templates/resources.html:80 templates/resources.html:84
+#: templates/resources.html:88
 msgid "Available"
 msgstr ""
 
-#: templates/resources.html:93
+#: templates/resources.html:94
 msgid "View by Floor Map"
 msgstr ""
 
-#: templates/resources.html:97
+#: templates/resources.html:98
 msgid "Loading floor maps..."
 msgstr ""
 
@@ -550,91 +602,91 @@ msgstr ""
 msgid "User Management - Smart Resource Booking"
 msgstr ""
 
-#: templates/user_management.html:38 templates/user_management.html:63
+#: templates/user_management.html:39 templates/user_management.html:64
 msgid "Add New User"
 msgstr ""
 
-#: templates/user_management.html:44 templates/user_management.html:113
+#: templates/user_management.html:45 templates/user_management.html:114
 msgid "ID"
 msgstr ""
 
-#: templates/user_management.html:46
+#: templates/user_management.html:47
 msgid "Email"
 msgstr ""
 
-#: templates/user_management.html:47
+#: templates/user_management.html:48
 msgid "Admin Status"
 msgstr ""
 
-#: templates/user_management.html:48
+#: templates/user_management.html:49
 msgid "Roles"
 msgstr ""
 
-#: templates/user_management.html:49
+#: templates/user_management.html:50
 msgid "Google Connected"
 msgstr ""
 
-#: templates/user_management.html:50 templates/user_management.html:117
+#: templates/user_management.html:51 templates/user_management.html:118
 msgid "Actions"
 msgstr ""
 
-#: templates/user_management.html:78
+#: templates/user_management.html:79
 msgid "(Leave blank if not changing for an existing user)"
 msgstr ""
 
-#: templates/user_management.html:81
+#: templates/user_management.html:82
 msgid "Confirm Password:"
 msgstr ""
 
-#: templates/user_management.html:86
+#: templates/user_management.html:87
 msgid "Is Admin"
 msgstr ""
 
-#: templates/user_management.html:90
+#: templates/user_management.html:91
 msgid "Assign Roles:"
 msgstr ""
 
-#: templates/user_management.html:97
+#: templates/user_management.html:98
 msgid "Save User"
 msgstr ""
 
-#: templates/user_management.html:106
+#: templates/user_management.html:107
 msgid "Role Management"
 msgstr ""
 
-#: templates/user_management.html:107 templates/user_management.html:130
+#: templates/user_management.html:108 templates/user_management.html:131
 msgid "Add New Role"
 msgstr ""
 
-#: templates/user_management.html:114
+#: templates/user_management.html:115
 msgid "Name"
 msgstr ""
 
-#: templates/user_management.html:115
+#: templates/user_management.html:116
 msgid "Description"
 msgstr ""
 
-#: templates/user_management.html:116
+#: templates/user_management.html:117
 msgid "Permissions"
 msgstr ""
 
-#: templates/user_management.html:135
+#: templates/user_management.html:136
 msgid "Role Name:"
 msgstr ""
 
-#: templates/user_management.html:139
+#: templates/user_management.html:140
 msgid "Description:"
 msgstr ""
 
-#: templates/user_management.html:143
+#: templates/user_management.html:144
 msgid "Permissions:"
 msgstr ""
 
-#: templates/user_management.html:144
+#: templates/user_management.html:145
 msgid "Comma-separated permissions, e.g., edit_resource,view_logs"
 msgstr ""
 
-#: templates/user_management.html:147
+#: templates/user_management.html:148
 msgid "Save Role"
 msgstr ""
 


### PR DESCRIPTION
This commit implements the ability for authenticated users to list, update (title only), and cancel their own bookings.

Key changes:

Backend (app.py):
- Added GET /api/bookings/my_bookings: Returns a list of bookings made by the currently authenticated user, ordered by start time. Includes resource name for clarity.
- Added DELETE /api/bookings/<booking_id>: Allows a user to cancel their own booking. Verifies ownership before deletion.
- Added PUT /api/bookings/<booking_id>: Allows a user to update the title of their own booking. Verifies ownership.
- All new booking management endpoints include authorization checks and audit logging for relevant actions (CANCEL_BOOKING_USER, UPDATE_BOOKING_USER).

Frontend:
- Created templates/my_bookings.html: New page to display your bookings with options to update title or cancel.
- Created static/js/my_bookings.js: Handles fetching bookings, rendering them using a template, and managing UI interactions for updating title (via modal) and cancelling bookings.
- Updated static/js/script.js: Modified updateAuthLink function to correctly show/hide the "My Bookings" navigation link based on your login status.
- Updated navigation menus in all relevant HTML templates to include the "My Bookings" link.

Internationalization:
- Updated messages.pot, translations/en/LC_MESSAGES/messages.po, and compiled .mo file to include "My Bookings".

This feature enhances your self-service capabilities within the resource booking system.