### PR TITLE
Add analytics dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /__pycache__/*
 data/site.db
 /tests/*
+!tests/__init__.py
 *.db
 /data
 __pycache__/

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -160,6 +160,7 @@ async function updateAuthLink() {
     const userDropdownMenu = document.getElementById('user-dropdown-menu');
     const logoutLinkDropdown = document.getElementById('logout-link-dropdown');
     const myBookingsNavLink = document.getElementById('my-bookings-nav-link'); // Added
+    const analyticsNavLink = document.getElementById('analytics-nav-link');
 
     const loginUrl = document.body.dataset.loginUrl || '/login';
 
@@ -182,6 +183,7 @@ async function updateAuthLink() {
         if (adminMapsNavLink) adminMapsNavLink.style.display = 'none';
         if (userManagementNavLink) userManagementNavLink.style.display = 'none';
         if (myBookingsNavLink) myBookingsNavLink.style.display = 'none'; // Added
+        if (analyticsNavLink) analyticsNavLink.style.display = 'none';
     }
 
     try {
@@ -224,6 +226,9 @@ async function updateAuthLink() {
             }
             if (myBookingsNavLink) { // Added
                 myBookingsNavLink.style.display = 'list-item'; // Show if logged in
+            }
+            if (analyticsNavLink) {
+                analyticsNavLink.style.display = data.user.is_admin ? 'list-item' : 'none';
             }
 
             if (logoutLinkDropdown) {

--- a/templates/analytics.html
+++ b/templates/analytics.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+
+{% block title %}{{ _('Analytics') }}{% endblock %}
+
+{% block content %}
+<h1>{{ _('Resource Usage Analytics') }}</h1>
+<canvas id="usageChart" width="400" height="200"></canvas>
+{% endblock %}
+
+{% block scripts %}
+    {{ super() }}
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script>
+    fetch("{{ url_for('analytics.analytics_bookings_data') }}")
+        .then(resp => resp.json())
+        .then(function(data){
+            const ctx = document.getElementById('usageChart');
+            const labelsSet = new Set();
+            Object.values(data).forEach(arr => arr.forEach(pt => labelsSet.add(pt.date)));
+            const labels = Array.from(labelsSet).sort();
+            const datasets = Object.keys(data).map(function(resource){
+                const counts = labels.map(function(l){
+                    const item = data[resource].find(d => d.date === l);
+                    return item ? item.count : 0;
+                });
+                return {label: resource, data: counts, fill:false};
+            });
+            new Chart(ctx, {type:'line', data:{labels:labels, datasets:datasets}, options:{responsive:true, scales:{y:{beginAtZero:true}}}});
+        });
+    </script>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -40,6 +40,9 @@
             <li id="log-nav-link" style="display: none;">
                 <a href="{{ url_for('serve_audit_log_page') }}">{{ _('Audit Logs') }}</a>
             </li>
+            <li id="analytics-nav-link" style="display: none;">
+                <a href="{{ url_for('analytics.analytics_dashboard') }}">{{ _('Analytics') }}</a>
+            </li>
 
 
             {# Container for user-specific welcome message - populated by JS when logged in #}

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,2 @@
+import os, sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))


### PR DESCRIPTION
## Summary
- create analytics blueprint and routes
- update default roles with `view_analytics` permission
- render analytics graphs with Chart.js
- show Analytics nav link for admins
- support imports for tests

## Testing
- `pytest -q`