### PR TITLE
Fix: Address startup, login, and logout issues

### DIFF
--- a/app.py
+++ b/app.py
@@ -285,6 +285,7 @@ def add_audit_log(action: str, details: str, user_id: int = None, username: str 
         db.session.rollback() # Rollback in case of error during audit logging itself
 
 @app.route("/")
+@login_required
 def serve_index():
     return render_template("index.html")
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -13,13 +13,37 @@
             <li><a href="{{ url_for('serve_index') }}">{{ _('Home') }}</a></li>
             <li><a href="{{ url_for('serve_new_booking') }}">{{ _('New Booking') }}</a></li>
             <li><a href="{{ url_for('serve_resources') }}">{{ _('View Resources') }}</a></li>
-            {% if current_user.is_authenticated %}
-                <li><a href="{{ url_for('serve_my_bookings_page') }}">{{ _('My Bookings') }}</a></li>
-                {# Add other authenticated user links here if needed, e.g., profile #}
-                <li><a href="/logout">{{ _('Logout') }}</a></li> {# Changed from url_for('logout') #}
-            {% else %}
-                <li><a href="{{ url_for('login') }}">{{ _('Login') }}</a></li>
-            {% endif %}
+            
+            {# General links visible to all - JavaScript will manage the display of login/logout and user info #}
+
+            {# Container for the 'Login' link - shown by JS when logged out #}
+            <li id="auth-link-container" style="display: none;">
+                <a href="{{ url_for('serve_login') }}">{{ _('Login') }}</a>
+            </li>
+
+            {# Container for 'My Bookings' - shown by JS when logged in #}
+            <li id="my-bookings-nav-link" style="display: none;">
+                 <a href="{{ url_for('serve_my_bookings_page') }}">{{ _('My Bookings') }}</a>
+            </li>
+            
+            {# Container for Admin Maps link - shown by JS if admin #}
+            <li id="admin-maps-nav-link" style="display: none;">
+                <a href="{{ url_for('serve_admin_maps') }}">{{ _('Admin Maps') }}</a>
+            </li>
+
+            {# Container for user-specific welcome message - populated by JS when logged in #}
+            <li id="welcome-message-container" style="display: none; margin-right: 10px; color: white; align-self: center;"></li>
+
+            {# Container for user dropdown (Profile, Logout) - shown by JS when logged in #}
+            <li id="user-dropdown-container" style="display: none; position: relative;">
+                <button id="user-dropdown-button" aria-haspopup="true" aria-expanded="false" style="background: none; border: none; color: white; font-size: 1em; cursor: pointer; padding: 10px 15px; font-weight: bold;">
+                    {{ _('User Menu') }} {# Placeholder, JS will update with username #}
+                </button>
+                <div class="dropdown-menu" id="user-dropdown-menu" style="display: none; position: absolute; top: 100%; left: 0; background-color: #333; border: 1px solid #555; min-width: 160px; z-index: 1000; list-style-type: none; padding: 0; margin: 0; box-shadow: 0 2px 5px rgba(0,0,0,0.2);">
+                    <a class="dropdown-item" href="{{ url_for('serve_profile_page') }}" style="display: block; padding: 10px 15px; text-decoration: none; color: white;">{{ _('Profile') }}</a>
+                    <a class="dropdown-item" href="#" id="logout-link-dropdown" style="display: block; padding: 10px 15px; text-decoration: none; color: white;">{{ _('Logout') }}</a>
+                </div>
+            </li>
             {# Links for admin users or specific roles could be added here with appropriate checks #}
             {# Example: {% if current_user.is_admin %}<li><a href="{{ url_for('serve_admin_dashboard') }}">{{ _('Admin') }}</a></li>{% endif %} #}
         </ul>


### PR DESCRIPTION
This commit resolves several issues based on your feedback:

1.  **Default to Login Screen & Prevent Auto Admin Login:**
    *   The root route (`/`) is now decorated with `@login_required`. This ensures that unauthenticated users are redirected to the `/login` page, making it the default screen.
    *   This change also helps prevent scenarios where an admin or any user might appear automatically logged in on startup due to reaching content that could trigger re-authentication flows (like Google Sign-In) before a login action.

2.  **Fix Logout Link and 404 Error:**
    *   Updated `templates/base.html` to use a JavaScript-driven approach for displaying user authentication status and handling logout.
    *   The logout link in the navigation dropdown now correctly uses `href="#"` and relies on the `handleLogout` function in `static/js/script.js`. This function makes a POST request to `/api/auth/logout`.
    *   This fixes the issue where a GET request to `/logout` was causing a 404 error.

3.  **Ensure Login Menu Appears When Logged Out:**
    *   The structure of `templates/base.html` has been revised with specific element IDs that `static/js/script.js` (`updateAuthLink` function) uses to dynamically show the "Login" link when a user is logged out, and display user information (username, Profile/Logout dropdown) when logged in.
    *   The `explicitlyLoggedOut` session storage flag, implemented previously, further ensures that the UI correctly reflects a logged-out state immediately after logout.

These changes aim to provide a standard and correct authentication flow: you will start at a login page, can log in, see appropriate UI changes, can log out reliably, and remain logged out until you choose to log in again.