### PR TITLE
Enhance resource management

### DIFF
--- a/templates/resource_management.html
+++ b/templates/resource_management.html
@@ -8,6 +8,30 @@
     <button id="add-bulk-resource-btn" class="button" style="margin-left:5px;">{{ _('Bulk Add Resources') }}</button>
     <button id="bulk-edit-btn" class="button" style="margin-left:5px;">{{ _('Bulk Edit') }}</button>
     <button id="bulk-delete-btn" class="button danger" style="margin-left:5px;">{{ _('Bulk Delete') }}</button>
+    <div class="filters-section" style="margin-top:15px;">
+        <h3>{{ _('Filters') }}</h3>
+        <label for="resource-filter-name">{{ _('Name:') }}</label>
+        <input type="text" id="resource-filter-name" placeholder="{{ _('Filter by Name') }}">
+
+        <label for="resource-filter-status">{{ _('Status:') }}</label>
+        <select id="resource-filter-status">
+            <option value="">{{ _('-- Any --') }}</option>
+            <option value="draft">{{ _('Draft') }}</option>
+            <option value="published">{{ _('Published') }}</option>
+            <option value="archived">{{ _('Archived') }}</option>
+        </select>
+
+        <label for="resource-filter-map">{{ _('Floor Map:') }}</label>
+        <select id="resource-filter-map">
+            <option value="">{{ _('-- Any --') }}</option>
+        </select>
+
+        <label for="resource-filter-tags">{{ _('Group/Tags:') }}</label>
+        <input type="text" id="resource-filter-tags" placeholder="{{ _('Filter by Group') }}">
+
+        <button id="resource-apply-filters-btn" class="button">{{ _('Apply Filters') }}</button>
+        <button id="resource-clear-filters-btn" class="button">{{ _('Clear Filters') }}</button>
+    </div>
     <div id="resource-management-status" class="status-message" style="margin-top: 15px;"></div>
 
     <table id="resources-table" class="styled-table" style="margin-top: 15px;">
@@ -18,6 +42,7 @@
                 <th>{{ _('Name') }}</th>
                 <th>{{ _('Status') }}</th>
                 <th>{{ _('Capacity') }}</th>
+                <th>{{ _('Tags') }}</th>
                 <th>{{ _('Actions') }}</th>
             </tr>
         </thead>
@@ -43,6 +68,10 @@
                 <div>
                     <label for="resource-equipment">{{ _('Equipment:') }}</label>
                     <input type="text" id="resource-equipment" name="equipment">
+                </div>
+                <div>
+                    <label for="resource-tags">{{ _('Group/Tags:') }}</label>
+                    <input type="text" id="resource-tags" name="tags">
                 </div>
                 <div>
                     <label for="resource-status-modal">{{ _('Status:') }}</label>
@@ -92,6 +121,10 @@
                     <input type="text" id="bulk-equipment" name="equipment">
                 </div>
                 <div>
+                    <label for="bulk-tags">{{ _('Group/Tags:') }}</label>
+                    <input type="text" id="bulk-tags" name="tags">
+                </div>
+                <div>
                     <label for="bulk-status">{{ _('Status:') }}</label>
                     <select id="bulk-status" name="status" class="form-control">
                         <option value="draft">{{ _('Draft') }}</option>
@@ -126,6 +159,10 @@
                 <div>
                     <label for="bulk-edit-equipment">{{ _('Equipment:') }}</label>
                     <input type="text" id="bulk-edit-equipment" name="equipment">
+                </div>
+                <div>
+                    <label for="bulk-edit-tags">{{ _('Group/Tags:') }}</label>
+                    <input type="text" id="bulk-edit-tags" name="tags">
                 </div>
                 <button type="submit" class="button" style="margin-top: 10px;">{{ _('Apply Changes') }}</button>
                 <div id="bulk-edit-form-status" class="status-message" style="margin-top: 10px;"></div>

--- a/templates/resources.html
+++ b/templates/resources.html
@@ -9,6 +9,20 @@
         <input type="date" id="availability-date" name="availability-date">
     </div>
 
+    <div class="filters-section" style="margin-top:15px;">
+        <label for="resource-filter-capacity">{{ _('Min Capacity:') }}</label>
+        <input type="number" id="resource-filter-capacity" min="1">
+
+        <label for="resource-filter-equipment">{{ _('Equipment:') }}</label>
+        <input type="text" id="resource-filter-equipment">
+
+        <label for="resource-filter-tags">{{ _('Tags:') }}</label>
+        <input type="text" id="resource-filter-tags">
+
+        <button id="resource-apply-filters-btn" class="button">{{ _('Apply Filters') }}</button>
+        <button id="resource-clear-filters-btn" class="button">{{ _('Clear Filters') }}</button>
+    </div>
+
     <div id="resource-loading-status" class="status-message" style="margin-bottom: 15px;"></div>
     <div id="resource-buttons-container" class="resource-buttons-grid" style="margin-top: 20px;">
         <!-- Resource buttons will be populated by JavaScript -->


### PR DESCRIPTION
## Summary
- allow creating and editing resource tags in the backend
- return tags in resource API responses
- add resource filters and grouping by floor map on management page
- support resource tags in bulk creation/edit UI
- add filtering to the public resources page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683a6d541f488324b92c03e1d4fe4610