### PR TITLE
Feat: Group resources by floor map on resources page

### DIFF
--- a/app.py
+++ b/app.py
@@ -906,6 +906,27 @@ def get_resource_availability(resource_id):
         app.logger.exception(f"Error fetching availability for resource {resource_id} on {target_date_obj}:")
         return jsonify({'error': 'Failed to fetch resource availability due to a server error.'}), 500
 
+
+@app.route('/api/maps', methods=['GET'])
+def get_public_floor_maps():
+    try:
+        maps = FloorMap.query.all()
+        maps_list = []
+        for m in maps:
+            maps_list.append({
+                'id': m.id,
+                'name': m.name,
+                'image_filename': m.image_filename, # Keep for consistency, though frontend might not use it directly for this feature
+                'location': m.location,
+                'floor': m.floor,
+                'image_url': url_for('static', filename=f'floor_map_uploads/{m.image_filename}')
+            })
+        # app.logger.info("Successfully fetched all floor maps for public API.") # Optional logging
+        return jsonify(maps_list), 200
+    except Exception as e:
+        app.logger.exception("Error fetching public floor maps:")
+        return jsonify({'error': 'Failed to fetch maps due to a server error.'}), 500
+
 # Helper function to check allowed file extensions
 def allowed_file(filename):
     return '.' in filename and \

--- a/static/style.css
+++ b/static/style.css
@@ -871,3 +871,32 @@ body.high-contrast input[type="button"]:hover {
 #rpbm-slot-options .time-slot-btn.available:hover {
     background-color: #45a049; /* Slightly darker green on hover */
 }
+
+/* Styling for Floor Map Groupings on Resources Page */
+.map-group-heading {
+    margin-top: 25px;
+    margin-bottom: 15px;
+    font-size: 1.4em; /* Slightly larger than default h3 if needed */
+    color: #333; /* Or match your theme's heading color */
+    border-bottom: 2px solid #eee; /* A light separator */
+    padding-bottom: 5px;
+}
+
+.map-specific-grid {
+    /* If the default .resource-buttons-grid already has good spacing, 
+       you might not need much here. This is a placeholder. */
+    /* Example: add some padding if grids are too close to headings */
+    padding-top: 10px;
+    margin-bottom: 20px; /* Space before the next map group heading */
+}
+
+.unassigned-grid {
+    /* Similar to map-specific-grid, if needed */
+    padding-top: 10px;
+}
+
+/* Ensure the main container still allows for these new elements */
+#resource-buttons-container {
+    /* Existing styles should be fine, but if it was a strict grid itself, 
+       it might need adjustment. Assuming it's a block container. */
+}


### PR DESCRIPTION
This commit introduces a new feature to the resources page (/resources) where resource buttons are now grouped by their assigned floor map.

Changes include:

1.  **Backend:** Added a new public API endpoint `GET /api/maps` that returns a list of all floor maps with their details (id, name, location, floor, image_url). This allows the frontend to fetch map information without requiring admin privileges.

2.  **Frontend (`static/js/script.js`):**
    - The `fetchAndRenderResources` function has been significantly updated. It now fetches both resources (from `/api/resources`) and floor maps (from the new `/api/maps`).
    - Resources are then processed and grouped based on their `floor_map_id`. Resources not assigned to a map are placed in an "Other Resources" category.
    - The DOM is then rendered with `<h3>` headings for each map (e.g., "Map: MapName (Location - Floor)") or "Other Resources", followed by a grid of the respective resource buttons.
    - The original click event listener for resource buttons (to open the booking modal) has been preserved and is correctly attached to all buttons in their new grouped structure.
    - The `updateAllButtonColors` function continues to manage the styling and visibility of buttons based on date selection.

3.  **Styling (`static/style.css`):**
    - Added basic CSS rules for `.map-group-heading`, `.map-specific-grid`, and `.unassigned-grid` to provide clear visual separation and styling for the new groupings.

This feature enhances the usability of the resources page by organizing resources in a more structured and intuitive manner, especially for environments with multiple floor maps.