### PR TITLE
Fix missing DB columns on upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,11 @@ The application uses an SQLite database to store resource information. If you ha
 ### Updating Existing Databases
 
 If you upgrade from an earlier version and encounter a database error such as
-`no such column: resource.tags`, your `site.db` file is missing a recent field.
+`no such column: resource.tags`, `no such column: resource.image_filename`, or
+`no such column: floor_map.location`, your `site.db` file is missing recently
+added fields.
 
-Running `python init_setup.py` will now add this column automatically. If you prefer you can also run the helper script directly:
+Running `python init_setup.py` will now add these columns automatically. If you prefer you can also run the helper script directly:
 
 
 ```bash

--- a/init_setup.py
+++ b/init_setup.py
@@ -103,6 +103,68 @@ def ensure_tags_column():
     except Exception as exc:
         print(f"Failed to ensure 'tags' column exists: {exc}")
 
+def ensure_resource_image_column():
+    """Ensure the 'image_filename' column exists in the resource table."""
+    if not os.path.exists(DB_PATH):
+        print("Database file not found, skipping 'image_filename' column check.")
+        return
+
+    import sqlite3
+    try:
+        conn = sqlite3.connect(DB_PATH)
+        cursor = conn.cursor()
+        cursor.execute("PRAGMA table_info(resource)")
+        columns = [info[1] for info in cursor.fetchall()]
+        if 'image_filename' not in columns:
+            print("Adding 'image_filename' column to 'resource' table...")
+            cursor.execute("ALTER TABLE resource ADD COLUMN image_filename VARCHAR(255)")
+            conn.commit()
+            print("'image_filename' column added.")
+        else:
+            print("'image_filename' column already exists. No action taken.")
+    except Exception as exc:
+        print(f"Failed to ensure 'image_filename' column exists: {exc}")
+    finally:
+        if 'conn' in locals():
+            conn.close()
+
+def ensure_floor_map_columns():
+    """Ensure the 'location' and 'floor' columns exist in the floor_map table."""
+    if not os.path.exists(DB_PATH):
+        print("Database file not found, skipping floor_map column checks.")
+        return
+
+    import sqlite3
+    try:
+        conn = sqlite3.connect(DB_PATH)
+        cursor = conn.cursor()
+        cursor.execute("PRAGMA table_info(floor_map)")
+        columns = [info[1] for info in cursor.fetchall()]
+        to_commit = False
+
+        if 'location' not in columns:
+            print("Adding 'location' column to 'floor_map' table...")
+            cursor.execute("ALTER TABLE floor_map ADD COLUMN location VARCHAR(100)")
+            to_commit = True
+        else:
+            print("'location' column already exists. No action taken for this column.")
+
+        if 'floor' not in columns:
+            print("Adding 'floor' column to 'floor_map' table...")
+            cursor.execute("ALTER TABLE floor_map ADD COLUMN floor VARCHAR(50)")
+            to_commit = True
+        else:
+            print("'floor' column already exists. No action taken for this column.")
+
+        if to_commit:
+            conn.commit()
+            print("Floor map column additions committed.")
+    except Exception as exc:
+        print(f"Failed to ensure floor_map columns exist: {exc}")
+    finally:
+        if 'conn' in locals():
+            conn.close()
+
 
 # Moved from app.py
 def init_db(force=False):
@@ -396,6 +458,8 @@ def main():
     if os.path.exists(DB_PATH):
         print(f"Existing database found at {DB_PATH}. Skipping init_db to preserve data.")
         ensure_tags_column()
+        ensure_resource_image_column()
+        ensure_floor_map_columns()
     else:
         print("Initializing database...")
         try:


### PR DESCRIPTION
## Summary
- add helper functions in `init_setup.py` to add `image_filename`, `location` and `floor`
- ensure `init_setup.py` runs these helpers when a DB already exists
- update documentation about upgrading existing databases

## Testing
- `pytest -q`