### PR TITLE
Fix bulk edit modal closing and add Azure integrations

### DIFF
--- a/azure_backup.py
+++ b/azure_backup.py
@@ -48,6 +48,19 @@ def backup_database():
     return file_name
 
 
+def save_floor_map_to_share(local_path, dest_filename=None):
+    """Upload a single floor map file to the configured Azure File Share."""
+    service_client = _get_service_client()
+    share_name = os.environ.get('AZURE_MEDIA_SHARE', 'media')
+    share_client = service_client.get_share_client(share_name)
+    if not share_client.exists():
+        share_client.create_share()
+    if dest_filename is None:
+        dest_filename = os.path.basename(local_path)
+    file_path = f'floor_map_uploads/{dest_filename}'
+    upload_file(share_client, local_path, file_path)
+
+
 def backup_media():
     service_client = _get_service_client()
     share_name = os.environ.get('AZURE_MEDIA_SHARE', 'media')

--- a/static/js/resource_management.js
+++ b/static/js/resource_management.js
@@ -164,6 +164,10 @@ document.addEventListener('DOMContentLoaded', function() {
     bulkCloseBtn && bulkCloseBtn.addEventListener('click', () => bulkModal.style.display = 'none');
     window.addEventListener('click', e => { if (e.target === bulkModal) bulkModal.style.display = 'none'; });
 
+    const bulkEditCloseBtn = bulkEditModal ? bulkEditModal.querySelector('.close-modal-btn') : null;
+    bulkEditCloseBtn && bulkEditCloseBtn.addEventListener('click', () => bulkEditModal.style.display = 'none');
+    window.addEventListener('click', e => { if (e.target === bulkEditModal) bulkEditModal.style.display = 'none'; });
+
     bulkEditBtn && bulkEditBtn.addEventListener('click', () => {
         const ids = getSelectedResourceIds();
         if (ids.length === 0) {


### PR DESCRIPTION
## Summary
- allow using Azure SQL by reading `AZURE_SQL_CONNECTION_STRING` or `DATABASE_URL`
- upload new floor maps to Azure File Share when available
- export helper in `azure_backup` to upload a single floor map
- fix close button for the bulk edit modal

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a7fdf63108324891d143e6f9272c4