### PR TITLE
Fix: Resources page date filter now hides/shows resources

### DIFF
--- a/static/js/script.js
+++ b/static/js/script.js
@@ -955,7 +955,7 @@ document.addEventListener('DOMContentLoaded', function() {
         console.log("Resource buttons page script initializing...");
 
         // 1. Initial Setup: DOM Elements & Variables
-        const availabilityDateInput = document.getElementById('resource-availability-date'); // Date picker for this view
+        const availabilityDateInput = document.getElementById('availability-date'); // Date picker for this view
         const resourceLoadingStatusDiv = document.getElementById('resource-loading-status');
 
         // Modal elements (rpbm- prefix)
@@ -1274,6 +1274,17 @@ document.addEventListener('DOMContentLoaded', function() {
                 button.classList.add('unavailable');
                 button.title = `${button.dataset.resourceName} - Unavailable`;
                 console.log(`Resource ${resourceId} is unavailable. Class: unavailable`);
+            }
+
+            // Existing class adding logic should be right above this
+            if (button.classList.contains('unavailable') && !button.title.includes('Restricted Access')) {
+                // If the button is 'unavailable' AND it's not due to a permission restriction (title check)
+                button.style.display = 'none';
+                console.log(`Resource ${resourceId} is unavailable and not restricted, hiding button.`);
+            } else {
+                // For 'available', 'partial', or 'unavailable' due to restriction, or 'error' state
+                button.style.display = ''; // Reset to default display (usually 'block' or 'inline-block' based on CSS)
+                console.log(`Resource ${resourceId} is available, partial, restricted, or in error state, showing button. Classes: ${button.className}`);
             }
         }
 


### PR DESCRIPTION
The date filter on the resources page was previously only updating the visual style (color) of the resource buttons but not changing which resources were displayed. This commit addresses the issue by:

1. Correcting the JavaScript to use the correct ID ('availability-date') for the date input element, ensuring the event listener for date changes is properly attached.
2. Modifying the `updateButtonColor` function in `static/js/script.js` to set `button.style.display = 'none'` for resources that are fully unavailable (booked up and not due to permission restrictions) on the selected date. Other resources (available, partially available, or restricted by permission) will have their display style reset to ensure they are visible.

This change ensures that when you select a date, the list of resource buttons dynamically updates to show only those resources that are actually available or partially available on that date, providing a more accurate and user-friendly experience.