### PR TITLE
Improve sidebar icons and accessibility menu

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -88,6 +88,35 @@ nav ul li a:focus {
     margin-right: 2px;
 }
 
+/* Icons and text handling for sidebar menu */
+#sidebar li .menu-icon {
+    display: inline-block;
+    width: 1.2em;
+    text-align: center;
+    margin-right: 0.5em;
+}
+#sidebar.collapsed .menu-text {
+    display: none;
+}
+#sidebar.collapsed li {
+    text-align: center;
+}
+
+/* Compact accessibility controls at top */
+.accessibility-top {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    gap: 0.25rem;
+    font-size: 0.85rem;
+    margin-bottom: 0.5rem;
+}
+
+.accessibility-top button {
+    font-size: 0.75rem;
+    padding: 2px 4px;
+}
+
 /* Keep icon and arrow vertically centered */
 #user-dropdown-button {
     display: flex;

--- a/templates/base.html
+++ b/templates/base.html
@@ -12,21 +12,21 @@
     <nav id="sidebar" class="collapsed">
         <button id="sidebar-toggle" aria-label="{{ _('Toggle menu') }}">&#9776;</button>
         <ul>
-            <li><a href="{{ url_for('serve_index') }}">{{ _('Home') }}</a></li>
-            <li><a href="{{ url_for('serve_new_booking') }}">{{ _('New Booking') }}</a></li>
-            <li><a href="{{ url_for('serve_resources') }}">{{ _('View Resources') }}</a></li>
-            <li><a href="{{ url_for('serve_calendar') }}">{{ _('Calendar') }}</a></li>
+            <li><a href="{{ url_for('serve_index') }}"><span class="menu-icon" aria-hidden="true">🏠</span><span class="menu-text">{{ _('Home') }}</span></a></li>
+            <li><a href="{{ url_for('serve_new_booking') }}"><span class="menu-icon" aria-hidden="true">🆕</span><span class="menu-text">{{ _('New Booking') }}</span></a></li>
+            <li><a href="{{ url_for('serve_resources') }}"><span class="menu-icon" aria-hidden="true">📁</span><span class="menu-text">{{ _('View Resources') }}</span></a></li>
+            <li><a href="{{ url_for('serve_calendar') }}"><span class="menu-icon" aria-hidden="true">📅</span><span class="menu-text">{{ _('Calendar') }}</span></a></li>
             
             {# General links visible to all - JavaScript will manage the display of login/logout and user info #}
 
             {# Container for the 'Login' link - shown by JS when logged out #}
             <li id="auth-link-container" style="display: none; margin-left:auto;">
-                <a href="{{ url_for('serve_login') }}">{{ _('Login') }}</a>
+                <a href="{{ url_for('serve_login') }}"><span class="menu-icon" aria-hidden="true">🔑</span><span class="menu-text">{{ _('Login') }}</span></a>
             </li>
 
             {# Container for 'My Bookings' - shown by JS when logged in #}
             <li id="my-bookings-nav-link" style="display: none;">
-                 <a href="{{ url_for('serve_my_bookings_page') }}">{{ _('My Bookings') }}</a>
+                 <a href="{{ url_for('serve_my_bookings_page') }}"><span class="menu-icon" aria-hidden="true">📖</span><span class="menu-text">{{ _('My Bookings') }}</span></a>
             </li>
             
             {# Container for Admin Maps link - shown by JS if admin #}
@@ -57,7 +57,7 @@
         </li>
 
             <li>
-                <button id="theme-toggle" type="button">{{ _('Toggle Theme') }}</button>
+                <button id="theme-toggle" type="button"><span class="menu-icon" aria-hidden="true">🌓</span><span class="menu-text">{{ _('Toggle Theme') }}</span></button>
             </li>
 
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,6 +3,13 @@
 {% block title %}{{ _('Smart Resource Booking - Dashboard') }}{% endblock %}
 
 {% block content %}
+    <div id="accessibility-controls" class="accessibility-top">
+        <span class="menu-icon" aria-hidden="true">&#9855;</span>
+        <button id="toggle-high-contrast" title="{{ _('Toggle High Contrast') }}">HC</button>
+        <button id="increase-font-size" title="{{ _('Increase Font Size') }}">A+</button>
+        <button id="decrease-font-size" title="{{ _('Decrease Font Size') }}">A-</button>
+        <button id="reset-font-size" title="{{ _('Reset Font Size') }}">A</button>
+    </div>
     <h1>{{ _('Welcome to Smart Resource Booking') }}</h1>
     <p>{{ _('Your smart solution for managing and booking resources efficiently.') }}</p>
     <section id="upcoming-bookings">
@@ -15,12 +22,4 @@
     </section>
 {% endblock %}
 
-{% block footer_extra %}
-    <div id="accessibility-controls" style="margin-top: 10px; padding: 10px; border-top: 1px solid var(--border-color);">
-        <h3>{{ _('Accessibility') }}</h3>
-        <button id="toggle-high-contrast">{{ _('Toggle High Contrast') }}</button>
-        <button id="increase-font-size">{{ _('Increase Font Size (A+)') }}</button>
-        <button id="decrease-font-size">{{ _('Decrease Font Size (A-)') }}</button>
-        <button id="reset-font-size">{{ _('Reset Font Size') }}</button>
-    </div>
-{% endblock %}
+{% block footer_extra %}{% endblock %}


### PR DESCRIPTION
## Summary
- add compact accessibility controls to top of dashboard
- show icons for sidebar items and hide text when collapsed
- style sidebar icons and accessibility controls

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683ab5d5007483248c413b76ba9f5682