### PR TITLE
fix: Resolve /resources page buttons not displaying

### DIFF
--- a/static/js/script.js
+++ b/static/js/script.js
@@ -750,6 +750,7 @@ function checkUserPermissionForResource(resource, currentUserId, currentUserIsAd
         const modalBookingTitle = document.getElementById('rpbm-booking-title');
         const modalConfirmBtn = document.getElementById('rpbm-confirm-booking-btn');
         const modalStatusMsg = document.getElementById('rpbm-status-message');
+        const resourceLoadingStatusDiv = document.getElementById('resource-loading-status');
 
         let allFetchedResources = [];
         let currentResourceBookingsCache = {}; // Cache for bookings: { resourceId: [bookings] }
@@ -841,15 +842,18 @@ function checkUserPermissionForResource(resource, currentUserId, currentUserIsAd
         async function fetchAndRenderResources() {
             try {
                 console.log('Fetching all resources...');
-                showLoading(resourceButtonsContainer, 'Loading resources...');
-                const resources = await apiCall('/api/resources', {}, resourceButtonsContainer); // temp store in 'resources'
+                // showLoading(resourceButtonsContainer, 'Loading resources...'); // Removed this line
+                const resources = await apiCall('/api/resources', {}, resourceLoadingStatusDiv); // Use resourceLoadingStatusDiv
                 console.log('Fetched all resources raw:', JSON.stringify(resources));
                 allFetchedResources = resources; // Assign to global cache
                 console.log('Processed allFetchedResources:', JSON.stringify(allFetchedResources));
-                resourceButtonsContainer.innerHTML = ''; // Clear "Loading..."
+                
+                resourceButtonsContainer.innerHTML = ''; // Clear placeholder/previous buttons
                 
                 if (!allFetchedResources || allFetchedResources.length === 0) {
-                    resourceButtonsContainer.innerHTML = '<p>No resources found.</p>';
+                    // If resourceLoadingStatusDiv handled an error, it will show. 
+                    // If it was successful but no resources, we might want to show a message in resourceButtonsContainer or resourceLoadingStatusDiv
+                    showError(resourceLoadingStatusDiv, 'No resources found.'); // Or use resourceButtonsContainer if preferred for this specific message
                     return;
                 }
 
@@ -912,8 +916,12 @@ function checkUserPermissionForResource(resource, currentUserId, currentUserIsAd
                 await updateAllButtonColors(); // Initial color update
 
             } catch (error) {
-                showError(resourceButtonsContainer, 'Failed to load resources.');
+                // showError(resourceButtonsContainer, 'Failed to load resources.'); // apiCall will use resourceLoadingStatusDiv
                 console.error('Error in fetchAndRenderResources:', error);
+                // If resourceLoadingStatusDiv is not already displaying an error from apiCall, set it.
+                if (resourceLoadingStatusDiv && !resourceLoadingStatusDiv.textContent.includes('Error')) {
+                    showError(resourceLoadingStatusDiv, 'Failed to load resources.');
+                }
             }
         }
 

--- a/templates/resources.html
+++ b/templates/resources.html
@@ -9,6 +9,7 @@
         <input type="date" id="availability-date" name="availability-date">
     </div>
 
+    <div id="resource-loading-status" class="status-message" style="margin-bottom: 15px;"></div>
     <div id="resource-buttons-container" class="resource-buttons-grid" style="margin-top: 20px;">
         <!-- Resource buttons will be populated by JavaScript -->
         <p>{{ _('Loading resources...') }}</p>


### PR DESCRIPTION
Addresses issue where resource buttons were not visible:
- Adds a dedicated status message div in `resources.html`.
- Modifies `fetchAndRenderResources` in `script.js` to use this new div for API call messages, preventing the main button container from being hidden by `hideMessage()`.
- Ensures button container is explicitly cleared before rendering.

This should allow resource buttons to be displayed correctly. Socket.IO client script remains temporarily commented out.