### PR TITLE
Implement check-in workflow

### DIFF
--- a/static/js/my_bookings.js
+++ b/static/js/my_bookings.js
@@ -49,9 +49,20 @@ document.addEventListener('DOMContentLoaded', () => {
                 
                 const updateBtn = bookingItemClone.querySelector('.update-booking-btn');
                 updateBtn.dataset.bookingId = booking.id;
-                
+
                 const cancelBtn = bookingItemClone.querySelector('.cancel-booking-btn');
                 cancelBtn.dataset.bookingId = booking.id;
+
+                const checkInBtn = bookingItemClone.querySelector('.check-in-btn');
+                const checkOutBtn = bookingItemClone.querySelector('.check-out-btn');
+                checkInBtn.dataset.bookingId = booking.id;
+                checkOutBtn.dataset.bookingId = booking.id;
+                if (booking.can_check_in) {
+                    checkInBtn.style.display = 'inline-block';
+                }
+                if (booking.checked_in_at && !booking.checked_out_at) {
+                    checkOutBtn.style.display = 'inline-block';
+                }
 
                 bookingsListDiv.appendChild(bookingItemClone);
             });
@@ -96,6 +107,35 @@ document.addEventListener('DOMContentLoaded', () => {
             updateBookingModalLabel.textContent = `Update Booking Title for: ${resourceName}`;
             hideStatusMessage(updateModalStatusDiv);
             updateModal.show();
+        }
+
+        if (target.classList.contains('check-in-btn')) {
+            const bookingId = target.dataset.bookingId;
+            showLoading(statusDiv, 'Checking in...');
+            try {
+                await apiCall(`/api/bookings/${bookingId}/check_in`, 'POST');
+                target.style.display = 'none';
+                const bookingItemDiv = target.closest('.booking-item');
+                const checkOutBtn = bookingItemDiv.querySelector('.check-out-btn');
+                if (checkOutBtn) checkOutBtn.style.display = 'inline-block';
+                showSuccess(statusDiv, 'Checked in successfully.');
+            } catch (error) {
+                console.error('Check in failed:', error);
+                showError(statusDiv, error.message || 'Check in failed.');
+            }
+        }
+
+        if (target.classList.contains('check-out-btn')) {
+            const bookingId = target.dataset.bookingId;
+            showLoading(statusDiv, 'Checking out...');
+            try {
+                await apiCall(`/api/bookings/${bookingId}/check_out`, 'POST');
+                target.style.display = 'none';
+                showSuccess(statusDiv, 'Checked out successfully.');
+            } catch (error) {
+                console.error('Check out failed:', error);
+                showError(statusDiv, error.message || 'Check out failed.');
+            }
         }
     });
 

--- a/templates/my_bookings.html
+++ b/templates/my_bookings.html
@@ -30,6 +30,8 @@
                 </p>
                 <button class="btn btn-sm btn-primary update-booking-btn" data-booking-id="">{{ _('Update Title') }}</button>
                 <button class="btn btn-sm btn-danger cancel-booking-btn" data-booking-id="">{{ _('Cancel Booking') }}</button>
+                <button class="btn btn-sm btn-success check-in-btn" data-booking-id="" style="display:none;">{{ _('Check In') }}</button>
+                <button class="btn btn-sm btn-secondary check-out-btn" data-booking-id="" style="display:none;">{{ _('Check Out') }}</button>
             </div>
         </div>
     </template>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -263,6 +263,22 @@ class AppTests(unittest.TestCase):
         self.assertIn('date', first_entry)
         self.assertIn('count', first_entry)
 
+    def test_check_in_and_out_endpoints(self):
+        self.login('testuser', 'password')
+        start = datetime.utcnow() - timedelta(minutes=1)
+        end = start + timedelta(hours=1)
+        booking = Booking(resource_id=self.resource1.id, user_name='testuser', start_time=start, end_time=end, title='CI Test')
+        db.session.add(booking)
+        db.session.commit()
+
+        resp = self.client.post(f'/api/bookings/{booking.id}/check_in')
+        self.assertEqual(resp.status_code, 200)
+        self.assertIsNotNone(Booking.query.get(booking.id).checked_in_at)
+
+        resp = self.client.post(f'/api/bookings/{booking.id}/check_out')
+        self.assertEqual(resp.status_code, 200)
+        self.assertIsNotNone(Booking.query.get(booking.id).checked_out_at)
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- add `checked_in_at` and `checked_out_at` columns to `Booking`
- create `/api/bookings/<id>/check_in` and `/check_out` endpoints
- show check-in / check-out buttons on bookings list
- allow map modal check-in
- add background job to cancel unclaimed bookings
- test check-in/out flow

## Testing
- `bash tests/setup.sh`
- `pytest -q`