### PR TITLE
Add resource tags column helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,19 @@ The application uses an SQLite database to store resource information. If you ha
    ```
 **Important:** You only need to run `init_db()` once in a fresh environment. Omitting `force=True` will keep existing records intact.
 
+### Updating Existing Databases
+
+If you upgrade from an earlier version and encounter a database error such as
+`no such column: resource.tags`, your `site.db` file is missing a recent field.
+Run the helper script to add the column without losing data:
+
+```bash
+python add_resource_tags_column.py
+```
+
+If you do not need to keep your current data, you can instead recreate the
+database with `init_db(force=True)`.
+
 ### Email Configuration
 
 Flask-Mail is used to send email notifications when bookings are created, updated or cancelled. Configure your SMTP credentials through environment variables before running the application:

--- a/add_resource_tags_column.py
+++ b/add_resource_tags_column.py
@@ -1,0 +1,30 @@
+import sqlite3
+import os
+
+BASEDIR = os.path.abspath(os.path.dirname(__file__))
+DATA_DIR = os.path.join(BASEDIR, 'data')
+DB_PATH = os.path.join(DATA_DIR, 'site.db')
+
+def add_tags_column():
+    if not os.path.exists(DB_PATH):
+        print(f"Database file not found at {DB_PATH}. Run init_db() first.")
+        return
+
+    conn = sqlite3.connect(DB_PATH)
+    cursor = conn.cursor()
+
+    cursor.execute("PRAGMA table_info(resource)")
+    columns = [info[1] for info in cursor.fetchall()]
+
+    if 'tags' not in columns:
+        print("Adding 'tags' column to 'resource' table...")
+        cursor.execute("ALTER TABLE resource ADD COLUMN tags VARCHAR(200)")
+        conn.commit()
+        print("'tags' column added.")
+    else:
+        print("'tags' column already exists. No action taken.")
+
+    conn.close()
+
+if __name__ == '__main__':
+    add_tags_column()


### PR DESCRIPTION
## Summary
- add script to add missing `tags` column to `resource` table
- document how to use the script when upgrading

## Testing
- `pip install -r requirements.txt`
- `pytest -q`