### PR TITLE
fix: Ensure close buttons on My Bookings update modal function correctly

### DIFF
--- a/static/js/my_bookings.js
+++ b/static/js/my_bookings.js
@@ -27,6 +27,31 @@ document.addEventListener('DOMContentLoaded', () => {
     const modalBookingIdInput = document.getElementById('modal-booking-id');
     const newBookingTitleInput = document.getElementById('new-booking-title');
     const saveBookingTitleBtn = document.getElementById('save-booking-title-btn');
+
+    // Add explicit event listeners for modal close buttons
+    const modalHeaderCloseButton = updateModalElement.querySelector('.modal-header .btn-close');
+    const modalFooterCloseButton = updateModalElement.querySelector('.modal-footer .btn-secondary[data-bs-dismiss="modal"]');
+
+    if (modalHeaderCloseButton) {
+        modalHeaderCloseButton.addEventListener('click', () => {
+            if (updateModal && typeof updateModal.hide === 'function') {
+                updateModal.hide();
+            } else if (updateModalElement) { // Fallback if Bootstrap instance not available
+                updateModalElement.style.display = 'none';
+            }
+        });
+    }
+
+    if (modalFooterCloseButton) {
+        modalFooterCloseButton.addEventListener('click', () => {
+            if (updateModal && typeof updateModal.hide === 'function') {
+                updateModal.hide();
+            } else if (updateModalElement) { // Fallback
+                updateModalElement.style.display = 'none';
+            }
+        });
+    }
+
     const updateModalStatusDiv = document.getElementById('update-modal-status');
 
     // Helper to display status messages (could be moved to script.js if used globally)


### PR DESCRIPTION
This commit addresses an issue where the close buttons on the 'Update Booking' modal (#update-booking-modal) on the 'My Bookings' page were not working.

The fix involves adding explicit JavaScript event listeners in `static/js/my_bookings.js` to both the header 'x' button and the footer 'Close' button of the modal. These listeners directly call the `updateModal.hide()` method (or a fallback style change) to ensure the modal is dismissed when these buttons are clicked.

This provides a robust solution for closing the modal, supplementing Bootstrap's default `data-bs-dismiss` functionality which may have been encountering issues.