### PR TITLE
Fix scheduled_status DB column handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,10 @@ The application uses an SQLite database to store resource information. If you ha
 ### Updating Existing Databases
 
 If you upgrade from an earlier version and encounter a database error such as
-`no such column: resource.tags`, `no such column: resource.image_filename`, or
-`no such column: floor_map.location`, your `site.db` file is missing recently
-added fields.
+`no such column: resource.tags`, `no such column: resource.image_filename`,
+`no such column: floor_map.location`, or
+`no such column: resource.scheduled_status`, your `site.db` file is missing
+recently added fields.
 
 Running `python init_setup.py` will now add these columns automatically. If you prefer you can also run the helper script directly:
 

--- a/init_setup.py
+++ b/init_setup.py
@@ -165,6 +165,43 @@ def ensure_floor_map_columns():
         if 'conn' in locals():
             conn.close()
 
+def ensure_scheduled_status_columns():
+    """Ensure the 'scheduled_status' and 'scheduled_status_at' columns exist in the resource table."""
+    if not os.path.exists(DB_PATH):
+        print("Database file not found, skipping scheduled status column checks.")
+        return
+
+    import sqlite3
+    try:
+        conn = sqlite3.connect(DB_PATH)
+        cursor = conn.cursor()
+        cursor.execute("PRAGMA table_info(resource)")
+        columns = [info[1] for info in cursor.fetchall()]
+        to_commit = False
+
+        if 'scheduled_status' not in columns:
+            print("Adding 'scheduled_status' column to 'resource' table...")
+            cursor.execute("ALTER TABLE resource ADD COLUMN scheduled_status VARCHAR(50)")
+            to_commit = True
+        else:
+            print("'scheduled_status' column already exists. No action taken for this column.")
+
+        if 'scheduled_status_at' not in columns:
+            print("Adding 'scheduled_status_at' column to 'resource' table...")
+            cursor.execute("ALTER TABLE resource ADD COLUMN scheduled_status_at DATETIME")
+            to_commit = True
+        else:
+            print("'scheduled_status_at' column already exists. No action taken for this column.")
+
+        if to_commit:
+            conn.commit()
+            print("Scheduled status column additions committed.")
+    except Exception as exc:
+        print(f"Failed to ensure scheduled status columns exist: {exc}")
+    finally:
+        if 'conn' in locals():
+            conn.close()
+
 
 # Moved from app.py
 def init_db(force=False):
@@ -460,6 +497,7 @@ def main():
         ensure_tags_column()
         ensure_resource_image_column()
         ensure_floor_map_columns()
+        ensure_scheduled_status_columns()
     else:
         print("Initializing database...")
         try:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,10 +1,11 @@
 import unittest
+import unittest.mock
 import json
 from sqlalchemy import text
 
 from datetime import datetime, time, date, timedelta
 
-from app import app, db, User, Resource, Booking, WaitlistEntry, FloorMap, email_log, teams_log, slack_log
+from app import app, db, User, Resource, Booking, WaitlistEntry, FloorMap, AuditLog, email_log, teams_log, slack_log
 
 
 # from flask_login import current_user # Not directly used for assertions here
@@ -532,6 +533,8 @@ class TestAdminFunctionality(AppTests): # Renamed from AppTests to avoid confusi
 
         apply_scheduled_resource_status_changes() # Call the job function
 
+        db.session.expire_all()  # Refresh session state after job commits
+
         updated_res1 = Resource.query.get(resource_id_1)
         self.assertEqual(updated_res1.status, "published")
         self.assertIsNotNone(updated_res1.published_at)
@@ -564,6 +567,8 @@ class TestAdminFunctionality(AppTests): # Renamed from AppTests to avoid confusi
         mock_datetime.utcnow.return_value = datetime.utcnow() # Mock 'now' again
 
         apply_scheduled_resource_status_changes()
+
+        db.session.expire_all()  # Refresh after second job
 
         updated_res2 = Resource.query.get(resource_id_2)
         self.assertEqual(updated_res2.status, "archived")


### PR DESCRIPTION
## Summary
- ensure `scheduled_status` columns are added when the DB already exists
- document this new column in upgrade instructions
- update tests for Python 3.12

## Testing
- `pytest -q`