### PR TITLE
fix: Calendar view, Socket.IO setup, and date parsing

### DIFF
--- a/templates/calendar.html
+++ b/templates/calendar.html
@@ -10,9 +10,10 @@
 <h2>{{ _('Booking Calendar') }}</h2>
 
 <div class="mb-3">
-    <label for="calendar-resource-select" class="form-label">{{ _('Select Resource:') }}</label>
+    <label for="calendar-resource-select" class="form-label">{{ _('Filter by Resource:') }}</label> {# Changed label for clarity #}
     <select id="calendar-resource-select" class="form-select">
-        <option value="">{{ _('Loading resources...') }}</option>
+        <option value="all" selected>-- {{ _('All My Booked Resources') }} --</option>
+        {# Options for individual resources will be populated by JavaScript #}
     </select>
 </div>
 


### PR DESCRIPTION
- Calendar:
  - Defaults to showing all bookings for your current logged-in user, fetched from `/api/bookings/calendar`.
  - Resource dropdown now acts as a client-side filter for these events.
  - Removes 'available slots' generation to simplify your booking view.
  - Adds a default 'All My Booked Resources' option to the filter.
- API Date Parsing:
  - Improves date parsing in `/api/resources/<id>/all_bookings` endpoint in `app.py` to more robustly handle ISO8601 date strings with various timezone offsets, as sent by FullCalendar.
- Socket.IO:
  - Verified server-side setup (`socketio.run(app)`) and client-side inclusion are correct. Persistent 400 errors for `socket.io.js` are likely environmental or due to how the app is run.