### PR TITLE
Refactor: Adjust resources page layout and remove old section

### DIFF
--- a/static/js/script.js
+++ b/static/js/script.js
@@ -886,66 +886,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     clearCalendar(true);
                 });
         }
-        
-        const floorMapsListUl = document.getElementById('floor-maps-list');
-        const floorMapsLoadingStatusDiv = document.getElementById('floor-maps-loading-status');
-        const locationFilter = document.getElementById('location-filter');
-        const floorFilter = document.getElementById('floor-filter');
-        if (floorMapsListUl && floorMapsLoadingStatusDiv) {
-            // ... (Keep existing floor map list logic as is) ...
-            let allMaps = [];
-
-            function renderMapLinks() {
-                floorMapsListUl.innerHTML = '';
-                const loc = locationFilter ? locationFilter.value : '';
-                const fl = floorFilter ? floorFilter.value : '';
-                const filtered = allMaps.filter(m => (!loc || m.location === loc) && (!fl || m.floor === fl));
-                if (filtered.length === 0) {
-                    floorMapsListUl.innerHTML = '<li>No floor maps match selection.</li>';
-                    return;
-                }
-                filtered.forEach(map => {
-                    const li = document.createElement('li');
-                    const link = document.createElement('a');
-                    link.href = `/map_view/${map.id}`;
-                    link.textContent = map.name;
-                    li.appendChild(link);
-                    floorMapsListUl.appendChild(li);
-                });
-            }
-
-            function updateFloorOptions() {
-                if (!floorFilter) return;
-                const loc = locationFilter ? locationFilter.value : '';
-                const floors = [...new Set(allMaps.filter(m => !loc || m.location === loc).map(m => m.floor).filter(f => f))];
-                floorFilter.innerHTML = '<option value="">All</option>';
-                floors.forEach(f => {
-                    const opt = new Option(f, f);
-                    floorFilter.add(opt);
-                });
-            }
-
-            async function fetchAndDisplayFloorMapLinks() {
-                try {
-                    const maps = await apiCall('/api/admin/maps', {}, floorMapsLoadingStatusDiv);
-                    allMaps = maps || [];
-                    if (locationFilter) {
-                        const locations = [...new Set(allMaps.map(m => m.location).filter(l => l))];
-                        locationFilter.innerHTML = '<option value="">All</option>';
-                        locations.forEach(loc => locationFilter.add(new Option(loc, loc)));
-                    }
-                    updateFloorOptions();
-                    renderMapLinks();
-                } catch (error) {
-                    if (floorMapsListUl) floorMapsListUl.innerHTML = '<li>Error loading floor maps.</li>';
-                }
-            }
-
-            if (locationFilter) locationFilter.addEventListener('change', () => { updateFloorOptions(); renderMapLinks(); });
-            if (floorFilter) floorFilter.addEventListener('change', renderMapLinks);
-
-            fetchAndDisplayFloorMapLinks();
-        }
+        // Removed the floorMapsListUl, floorMapsLoadingStatusDiv, locationFilter, floorFilter related block
     } 
 
 

--- a/static/style.css
+++ b/static/style.css
@@ -875,8 +875,8 @@ body.high-contrast input[type="button"]:hover {
 /* Styling for Floor Map Groupings on Resources Page */
 .map-group-heading {
     margin-top: 25px;
-    margin-bottom: 15px;
-    font-size: 1.4em; /* Slightly larger than default h3 if needed */
+    margin-bottom: 10px; /* Adjusted */
+    font-size: 1.2em; /* Reduced */
     color: #333; /* Or match your theme's heading color */
     border-bottom: 2px solid #eee; /* A light separator */
     padding-bottom: 5px;
@@ -886,13 +886,13 @@ body.high-contrast input[type="button"]:hover {
     /* If the default .resource-buttons-grid already has good spacing, 
        you might not need much here. This is a placeholder. */
     /* Example: add some padding if grids are too close to headings */
-    padding-top: 10px;
+    margin-top: 15px; /* Changed from padding-top */
     margin-bottom: 20px; /* Space before the next map group heading */
 }
 
 .unassigned-grid {
     /* Similar to map-specific-grid, if needed */
-    padding-top: 10px;
+    margin-top: 15px; /* Changed from padding-top */
 }
 
 /* Ensure the main container still allows for these new elements */

--- a/templates/resources.html
+++ b/templates/resources.html
@@ -41,18 +41,4 @@
         </div>
     </div>
 
-    <hr>
-    <section id="floor-maps-selection-section">
-        <h2>{{ _('View by Floor Map') }}</h2>
-        <div>
-            <label for="location-filter">{{ _('Location:') }}</label>
-            <select id="location-filter"></select>
-            <label for="floor-filter">{{ _('Floor:') }}</label>
-            <select id="floor-filter"></select>
-        </div>
-        <div id="floor-maps-loading-status" aria-live="polite" style="margin-bottom: 10px;"></div>
-        <ul id="floor-maps-list">
-            <li>{{ _('Loading floor maps...') }}</li>
-        </ul>
-    </section>
 {% endblock %}


### PR DESCRIPTION
This commit applies your requested refinements to the resources page:

1.  **Styling:**
    - Reduced the font size of floor map group headings (`.map-group-heading`) to `1.2em` for a less prominent appearance.
    - Adjusted margins for `.map-group-heading`, `.map-specific-grid`, and `.unassigned-grid` to ensure clear visual separation between group headings (with their bottom border) and the resource button grids below them. Grids now use `margin-top` for this spacing.

2.  **HTML Structure (`templates/resources.html`):**
    - Removed the entire `<section id="floor-maps-selection-section">` (including its preceding `<hr>` tag). This section, titled "View by Floor Map," which contained filters and links to map pages, was reported as non-functional and is made redundant by the new map-based grouping of resources directly on the page.

3.  **JavaScript (`static/js/script.js`):**
    - Deleted the corresponding JavaScript block that powered the removed "View by Floor Map" section. This includes functions like `fetchAndDisplayFloorMapLinks` and associated event listeners.

These changes streamline the resources page, improve its layout based on your feedback, and remove unused/non-functional elements.