### PR TITLE
Preserve DB in init_setup and auto-add tags column

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ After activating your virtual environment, run the initialization script:
 python init_setup.py
 ```
 
-This script checks your Python version and creates a `data/` directory for potentially storing application data in the future. It's recommended to run this once after cloning the repository and setting up your virtual environment.
+This script checks your Python version, creates the required directories, and initializes the database **only if one does not already exist**.  When an existing `site.db` file is present it is left untouched, but the script will ensure new fields such as the `resource.tags` column are added when upgrading from older versions.  Run this once after cloning the repository or when updating to a newer release.
 
 ### Installing Dependencies
 
@@ -94,7 +94,7 @@ The application uses an SQLite database to store resource information. If you ha
 
 If you upgrade from an earlier version and encounter a database error such as
 `no such column: resource.tags`, your `site.db` file is missing a recent field.
-Run the helper script to add the column without losing data:
+Running `python init_setup.py` will now add this column automatically. If you prefer you can also run the helper script directly:
 
 ```bash
 python add_resource_tags_column.py

--- a/init_setup.py
+++ b/init_setup.py
@@ -4,12 +4,14 @@ import sys
 import os
 import pathlib
 from app import app, init_db
+from add_resource_tags_column import add_tags_column
 
 MIN_PYTHON_VERSION = (3, 7)
 DATA_DIR_NAME = "data"
 STATIC_DIR_NAME = "static"
 FLOOR_MAP_UPLOADS_DIR_NAME = os.path.join(STATIC_DIR_NAME, "floor_map_uploads")
 RESOURCE_UPLOADS_DIR_NAME = os.path.join(STATIC_DIR_NAME, "resource_uploads")
+DB_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)), DATA_DIR_NAME, 'site.db')
 
 def check_python_version():
     """Checks if the current Python version meets the minimum requirement."""
@@ -77,6 +79,17 @@ def create_required_directories():
         print(f"'{resource_uploads_dir}' directory already exists.")
     return True
 
+def ensure_tags_column():
+    """Ensure the 'tags' column exists in the resource table."""
+    if not os.path.exists(DB_PATH):
+        print("Database file not found, skipping 'tags' column check.")
+        return
+
+    try:
+        add_tags_column()
+    except Exception as exc:
+        print(f"Failed to ensure 'tags' column exists: {exc}")
+
 def main():
     """Main function to run setup checks and tasks."""
     print("Starting project initialization...")
@@ -85,14 +98,18 @@ def main():
     print("-" * 30)
     create_required_directories()
     print("-" * 30) 
-    print("Initializing database (calling app.init_db)...")
-    try:
-        init_db() # This function is imported from app.py
-        print("Database initialization process (app.init_db) completed.")
-    except Exception as e:
-        print(f"An error occurred during database initialization (app.init_db): {e}")
-        print("Please check the output from app.init_db for more details, or run app.py with init_db() uncommented if issues persist.")
-        sys.exit(1) # Exit if DB initialization fails
+    if os.path.exists(DB_PATH):
+        print(f"Existing database found at {DB_PATH}. Skipping init_db to preserve data.")
+        ensure_tags_column()
+    else:
+        print("Initializing database (calling app.init_db)...")
+        try:
+            init_db()
+            print("Database initialization process (app.init_db) completed.")
+        except Exception as e:
+            print(f"An error occurred during database initialization (app.init_db): {e}")
+            print("Please check the output from app.init_db for more details, or run app.py with init_db() uncommented if issues persist.")
+            sys.exit(1)  # Exit if DB initialization fails
     print("-" * 30)
     print("Project initialization script completed successfully.")
     print("Remember to activate your virtual environment if you haven't already.")


### PR DESCRIPTION
## Summary
- avoid overwriting existing database in `init_setup.py`
- automatically add the `resource.tags` column when missing
- mention new behavior in README

## Testing
- `pytest -q`