### PR TITLE
Fix missing resource.tags error

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ python init_setup.py
 
 This script checks your Python version, creates the required directories, and initializes the database **only if one does not already exist**.  When an existing `site.db` file is present it is left untouched, but the script will ensure new fields such as the `resource.tags` column are added when upgrading from older versions.  Run this once after cloning the repository or when updating to a newer release.
 
+The application itself will also perform a quick check for the `resource.tags`
+column whenever it starts, so you can simply run `python app.py` or `flask run`
+after upgrading. However, running `init_setup.py` remains the safest approach
+when setting up a new environment.
+
 
 ### Installing Dependencies
 
@@ -102,6 +107,9 @@ Running `python init_setup.py` will now add this column automatically. If you pr
 ```bash
 python add_resource_tags_column.py
 ```
+
+Recent versions of `app.py` also attempt to add this column on startup,
+but running `init_setup.py` is recommended if you see schema errors.
 
 If you do not need to keep your current data, you can instead recreate the
 database with `init_db(force=True)`.

--- a/app.py
+++ b/app.py
@@ -21,6 +21,9 @@ from flask import g  # For storing current locale
 from flask_wtf.csrf import CSRFProtect # For CSRF protection
 from flask_socketio import SocketIO
 
+# Helper to add new DB fields when older databases are used
+from add_resource_tags_column import add_tags_column
+
 
 # Attempt to import APScheduler; provide a basic fallback if unavailable
 try:
@@ -116,6 +119,16 @@ class SimpleTranslator:
         return self.translations.get(lang, {}).get(text, text)
 
 translator = SimpleTranslator()
+
+# --- Database Schema Helpers ---
+def ensure_tags_column_on_startup():
+    """Add the 'tags' column to the resource table if it is missing."""
+    try:
+        add_tags_column()
+    except Exception as exc:  # pragma: no cover - defensive
+        app.logger.warning(f"Could not verify 'tags' column: {exc}")
+
+ensure_tags_column_on_startup()
 
 def _(text):
     lang = get_locale() if has_request_context() else translator.default_locale


### PR DESCRIPTION
## Summary
- auto-add `tags` column on start-up if missing
- document the automatic check in README

## Testing
- `pytest -q`