### PR TITLE
Implement bulk user management with import/export

### DIFF
--- a/app.py
+++ b/app.py
@@ -1950,6 +1950,132 @@ def assign_google_auth(user_id):
         app.logger.exception(f"Error assigning Google ID to user {user_id}:")
         return jsonify({'error': 'Failed to assign Google ID due to a server error.'}), 500
 
+@app.route('/api/admin/users/bulk', methods=['DELETE'])
+@login_required
+def delete_users_bulk():
+    if not current_user.has_permission('manage_users'):
+        return jsonify({'error': 'Permission denied to manage users.'}), 403
+
+    data = request.get_json()
+    if not data or 'ids' not in data or not isinstance(data['ids'], list):
+        return jsonify({'error': 'Invalid input. "ids" list required.'}), 400
+
+    ids = data['ids']
+    deleted = []
+    skipped = []
+    for uid in ids:
+        user = User.query.get(uid)
+        if not user or user.id == current_user.id:
+            skipped.append(uid)
+            continue
+        db.session.delete(user)
+        deleted.append(uid)
+
+    try:
+        db.session.commit()
+        return jsonify({'deleted': deleted, 'skipped': skipped}), 200
+    except Exception:
+        db.session.rollback()
+        app.logger.exception("Error deleting users in bulk:")
+        return jsonify({'error': 'Failed to delete users due to a server error.'}), 500
+
+
+@app.route('/api/admin/users/export', methods=['GET'])
+@login_required
+def export_users():
+    if not current_user.has_permission('manage_users'):
+        return jsonify({'error': 'Permission denied to manage users.'}), 403
+
+    users = User.query.all()
+    roles = Role.query.all()
+
+    users_data = []
+    for u in users:
+        users_data.append({
+            'id': u.id,
+            'username': u.username,
+            'email': u.email,
+            'is_admin': u.is_admin,
+            'roles': [r.id for r in u.roles]
+        })
+
+    roles_data = []
+    for r in roles:
+        roles_data.append({
+            'id': r.id,
+            'name': r.name,
+            'description': r.description,
+            'permissions': r.permissions
+        })
+
+    return jsonify({'users': users_data, 'roles': roles_data}), 200
+
+
+@app.route('/api/admin/users/import', methods=['POST'])
+@login_required
+def import_users():
+    if not current_user.has_permission('manage_users'):
+        return jsonify({'error': 'Permission denied to manage users.'}), 403
+
+    data = request.get_json()
+    if not data or 'users' not in data or not isinstance(data['users'], list):
+        return jsonify({'error': 'Invalid input. "users" list required.'}), 400
+
+    created = []
+    updated = []
+    errors = []
+
+    for item in data['users']:
+        if 'id' in item:
+            user = User.query.get(item['id'])
+            if not user:
+                errors.append({'id': item['id'], 'error': 'User not found'})
+                continue
+            if 'username' in item and item['username']:
+                if User.query.filter(User.id != user.id, User.username == item['username']).first():
+                    errors.append({'id': item['id'], 'error': 'Username already exists'})
+                    continue
+                user.username = item['username']
+            if 'email' in item and item['email']:
+                if User.query.filter(User.id != user.id, User.email == item['email']).first():
+                    errors.append({'id': item['id'], 'error': 'Email already exists'})
+                    continue
+                user.email = item['email']
+            if 'password' in item and item['password']:
+                user.set_password(item['password'])
+            if 'is_admin' in item:
+                user.is_admin = bool(item['is_admin'])
+            if 'role_ids' in item and isinstance(item['role_ids'], list):
+                roles = [Role.query.get(rid) for rid in item['role_ids'] if Role.query.get(rid)]
+                user.roles = roles
+            updated.append(user.id)
+        else:
+            username = item.get('username')
+            email = item.get('email')
+            password = item.get('password')
+            if not username or not email or not password:
+                errors.append({'username': username, 'error': 'Missing required fields'})
+                continue
+            if User.query.filter_by(username=username).first() or User.query.filter_by(email=email).first():
+                errors.append({'username': username, 'error': 'User exists'})
+                continue
+            new_user = User(username=username, email=email, is_admin=item.get('is_admin', False))
+            new_user.set_password(password)
+            if 'role_ids' in item and isinstance(item['role_ids'], list):
+                roles = [Role.query.get(rid) for rid in item['role_ids'] if Role.query.get(rid)]
+                new_user.roles = roles
+            db.session.add(new_user)
+            db.session.flush()
+            created.append(new_user.id)
+
+    try:
+        db.session.commit()
+        return jsonify({'created': created, 'updated': updated, 'errors': errors}), 200
+    except Exception:
+        db.session.rollback()
+        app.logger.exception("Error importing users:")
+        return jsonify({'error': 'Failed to import users due to a server error.'}), 500
+
 # --- Waitlist Management APIs ---
 @app.route('/api/admin/waitlist', methods=['GET'])
 @login_required

--- a/templates/user_management.html
+++ b/templates/user_management.html
@@ -5,6 +5,10 @@
 {% block content %}
     <h1>{{ _('User Management') }}</h1>
     <button id="add-new-user-btn" class="button">{{ _('Add New User') }}</button>
+    <button id="export-users-btn" class="button">{{ _('Export Users') }}</button>
+    <button id="import-users-btn" class="button">{{ _('Import Users') }}</button>
+    <input type="file" id="import-users-file" accept="application/json" style="display:none;">
+    <button id="delete-selected-users-btn" class="button danger">{{ _('Delete Selected') }}</button>
     <div class="filters-section" style="margin-top:15px;">
         <h3>{{ _('Filters') }}</h3>
         <label for="user-filter-username">{{ _('Username:') }}</label>
@@ -26,6 +30,7 @@
     <table id="users-table" class="styled-table" style="margin-top: 15px;">
         <thead>
             <tr>
+                <th><input type="checkbox" id="select-all-users"></th>
                 <th>{{ _('ID') }}</th>
                 <th>{{ _('Username') }}</th>
                 <th>{{ _('Email') }}</th>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1129,5 +1129,51 @@ class TestBulkResourceEditDelete(AppTests):
         self.assertIsNone(Resource.query.get(r2.id))
 
 
+class TestUserImportExport(AppTests):
+    def test_export_users(self):
+        admin = User(username='exportadmin', email='export@example.com', is_admin=True)
+        admin.set_password('adminpass')
+        db.session.add(admin)
+        db.session.commit()
+        self.login('exportadmin', 'adminpass')
+
+        user = User(username='exportuser', email='exportuser@example.com', is_admin=False)
+        user.set_password('pass')
+        db.session.add(user)
+        db.session.commit()
+
+        resp = self.client.get('/api/admin/users/export')
+        self.assertEqual(resp.status_code, 200)
+        data = resp.get_json()
+        usernames = [u['username'] for u in data['users']]
+        self.assertIn('exportuser', usernames)
+
+    def test_import_users_and_bulk_delete(self):
+        admin = User(username='importadmin', email='import@example.com', is_admin=True)
+        admin.set_password('adminpass')
+        db.session.add(admin)
+        db.session.commit()
+        self.login('importadmin', 'adminpass')
+
+        payload = {
+            'users': [
+                {'username': 'imp1', 'email': 'imp1@example.com', 'password': 'p1'},
+                {'username': 'imp2', 'email': 'imp2@example.com', 'password': 'p2'}
+            ]
+        }
+        resp = self.client.post('/api/admin/users/import', json=payload)
+        self.assertEqual(resp.status_code, 200)
+        u1 = User.query.filter_by(username='imp1').first()
+        u2 = User.query.filter_by(username='imp2').first()
+        self.assertIsNotNone(u1)
+        self.assertIsNotNone(u2)
+
+        del_payload = {'ids': [u1.id, u2.id]}
+        del_resp = self.client.delete('/api/admin/users/bulk', json=del_payload)
+        self.assertEqual(del_resp.status_code, 200)
+        self.assertIsNone(User.query.get(u1.id))
+        self.assertIsNone(User.query.get(u2.id))
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- add API endpoints for deleting users in bulk
- add endpoints to export and import users with roles
- support new admin actions in user management UI
- tests for user export, import, and bulk delete

## Testing
- `bash tests/setup.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a94d274148324878262ec3de33eeb