### PR TITLE
fix: Resolve SyntaxError preventing map display

### DIFF
--- a/static/js/new_booking_map.js
+++ b/static/js/new_booking_map.js
@@ -163,9 +163,24 @@ document.addEventListener('DOMContentLoaded', function () {
             if (data.mapped_resources && data.mapped_resources.length > 0) {
                 data.mapped_resources.forEach(resource => {
                     if (resource.map_coordinates && resource.map_coordinates.type === 'rect') {
-                        const coords = resource.map_coordinates;
-                        const areaDiv = document.createElement('div');
-                        const coords = resource.map_coordinates;
+                        // const coords = resource.map_coordinates; // First declaration, now potentially redundant
+                        // The following 'const coords' is the one introduced by the logging step.
+                        // We should use this one and ensure there's no prior 'const coords' in this specific block.
+                        // OR, if 'const coords' was already defined above this 'if', then this one should be removed.
+                        // Given the error is *at* 168, this implies this line or the one immediately after is the problem.
+
+                        // Corrected: Declare 'coords' once.
+                        // The previous logging step likely introduced 'const coords = resource.map_coordinates;'
+                        // and then the original code also had 'const coords = resource.map_coordinates;'.
+                        // The logging patch correctly had 'const coords = resource.map_coordinates;'
+                        // and then used it. The error implies a *second* 'const coords' or 'let coords'.
+                        // The issue was:
+                        // const coords = resource.map_coordinates; // Original or first one from logging
+                        // const areaDiv = document.createElement('div'); // This line is fine
+                        // const coords = resource.map_coordinates; // THIS WAS THE DUPLICATE from the merge error.
+
+                        // Corrected structure:
+                        const coords = resource.map_coordinates; // Define it once for this resource.
                         console.log('Processing Resource:', resource.name, 'Raw Coords:', coords);
 
                         // Directly using coordinate values as pixel values, applying offset to top
@@ -178,7 +193,8 @@ document.addEventListener('DOMContentLoaded', function () {
                                     'left=', leftPosition + 'px', 
                                     'width=', widthValue + 'px', 
                                     'height=', heightValue + 'px');
-                        
+                        // const areaDiv = document.createElement('div'); // This was also duplicated by the faulty merge.
+                        // The areaDiv should be created *after* coordinates are established.
                         const areaDiv = document.createElement('div');
                         areaDiv.className = 'resource-area'; // Base class
                         areaDiv.style.left = `${leftPosition}px`;


### PR DESCRIPTION
This commit fixes an `Uncaught SyntaxError: Identifier 'coords' has already been declared` (and a similar issue for `areaDiv`) in `static/js/new_booking_map.js`. This error was halting script execution and preventing the map and its selection options from rendering on the new booking page.

Key changes:
- Corrected duplicate `const` declarations for `coords` and `areaDiv` within the loop in the `loadMapDetails` function. These variables are now declared only once per appropriate scope/iteration.

Resolving this syntax error allows the JavaScript to execute correctly, restoring the map display and booking functionality.