### PR TITLE
debug: Temporarily comment out socket.io.js client

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -98,7 +98,7 @@
     </footer>
 
     {% block scripts %}
-    <script src="/socket.io/socket.io.js"></script>
+    <!-- <script src="/socket.io/socket.io.js"></script> -->
     <script src="{{ url_for('static', filename='js/script.js') }}" defer></script>
     {% endblock %}
 </body>


### PR DESCRIPTION
To diagnose if the 400 error on socket.io.js is blocking other JavaScript execution, particularly on the /resources page, this commit temporarily comments out its inclusion in base.html.