### PR TITLE
fix: Correct IndentationError in update_booking_by_user

### DIFF
--- a/app.py
+++ b/app.py
@@ -2598,7 +2598,7 @@ def update_booking_by_user(booking_id):
                 parsed_new_start_time = datetime.fromisoformat(new_start_iso)
                 parsed_new_end_time = datetime.fromisoformat(new_end_iso)
             except ValueError:
-        app.logger.warning(f"[API PUT /api/bookings/{booking_id}] User '{current_user.username}' provided invalid ISO format. Start: {new_start_iso}, End: {new_end_iso}")
+                app.logger.warning(f"[API PUT /api/bookings/{booking_id}] User '{current_user.username}' provided invalid ISO format. Start: {new_start_iso}, End: {new_end_iso}")
                 return jsonify({'error': 'Invalid datetime format. Use ISO 8601.'}), 400
 
             if parsed_new_start_time >= parsed_new_end_time:


### PR DESCRIPTION
Resolved an `IndentationError` in the `update_booking_by_user` function in `app.py`. The error occurred because the lines within the `except ValueError:` block (for handling invalid ISO datetime formats) were not properly indented.

This commit ensures the exception handling block is correctly structured.