### PR TITLE
Add location and floor to floor maps

### DIFF
--- a/app.py
+++ b/app.py
@@ -271,9 +271,12 @@ class FloorMap(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(100), nullable=False)
     image_filename = db.Column(db.String(255), nullable=False, unique=True) # Store unique filename
+    location = db.Column(db.String(100), nullable=True)
+    floor = db.Column(db.String(50), nullable=True)
 
     def __repr__(self):
-        return f"<FloorMap {self.name} ({self.image_filename})>"
+        loc_floor = f"{self.location or 'N/A'} - Floor {self.floor}" if self.location or self.floor else ""
+        return f"<FloorMap {self.name} ({loc_floor})>"
 
 # Association table for Resource and Role (Many-to-Many for resource-specific role permissions)
 resource_roles_table = db.Table('resource_roles',
@@ -914,6 +917,8 @@ def upload_floor_map():
     
     file = request.files['map_image']
     map_name = request.form.get('map_name')
+    location = request.form.get('location')
+    floor = request.form.get('floor')
 
     if not map_name:
         app.logger.warning("Map name missing in upload request.")
@@ -942,7 +947,8 @@ def upload_floor_map():
             file_path = os.path.join(app.config['UPLOAD_FOLDER'], filename)
             file.save(file_path)
 
-            new_map = FloorMap(name=map_name, image_filename=filename)
+            new_map = FloorMap(name=map_name, image_filename=filename,
+                               location=location, floor=floor)
             db.session.add(new_map)
             db.session.commit()
             app.logger.info(f"Floor map '{map_name}' uploaded successfully by {current_user.username}.")
@@ -951,6 +957,8 @@ def upload_floor_map():
                 'id': new_map.id,
                 'name': new_map.name,
                 'image_filename': new_map.image_filename,
+                'location': new_map.location,
+                'floor': new_map.floor,
                 'image_url': url_for('static', filename=f'floor_map_uploads/{new_map.image_filename}')
             }), 201
         except Exception as e:
@@ -979,6 +987,8 @@ def get_floor_maps():
                 'id': m.id,
                 'name': m.name,
                 'image_filename': m.image_filename,
+                'location': m.location,
+                'floor': m.floor,
                 'image_url': url_for('static', filename=f'floor_map_uploads/{m.image_filename}')
             })
         app.logger.info("Successfully fetched all floor maps for admin.")
@@ -1902,7 +1912,9 @@ def get_map_details(map_id):
         map_details_response = {
             'id': floor_map.id,
             'name': floor_map.name,
-            'image_url': url_for('static', filename=f'floor_map_uploads/{floor_map.image_filename}')
+            'image_url': url_for('static', filename=f'floor_map_uploads/{floor_map.image_filename}'),
+            'location': floor_map.location,
+            'floor': floor_map.floor
         }
         
         # Ensure only published resources are shown on the public map view

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -994,31 +994,61 @@ Enter a title for your booking (optional):`);
         
         // Logic for displaying floor map links on resources.html
         const floorMapsListUl = document.getElementById('floor-maps-list');
-        const floorMapsLoadingStatusDiv = document.getElementById('floor-maps-loading-status'); 
-        if (floorMapsListUl && floorMapsLoadingStatusDiv) { 
+        const floorMapsLoadingStatusDiv = document.getElementById('floor-maps-loading-status');
+        const locationFilter = document.getElementById('location-filter');
+        const floorFilter = document.getElementById('floor-filter');
+        if (floorMapsListUl && floorMapsLoadingStatusDiv) {
+            let allMaps = [];
+
+            function renderMapLinks() {
+                floorMapsListUl.innerHTML = '';
+                const loc = locationFilter ? locationFilter.value : '';
+                const fl = floorFilter ? floorFilter.value : '';
+                const filtered = allMaps.filter(m => (!loc || m.location === loc) && (!fl || m.floor === fl));
+                if (filtered.length === 0) {
+                    floorMapsListUl.innerHTML = '<li>No floor maps match selection.</li>';
+                    return;
+                }
+                filtered.forEach(map => {
+                    const li = document.createElement('li');
+                    const link = document.createElement('a');
+                    link.href = `/map_view/${map.id}`;
+                    link.textContent = map.name;
+                    li.appendChild(link);
+                    floorMapsListUl.appendChild(li);
+                });
+            }
+
+            function updateFloorOptions() {
+                if (!floorFilter) return;
+                const loc = locationFilter ? locationFilter.value : '';
+                const floors = [...new Set(allMaps.filter(m => !loc || m.location === loc).map(m => m.floor).filter(f => f))];
+                floorFilter.innerHTML = '<option value="">All</option>';
+                floors.forEach(f => {
+                    const opt = new Option(f, f);
+                    floorFilter.add(opt);
+                });
+            }
+
             async function fetchAndDisplayFloorMapLinks() {
                 try {
-                    const maps = await apiCall('/api/admin/maps', {}, floorMapsLoadingStatusDiv); 
-                    floorMapsListUl.innerHTML = ''; 
-                    if (!maps || maps.length === 0) {
-                        showSuccess(floorMapsLoadingStatusDiv, 'No floor maps available.');
-                        return;
+                    const maps = await apiCall('/api/admin/maps', {}, floorMapsLoadingStatusDiv);
+                    allMaps = maps || [];
+                    if (locationFilter) {
+                        const locations = [...new Set(allMaps.map(m => m.location).filter(l => l))];
+                        locationFilter.innerHTML = '<option value="">All</option>';
+                        locations.forEach(loc => locationFilter.add(new Option(loc, loc)));
                     }
-                    maps.forEach(map => {
-                        const listItem = document.createElement('li');
-                        const link = document.createElement('a');
-                        link.href = `/map_view/${map.id}`; 
-                        link.textContent = map.name;
-                        listItem.appendChild(link);
-                        floorMapsListUl.appendChild(listItem);
-                    });
-                     // apiCall success default behavior is to hide messageElement if no specific success message from API.
-                     // If a message was shown, and it wasn't an error, it's fine for it to be hidden.
+                    updateFloorOptions();
+                    renderMapLinks();
                 } catch (error) {
-                    // apiCall already showed error in floorMapsLoadingStatusDiv
-                    if (floorMapsListUl) floorMapsListUl.innerHTML = '<li>Error loading floor maps.</li>'; // Fallback
+                    if (floorMapsListUl) floorMapsListUl.innerHTML = '<li>Error loading floor maps.</li>';
                 }
             }
+
+            if (locationFilter) locationFilter.addEventListener('change', () => { updateFloorOptions(); renderMapLinks(); });
+            if (floorFilter) floorFilter.addEventListener('change', renderMapLinks);
+
             fetchAndDisplayFloorMapLinks();
         }
     } // End of `if (availabilityDateInput && roomSelectDropdown && calendarTable)`
@@ -1045,6 +1075,8 @@ Enter a title for your booking (optional):`);
                     const listItem = document.createElement('li');
                     listItem.innerHTML = `
                         <strong>${map.name}</strong> (ID: ${map.id})<br>
+                        ${map.location ? 'Location: ' + map.location + '<br>' : ''}
+                        ${map.floor ? 'Floor: ' + map.floor + '<br>' : ''}
                         Filename: ${map.image_filename}<br>
                         <img src="${map.image_url}" alt="${map.name}" style="max-width: 200px; max-height: 150px; border: 1px solid #eee;">
                         <br>
@@ -1888,6 +1920,9 @@ Enter a title for your booking (optional):`);
         const mapLoadingStatusDiv = document.getElementById('map-loading-status');
         const mapViewTitleH1 = document.getElementById('map-view-title');
         const mapAvailabilityDateInput = document.getElementById('map-availability-date');
+        const mapLocationSelect = document.getElementById('map-location-select');
+        const mapFloorSelect = document.getElementById('map-floor-select');
+        let allMapInfo = [];
 
         // Function to get today's date in YYYY-MM-DD for API calls
         function getTodayDateStringForMap() {
@@ -1901,6 +1936,52 @@ Enter a title for your booking (optional):`);
         if(mapAvailabilityDateInput) { // Initialize date picker
             mapAvailabilityDateInput.value = getTodayDateStringForMap();
         }
+
+        function updateFloorSelectOptions() {
+            if (!mapFloorSelect) return;
+            const loc = mapLocationSelect ? mapLocationSelect.value : '';
+            const floors = [...new Set(allMapInfo.filter(m => !loc || m.location === loc).map(m => m.floor).filter(f => f))];
+            mapFloorSelect.innerHTML = '<option value="">All</option>';
+            floors.forEach(fl => mapFloorSelect.add(new Option(fl, fl)));
+        }
+
+        function setSelectorsFromCurrentMap() {
+            const current = allMapInfo.find(m => m.id == mapId);
+            if (!current) return;
+            if (mapLocationSelect) mapLocationSelect.value = current.location || '';
+            updateFloorSelectOptions();
+            if (mapFloorSelect) mapFloorSelect.value = current.floor || '';
+        }
+
+        function handleSelectorChange() {
+            const loc = mapLocationSelect ? mapLocationSelect.value : '';
+            const fl = mapFloorSelect ? mapFloorSelect.value : '';
+            const found = allMapInfo.find(m => (!loc || m.location === loc) && (!fl || m.floor === fl));
+            if (found && found.id != mapId) {
+                window.location.href = `/map_view/${found.id}`;
+            }
+        }
+
+        async function loadMapSelectors() {
+            try {
+                const maps = await apiCall('/api/admin/maps', {}, mapLoadingStatusDiv);
+                allMapInfo = maps || [];
+                if (mapLocationSelect) {
+                    const locations = [...new Set(allMapInfo.map(m => m.location).filter(l => l))];
+                    mapLocationSelect.innerHTML = '<option value="">All</option>';
+                    locations.forEach(loc => mapLocationSelect.add(new Option(loc, loc)));
+                }
+                updateFloorSelectOptions();
+                setSelectorsFromCurrentMap();
+            } catch (e) {
+                console.error('Error loading map selector data', e);
+            }
+        }
+
+        if (mapLocationSelect) mapLocationSelect.addEventListener('change', () => { updateFloorSelectOptions(); handleSelectorChange(); });
+        if (mapFloorSelect) mapFloorSelect.addEventListener('change', handleSelectorChange);
+
+        loadMapSelectors();
 
         async function fetchAndRenderMap(currentMapId, dateString) {
             mapLoadingStatusDiv.textContent = 'Loading map details...';

--- a/templates/admin_maps.html
+++ b/templates/admin_maps.html
@@ -13,6 +13,14 @@
                 <input type="text" id="map-name" name="map_name" required>
             </div>
             <div>
+                <label for="map-location">{{ _('Location:') }}</label>
+                <input type="text" id="map-location" name="location">
+            </div>
+            <div>
+                <label for="map-floor">{{ _('Floor:') }}</label>
+                <input type="text" id="map-floor" name="floor">
+            </div>
+            <div>
                 <label for="map-image">{{ _('Map Image File:') }}</label>
                 <input type="file" id="map-image" name="map_image" accept="image/png, image/jpeg" required>
             </div>

--- a/templates/map_view.html
+++ b/templates/map_view.html
@@ -117,6 +117,12 @@
         <label for="map-availability-date">{{ _('View Availability for Date:') }}</label>
         <input type="date" id="map-availability-date" name="map-availability-date">
     </div>
+    <div>
+        <label for="map-location-select">{{ _('Location:') }}</label>
+        <select id="map-location-select"></select>
+        <label for="map-floor-select">{{ _('Floor:') }}</label>
+        <select id="map-floor-select"></select>
+    </div>
     <div id="map-container" data-map-id="{{ map_id_from_flask }}"></div>
     <div id="map-loading-status">{{ _('Loading map and resources...') }}</div>
     <div id="time-slot-modal" class="modal" style="display:none;" role="dialog" aria-modal="true" aria-labelledby="modal-title">

--- a/templates/resources.html
+++ b/templates/resources.html
@@ -67,6 +67,12 @@
     <hr>
     <section id="floor-maps-selection-section">
         <h2>{{ _('View by Floor Map') }}</h2>
+        <div>
+            <label for="location-filter">{{ _('Location:') }}</label>
+            <select id="location-filter"></select>
+            <label for="floor-filter">{{ _('Floor:') }}</label>
+            <select id="floor-filter"></select>
+        </div>
         <div id="floor-maps-loading-status" aria-live="polite" style="margin-bottom: 10px;"></div>
         <ul id="floor-maps-list">
             <li>{{ _('Loading floor maps...') }}</li>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -13,12 +13,12 @@ class AppTests(unittest.TestCase):
         """Set up test variables."""
         app.config['TESTING'] = True
         app.config['WTF_CSRF_ENABLED'] = False  # Disable CSRF for tests
-        app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
         app.config['LOGIN_DISABLED'] = False # Ensure login is enabled for tests
-        
+
         self.app_context = app.app_context()
         self.app_context.push() # Push app context for db operations
-        
+
+        db.drop_all()
         db.create_all()
         
         email_log.clear()
@@ -32,7 +32,7 @@ class AppTests(unittest.TestCase):
             db.session.commit()
 
         # Create a floor map and some resources for testing
-        floor_map = FloorMap(name='Test Map', image_filename='map.png')
+        floor_map = FloorMap(name='Test Map', image_filename='map.png', location='HQ', floor='1')
         db.session.add(floor_map)
         db.session.commit()
 
@@ -305,6 +305,16 @@ class AppTests(unittest.TestCase):
         updated = Booking.query.get(booking.id)
         self.assertEqual(updated.start_time, new_start)
         self.assertEqual(updated.end_time, new_end)
+
+    def test_map_details_includes_location_floor(self):
+        """Map details endpoint returns location and floor info."""
+        resp = self.client.get(f'/api/map_details/{self.floor_map.id}')
+        self.assertEqual(resp.status_code, 200)
+        data = resp.get_json()
+        self.assertIn('map_details', data)
+        details = data['map_details']
+        self.assertEqual(details['location'], 'HQ')
+        self.assertEqual(details['floor'], '1')
 
 
 


### PR DESCRIPTION
## Summary
- support `location` and `floor` attributes on `FloorMap`
- expose the new fields in map APIs and admin UI
- add selectors for location and floor on resources and map view pages
- adjust tests for new fields

## Testing
- `pytest -q`