### PR TITLE
Add Azure blob backup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,3 +178,17 @@ Pushing to the `main` branch triggers the workflow. The action zips the project 
 
 Make sure the database is initialized by running `python init_setup.py` locally or as part of your deployment process.
 
+
+## Backing Up Data to Azure File Share
+
+Use `azure_backup.py` to upload the SQLite database and uploaded images to an Azure File Share. The script reads these environment variables:
+
+- `AZURE_STORAGE_CONNECTION_STRING` – connection string to your storage account
+- `AZURE_DB_SHARE` – file share name for database backups (default `db-backups`)
+- `AZURE_MEDIA_SHARE` – file share name for uploaded images (default `media`)
+
+Run the script with:
+```bash
+python azure_backup.py
+```
+All floor map and resource images from `static/` along with `data/site.db` will be uploaded.

--- a/azure_backup.py
+++ b/azure_backup.py
@@ -1,0 +1,74 @@
+import os
+from datetime import datetime
+
+try:
+    from azure.storage.fileshare import ShareServiceClient
+except ImportError:  # pragma: no cover - azure sdk optional
+    ShareServiceClient = None
+
+
+BASE_DIR = os.path.abspath(os.path.dirname(__file__))
+DATA_DIR = os.path.join(BASE_DIR, 'data')
+STATIC_DIR = os.path.join(BASE_DIR, 'static')
+FLOOR_MAP_UPLOADS = os.path.join(STATIC_DIR, 'floor_map_uploads')
+RESOURCE_UPLOADS = os.path.join(STATIC_DIR, 'resource_uploads')
+
+
+def _get_service_client():
+    connection_string = os.environ.get('AZURE_STORAGE_CONNECTION_STRING')
+    if not connection_string:
+        raise RuntimeError('AZURE_STORAGE_CONNECTION_STRING environment variable is required')
+    if ShareServiceClient is None:
+        raise RuntimeError('azure-storage-file-share package is not installed')
+    return ShareServiceClient.from_connection_string(connection_string)
+
+
+def upload_file(share_client, source_path, file_path):
+    directory_path = os.path.dirname(file_path)
+    if directory_path:
+        directory_client = share_client.get_directory_client(directory_path)
+        if not directory_client.exists():
+            directory_client.create_directory()
+    with open(source_path, 'rb') as f:
+        file_client = share_client.get_file_client(file_path)
+        file_client.upload_file(f, overwrite=True)
+
+
+def backup_database():
+    service_client = _get_service_client()
+    share_name = os.environ.get('AZURE_DB_SHARE', 'db-backups')
+    share_client = service_client.get_share_client(share_name)
+    if not share_client.exists():
+        share_client.create_share()
+    db_path = os.path.join(DATA_DIR, 'site.db')
+    timestamp = datetime.utcnow().strftime('%Y%m%d_%H%M%S')
+    file_name = f'site_{timestamp}.db'
+    upload_file(share_client, db_path, file_name)
+    return file_name
+
+
+def backup_media():
+    service_client = _get_service_client()
+    share_name = os.environ.get('AZURE_MEDIA_SHARE', 'media')
+    share_client = service_client.get_share_client(share_name)
+    if not share_client.exists():
+        share_client.create_share()
+    # Upload floor map images
+    for folder in (FLOOR_MAP_UPLOADS, RESOURCE_UPLOADS):
+        if not os.path.isdir(folder):
+            continue
+        for fname in os.listdir(folder):
+            fpath = os.path.join(folder, fname)
+            if os.path.isfile(fpath):
+                file_path = f'{os.path.basename(folder)}/{fname}'
+                upload_file(share_client, fpath, file_path)
+
+
+def main():
+    db_file = backup_database()
+    backup_media()
+    print(f'Backup completed. Database file: {db_file}')
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ Authlib>=1.0.0
 Flask-Mail>=0.9
 requests>=2.25
 gunicorn
+
+azure-storage-file-share


### PR DESCRIPTION
## Summary
- provide `azure_backup.py` script to store the SQLite database and uploaded images in Azure File Share
- document required environment variables and how to run the script
- use `azure-storage-file-share` package instead of blob client

## Testing
- `pytest -q`
