### PR TITLE
Fix DB URI fallback and integrate Azure features

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,6 +22,12 @@ from flask_wtf.csrf import CSRFProtect # For CSRF protection
 from flask_socketio import SocketIO
 
 
+try:
+    from azure_backup import save_floor_map_to_share
+except Exception:
+    save_floor_map_to_share = None
+
+
 
 # Attempt to import APScheduler; provide a basic fallback if unavailable
 try:
@@ -171,7 +177,10 @@ if not os.path.exists(app.config['UPLOAD_FOLDER']):
     os.makedirs(app.config['UPLOAD_FOLDER'])
 if not os.path.exists(app.config['RESOURCE_UPLOAD_FOLDER']):
     os.makedirs(app.config['RESOURCE_UPLOAD_FOLDER'])
-app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///' + os.path.join(DATA_DIR, 'site.db')
+db_uri = os.environ.get('AZURE_SQL_CONNECTION_STRING') or \
+    os.environ.get('DATABASE_URL') or \
+    'sqlite:///' + os.path.join(DATA_DIR, 'site.db')
+app.config['SQLALCHEMY_DATABASE_URI'] = db_uri
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False # silence the warning
 
 # Flask-Mail configuration (defaults can be overridden with environment variables)
@@ -981,6 +990,11 @@ def upload_floor_map():
         try:
             file_path = os.path.join(app.config['UPLOAD_FOLDER'], filename)
             file.save(file_path)
+            if save_floor_map_to_share:
+                try:
+                    save_floor_map_to_share(file_path, filename)
+                except Exception:
+                    app.logger.exception('Failed to upload floor map to Azure File Share')
 
             new_map = FloorMap(name=map_name, image_filename=filename,
                                location=location, floor=floor)

--- a/azure_backup.py
+++ b/azure_backup.py
@@ -48,6 +48,19 @@ def backup_database():
     return file_name
 
 
+def save_floor_map_to_share(local_path, dest_filename=None):
+    """Upload a single floor map file to the configured Azure File Share."""
+    service_client = _get_service_client()
+    share_name = os.environ.get('AZURE_MEDIA_SHARE', 'media')
+    share_client = service_client.get_share_client(share_name)
+    if not share_client.exists():
+        share_client.create_share()
+    if dest_filename is None:
+        dest_filename = os.path.basename(local_path)
+    file_path = f'floor_map_uploads/{dest_filename}'
+    upload_file(share_client, local_path, file_path)
+
+
 def backup_media():
     service_client = _get_service_client()
     share_name = os.environ.get('AZURE_MEDIA_SHARE', 'media')

--- a/static/js/resource_management.js
+++ b/static/js/resource_management.js
@@ -164,6 +164,10 @@ document.addEventListener('DOMContentLoaded', function() {
     bulkCloseBtn && bulkCloseBtn.addEventListener('click', () => bulkModal.style.display = 'none');
     window.addEventListener('click', e => { if (e.target === bulkModal) bulkModal.style.display = 'none'; });
 
+    const bulkEditCloseBtn = bulkEditModal ? bulkEditModal.querySelector('.close-modal-btn') : null;
+    bulkEditCloseBtn && bulkEditCloseBtn.addEventListener('click', () => bulkEditModal.style.display = 'none');
+    window.addEventListener('click', e => { if (e.target === bulkEditModal) bulkEditModal.style.display = 'none'; });
+
     bulkEditBtn && bulkEditBtn.addEventListener('click', () => {
         const ids = getSelectedResourceIds();
         if (ids.length === 0) {


### PR DESCRIPTION
## Summary
- import helper for uploading floor maps to Azure File Share when available
- upload new map images to Azure File Share using `save_floor_map_to_share`
- expose `save_floor_map_to_share` in `azure_backup`
- close the bulk edit modal using its own close button
- handle empty Azure SQL connection strings when configuring `SQLALCHEMY_DATABASE_URI`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683a7fdf63108324891d143e6f9272c4