### PR TITLE
Feat: Hide empty resource groups on resources page

### DIFF
--- a/static/js/script.js
+++ b/static/js/script.js
@@ -955,6 +955,41 @@ document.addEventListener('DOMContentLoaded', function() {
             console.log("RPBM modal reset complete.");
         }
 
+        function updateGroupVisibility() {
+            console.log("Updating group visibility...");
+            const allHeadings = document.querySelectorAll('#resource-buttons-container .map-group-heading');
+    
+            allHeadings.forEach(heading => {
+                // A bit fragile if structure changes, but common pattern for heading + content div
+                const gridContainer = heading.nextElementSibling; 
+    
+                if (gridContainer && gridContainer.classList.contains('resource-buttons-grid')) {
+                    // More robust check for visibility:
+                    // Iterate through buttons and check computed style or explicit style.display !== 'none'
+                    let hasVisibleButton = false;
+                    const buttonsInGroup = gridContainer.querySelectorAll('.resource-availability-button');
+                    for (let i = 0; i < buttonsInGroup.length; i++) {
+                        if (buttonsInGroup[i].style.display !== 'none') {
+                            hasVisibleButton = true;
+                            break;
+                        }
+                    }
+    
+                    if (hasVisibleButton) {
+                        heading.style.display = ''; // Reset to default (visible)
+                        gridContainer.style.display = ''; // Reset to default (visible)
+                        console.log(`Group for heading "${heading.textContent}" has visible resources, showing group.`);
+                    } else {
+                        heading.style.display = 'none';
+                        gridContainer.style.display = 'none';
+                        console.log(`Group for heading "${heading.textContent}" has NO visible resources, hiding group.`);
+                    }
+                } else {
+                    // console.warn("Could not find grid container for heading:", heading.textContent);
+                }
+            });
+        }
+
         // 2. fetchAndRenderResources() function
         async function fetchAndRenderResources() {
             // Ensure resourceLoadingStatusDiv is defined in this scope or passed.
@@ -1368,11 +1403,15 @@ document.addEventListener('DOMContentLoaded', function() {
                 if (resourceLoadingStatusDiv && !resourceLoadingStatusDiv.classList.contains('error')) { // Check if an error occurred during any update
                     hideMessage(resourceLoadingStatusDiv); // Hide general loading message
                 }
+                updateGroupVisibility(); // Call here after successful updates
             } catch (error) {
                 console.error("Error during Promise.all for updateAllButtonColors:", error);
                 // Individual errors are handled in updateButtonColor. 
                 // This catch is for Promise.all itself if it rejects for some reason not caught by individual calls.
                 if (resourceLoadingStatusDiv) showError(resourceLoadingStatusDiv, "An error occurred while updating resource statuses.");
+                // Consider if updateGroupVisibility() should also be called in case of error, 
+                // if partially updated button states are possible and groups might need hiding.
+                // For now, calling only on full success of all button updates.
             }
         }
         


### PR DESCRIPTION
This commit enhances the resources page functionality by dynamically hiding entire resource groups (including their headings) if they contain no visible resources after date filtering.

Changes in `static/js/script.js`:
1.  A new function `updateGroupVisibility()` has been implemented. This function iterates through each map group (and the "Other Resources" group). For each group, it checks if any resource buttons within it are currently displayed (style.display is not 'none'). If no buttons are visible, the group's heading and its container div are hidden. Otherwise, they are shown.

2.  The `updateAllButtonColors()` function now calls `updateGroupVisibility()` at the end of successfully updating all individual button states. This ensures that after a date change and buttons are shown/hidden based on availability, the group visibility is also correctly adjusted.

This improvement declutters the resources page by removing sections that have no relevant content for your selected date, leading to a cleaner and more focused user experience.