### PR TITLE
Fix logout CSRF issue and improve booking page

### DIFF
--- a/app.py
+++ b/app.py
@@ -2242,8 +2242,8 @@ def api_login():
         add_audit_log(action="LOGIN_FAILED", details=f"Failed login attempt for username: '{username}'.")
         return jsonify({'error': 'Invalid username or password.'}), 401
 
+@csrf.exempt
 @app.route('/api/auth/logout', methods=['POST'])
-
 def api_logout():
     """Log out the current user if authenticated.
 

--- a/static/js/my_bookings.js
+++ b/static/js/my_bookings.js
@@ -70,7 +70,11 @@ document.addEventListener('DOMContentLoaded', () => {
             hideStatusMessage(statusDiv);
         } catch (error) {
             console.error('Error fetching bookings:', error);
-            showError(statusDiv, error.message || 'Failed to load bookings. Please try again.');
+            if (error.message && error.message.includes('401')) {
+                showError(statusDiv, 'Please log in to view your bookings.');
+            } else {
+                showError(statusDiv, error.message || 'Failed to load bookings. Please try again.');
+            }
         }
     }
 

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -296,8 +296,7 @@ async function handleLogout(event) {
         sessionStorage.removeItem('userPerformedLoginAction'); // Also clear on failed logout attempt
         sessionStorage.removeItem('autoLoggedOutDueToStartupSession');
         sessionStorage.setItem('explicitlyLoggedOut', 'true');
-        // apiCall helper would have logged the error. Alert a generic message.
-        alert("Logout failed. Please try again or check the console for details.");
+        console.error('Logout error:', error);
         // Ensure UI is in a logged-out state even if API call had issues
         await updateAuthLink(); // This will execute setStateLoggedOut due to the flag
     }


### PR DESCRIPTION
## Summary
- allow logout without CSRF token and avoid false failures
- show a login message when bookings fail to load due to authentication
- stop showing alert on logout errors

## Testing
- `pytest -q`