### PR TITLE
Adjust sidebar icon behavior

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -90,16 +90,31 @@ nav ul li a:focus {
 
 /* Icons and text handling for sidebar menu */
 #sidebar li .menu-icon {
-    display: inline-block;
+    display: none; /* hide icons when expanded */
     width: 1.2em;
     text-align: center;
     margin-right: 0.5em;
 }
+#sidebar.collapsed li .menu-icon {
+    display: inline-block; /* show only icons when collapsed */
+    margin-right: 0; /* no gap when centered */
+}
+#sidebar li .menu-text {
+    display: inline-block;
+}
 #sidebar.collapsed .menu-text {
-    display: none;
+    display: none; /* hide text when collapsed */
 }
 #sidebar.collapsed li {
     text-align: center;
+}
+#sidebar.collapsed li a {
+    display: flex;
+    justify-content: center; /* center icons horizontally */
+}
+#sidebar.collapsed summary {
+    display: flex;
+    justify-content: center;
 }
 
 /* Compact accessibility controls at top */
@@ -124,10 +139,9 @@ nav ul li a:focus {
 }
 
 main {
-    width: calc(100% - 220px);
-    margin-left: 220px;
-    max-width: 1200px; /* Max width for large screens */
-    margin: 30px auto; /* Keep vertical centering */
+    width: 100%;
+    max-width: none; /* use full available width */
+    margin: 30px auto; /* center content vertically and horizontally */
     background-color: var(--background-color-light);
     padding: 25px; /* Increased padding */
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.08); /* Softer, more modern shadow */

--- a/templates/base.html
+++ b/templates/base.html
@@ -32,7 +32,7 @@
             {# Container for Admin Maps link - shown by JS if admin #}
         <li id="admin-menu-item" style="display:none;">
             <details id="admin-section">
-                <summary>Admin</summary>
+                <summary><span class="menu-icon" aria-hidden="true">⚙️</span><span class="menu-text">{{ _('Admin') }}</span></summary>
                 <ul class="admin-menu">
                 <li id="admin-maps-nav-link" style="display: none;">
                     <a href="{{ url_for('serve_admin_maps') }}">{{ _('Admin Maps') }}</a>


### PR DESCRIPTION
## Summary
- hide icons when sidebar expanded and center icons when collapsed
- show admin menu icon on collapsed sidebar
- use full width for main content

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683abbc95f4c8324b07f80c1edad6430