### PR TITLE
feat: Implement booking time edits, resource status scheduling, and l…

### DIFF
--- a/static/js/resource_management.js
+++ b/static/js/resource_management.js
@@ -11,6 +11,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const resourceNameInput = document.getElementById('resource-name');
     const resourceCapacityInput = document.getElementById('resource-capacity');
     const resourceEquipmentInput = document.getElementById('resource-equipment');
+    const resourceStatusModalInput = document.getElementById('resource-status-modal'); // Added
 
     async function fetchAndDisplayResources() {
         showLoading(statusDiv, 'Fetching resources...');
@@ -43,6 +44,7 @@ document.addEventListener('DOMContentLoaded', function() {
     addBtn.addEventListener('click', function() {
         resourceForm.reset();
         resourceIdInput.value = '';
+        resourceStatusModalInput.value = 'draft'; // Default for new resource
         resourceFormModalTitle.textContent = 'Add New Resource';
         hideMessage(resourceFormStatus);
         resourceFormModal.style.display = 'block';
@@ -61,6 +63,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 resourceNameInput.value = data.name || '';
                 resourceCapacityInput.value = data.capacity !== null && data.capacity !== undefined ? data.capacity : '';
                 resourceEquipmentInput.value = data.equipment || '';
+                resourceStatusModalInput.value = data.status || 'draft'; // Populate status for editing
                 resourceFormModalTitle.textContent = 'Edit Resource';
                 hideMessage(resourceFormStatus);
                 resourceFormModal.style.display = 'block';
@@ -85,7 +88,8 @@ document.addEventListener('DOMContentLoaded', function() {
         const payload = {
             name: resourceNameInput.value,
             capacity: resourceCapacityInput.value !== '' ? parseInt(resourceCapacityInput.value, 10) : null,
-            equipment: resourceEquipmentInput.value
+            equipment: resourceEquipmentInput.value,
+            status: resourceStatusModalInput.value // Add status to payload
         };
         const id = resourceIdInput.value;
         try {

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -280,17 +280,8 @@ async function handleLogout(event) {
         
         await updateAuthLink(); // Refresh navigation and UI
 
-        const loginUrl = document.body.dataset.loginUrl || '/login';
-        const homeUrl = '/';
-
-        // Navigate to the home page after logout. If already on the login page
-        // (where ``loginUrl`` may be "#"), a reload is sufficient to reflect the
-        // logged-out state.
-        if (loginUrl === '#') {
-            window.location.reload();
-        } else {
-            window.location.href = homeUrl;
-        }
+        // Always redirect to /login after successful logout
+        window.location.href = '/login';
 
     } catch (error) {
         sessionStorage.removeItem('userPerformedLoginAction'); // Also clear on failed logout attempt

--- a/templates/admin_maps.html
+++ b/templates/admin_maps.html
@@ -130,6 +130,21 @@
                 <input type="datetime-local" id="edit-resource-maintenance-until" name="maintenance_until">
                 <label for="edit-resource-recurrence-limit">{{ _('Max Recurrence Count:') }}</label>
                 <input type="number" id="edit-resource-recurrence-limit" name="max_recurrence_count" min="1">
+
+                <div>
+                    <label for="edit-resource-scheduled-status">{{ _('Scheduled Status Change To:') }}</label>
+                    <select id="edit-resource-scheduled-status" name="scheduled_status">
+                        <option value="">{{ _('-- No Scheduled Change --') }}</option>
+                        <option value="draft">{{ _('Draft') }}</option>
+                        <option value="published">{{ _('Published') }}</option>
+                        <option value="archived">{{ _('Archived') }}</option>
+                    </select>
+                </div>
+                <div>
+                    <label for="edit-resource-scheduled-at">{{ _('Scheduled Change At:') }}</label>
+                    <input type="datetime-local" id="edit-resource-scheduled-at" name="scheduled_status_at">
+                </div>
+
                 <div class="permission-group">
                     <h4>{{ _('Authorized Specific Users (Optional)') }}</h4>
                     <p class="small-text">{{ _('If specified, only these users (and admins) can book.') }}</p>

--- a/templates/my_bookings.html
+++ b/templates/my_bookings.html
@@ -29,7 +29,7 @@
                     <strong>{{ _('Ends') }}:</strong> <span class="end-time"></span><br>
                     <strong>{{ _('Recurrence') }}:</strong> <span class="recurrence-rule"></span>
                 </p>
-                <button class="btn btn-sm btn-primary update-booking-btn" data-booking-id="">{{ _('Update Title') }}</button>
+                <button class="btn btn-sm btn-primary update-booking-btn" data-booking-id="">{{ _('Update Booking') }}</button>
                 <button class="btn btn-sm btn-danger cancel-booking-btn" data-booking-id="">{{ _('Cancel Booking') }}</button>
                 <button class="btn btn-sm btn-success check-in-btn" data-booking-id="" style="display:none;">{{ _('Check In') }}</button>
                 <button class="btn btn-sm btn-secondary check-out-btn" data-booking-id="" style="display:none;">{{ _('Check Out') }}</button>
@@ -42,16 +42,34 @@
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title" id="updateBookingModalLabel">{{ _('Update Booking Title') }}</h5>
+                    <h5 class="modal-title" id="updateBookingModalLabel">{{ _('Update Booking') }}</h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">
-                    <input type="hidden" id="modal-booking-id" value="">
-                    <div class="mb-3">
-                        <label for="new-booking-title" class="form-label">{{ _('New Title') }}:</label>
-                        <input type="text" class="form-control" id="new-booking-title" required>
-                    </div>
-                    <div id="update-modal-status" class="alert" style="display:none;"></div>
+                    <form id="update-booking-form">
+                        <input type="hidden" id="modal-booking-id" value="">
+                        <div class="mb-3">
+                            <label for="new-booking-title" class="form-label">{{ _('New Title') }}:</label>
+                            <input type="text" class="form-control" id="new-booking-title" required>
+                        </div>
+                        <div class="mb-3">
+                            <label for="new-booking-start-date" class="form-label">{{ _('New Start Date') }}:</label>
+                            <input type="date" class="form-control" id="new-booking-start-date">
+                        </div>
+                        <div class="mb-3">
+                            <label for="new-booking-start-time" class="form-label">{{ _('New Start Time') }}:</label>
+                            <input type="time" class="form-control" id="new-booking-start-time">
+                        </div>
+                        <div class="mb-3">
+                            <label for="new-booking-end-date" class="form-label">{{ _('New End Date') }}:</label>
+                            <input type="date" class="form-control" id="new-booking-end-date">
+                        </div>
+                        <div class="mb-3">
+                            <label for="new-booking-end-time" class="form-label">{{ _('New End Time') }}:</label>
+                            <input type="time" class="form-control" id="new-booking-end-time">
+                        </div>
+                        <div id="update-modal-status" class="alert" style="display:none;"></div>
+                    </form>
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ _('Close') }}</button>

--- a/templates/resource_management.html
+++ b/templates/resource_management.html
@@ -40,6 +40,14 @@
                     <label for="resource-equipment">{{ _('Equipment:') }}</label>
                     <input type="text" id="resource-equipment" name="equipment">
                 </div>
+                <div>
+                    <label for="resource-status-modal">{{ _('Status:') }}</label>
+                    <select id="resource-status-modal" name="status" class="form-control">
+                        <option value="draft">{{ _('Draft') }}</option>
+                        <option value="published">{{ _('Published') }}</option>
+                        <option value="archived">{{ _('Archived') }}</option>
+                    </select>
+                </div>
                 <button type="submit" class="button" style="margin-top: 10px;">{{ _('Save Resource') }}</button>
                 <div id="resource-form-modal-status" class="status-message" style="margin-top: 10px;"></div>
             </form>


### PR DESCRIPTION
…ogout redirect update

This commit introduces several enhancements and bug fixes:

1.  **Logout Redirection:**
    - The logout functionality now consistently redirects you to the /login page, regardless of the page you were on when you logged out.

2.  **Manage Booking - Date/Time Editing:**
    - You can now edit the date and time of your existing bookings, in addition to the title.
    - Backend API (`PUT /api/bookings/<id>`) updated to handle start_time and end_time changes.
    - Includes validation for valid time ranges and conflict checking against other bookings and resource maintenance periods.
    - Frontend modal in "My Bookings" updated with date/time inputs, and JavaScript logic adjusted to handle these new fields.

3.  **Resource Management - Status Configuration:**
    - The basic resource management list view (`/admin/resources_manage`) now displays the resource status.
    - The modal associated with this page now allows editing the resource status (Draft, Published, Archived).
    - Verified that the detailed resource edit modal (used in /admin/maps) continues to correctly handle status updates.

4.  **Scheduled Status Changes for Resources (New Feature):**
    - Resources can now have their status changes scheduled for a future date/time.
    - `Resource` model extended with `scheduled_status` and `scheduled_status_at`.
    - Backend API (`PUT /api/admin/resources/<id>`) updated to allow setting these scheduled parameters.
    - An APScheduler background job (`apply_scheduled_resource_status_changes`) has been added to periodically check for and apply due status changes.
    - Frontend detailed resource edit modal updated with fields for "Scheduled Status Change To" and "Scheduled Change At".

5.  **Testing:**
    - Comprehensive unit and integration tests added for all modified backend functionalities, including booking updates, resource status handling, the new scheduler job, and logout behavior.
    - Audit log entries for these operations have also been verified.