### PR TITLE
Add CSRF meta to templates

### DIFF
--- a/templates/admin_maps.html
+++ b/templates/admin_maps.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ _('Admin - Floor Maps - Smart Resource Booking') }}</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ _('Smart Resource Booking - Dashboard') }}</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">

--- a/templates/log_view.html
+++ b/templates/log_view.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ _('Audit Logs - Smart Resource Booking') }}</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">

--- a/templates/login.html
+++ b/templates/login.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ _('Login - Smart Resource Booking') }}</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">

--- a/templates/map_view.html
+++ b/templates/map_view.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Title can be set dynamically later if needed -->
     <title>{{ _('Map View - Smart Resource Booking') }}</title>

--- a/templates/new_booking.html
+++ b/templates/new_booking.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ _('Smart Resource Booking - New Booking') }}</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ _('User Profile - Smart Resource Booking') }}</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">

--- a/templates/resources.html
+++ b/templates/resources.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ _('Smart Resource Booking - Resource Availability') }}</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">

--- a/templates/user_management.html
+++ b/templates/user_management.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ _('User Management - Smart Resource Booking') }}</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">


### PR DESCRIPTION
## Summary
- ensure every standalone template includes a meta CSRF token
- keep tests green

## Testing
- `PYTHONPATH=. pytest -q`