### PR TITLE
Fix Azure File Share upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,12 @@ The application uses an SQLite database to store resource information. If you ha
    >>> from init_setup import init_db
    >>> init_db()  # Creates tables and adds sample data if the database is empty
    ```
-   This will create a `site.db` file in the `data/` directory and set up the tables.
-   You should see messages indicating success.
-   Pass `force=True` if you want to **reset and wipe** existing data:
+This will create a `site.db` file in the `data/` directory and set up the tables.
+The database is excluded from version control, but the `azure_backup.py` script
+automatically uploads `data/site.db` to Azure File Share whenever its contents
+change.
+You should see messages indicating success.
+Pass `force=True` if you want to **reset and wipe** existing data:
    ```python
    >>> init_db(force=True)
    ```

--- a/azure_backup.py
+++ b/azure_backup.py
@@ -89,7 +89,10 @@ def upload_file(share_client, source_path, file_path):
     file_client = share_client.get_file_client(file_path)
     with open(source_path, 'rb') as f:
         data = f.read()
-    file_client.upload_file(data, overwrite=True)
+    # ShareFileClient.upload_file does not support an 'overwrite' parameter.
+    # Passing it causes a TypeError when the request is sent. Simply uploading
+    # the data will overwrite the file if it already exists.
+    file_client.upload_file(data)
 
 
 def download_file(share_client, file_path, dest_path):
@@ -147,7 +150,13 @@ def backup_media():
 
 
 def backup_if_changed():
-    """Backup DB and media files only if their hashes changed."""
+    """Backup the SQLite database and media files only when their hashes change.
+
+    The database file lives in ``data/site.db`` and is not committed to the
+    repository. This function uploads that file along with any images under
+    ``static/floor_map_uploads`` and ``static/resource_uploads`` to the
+    configured Azure File Shares.
+    """
     hashes = _load_hashes()
     service_client = _get_service_client()
 


### PR DESCRIPTION
## Summary
- update Azure File Share upload helper to avoid unsupported `overwrite` parameter
- clarify that `backup_if_changed` backs up `data/site.db`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683abd568f788324b9742eab966add3f