### PR TITLE
feat: Enhance Admin Maps workflow and update booking times

### DIFF
--- a/templates/admin_maps.html
+++ b/templates/admin_maps.html
@@ -53,7 +53,10 @@
             <h3>{{ _('Assign Area to Resource') }}</h3>
             <div>
                 <label for="resource-to-map">{{ _('Select Resource:') }}</label>
-                <select id="resource-to-map" name="resource_id" required></select>
+                <select id="resource-to-map" name="resource_id" required>
+                    <option value="--CREATE_NEW--">{{ _('-- Create New Resource --') }}</option>
+                    <!-- Existing options will be populated by JS -->
+                </select>
             </div>
             <div>
                 <label for="booking-permission">{{ _('Booking Permission:') }}</label>


### PR DESCRIPTION
- Modifies booking slot definitions and display text to use 08:00-12:00 (First Half-Day), 13:00-17:00 (Second Half-Day), and 08:00-17:00 (Full Day) across the application.
- Enhances Admin Maps UI:
  - Clicking an existing mapped area now directly opens the comprehensive 'edit-resource-modal' for full resource editing.
  - Adds a workflow to create a new resource directly from the map interface when defining a new area. The 'resource-to-map' dropdown now includes a '-- Create New Resource --' option, which utilizes the 'edit-resource-modal' (repurposed for creation) and then selects the new resource for mapping.
- Reverts and verifies calendar functionality to display all bookings for a selected resource, ensuring the resource filter and data fetching from `/api/resources/<id>/all_bookings` are active. Updates 'available slots' generation to align with new time definitions. Further investigation on calendar data display will occur if issues persist.