### PR TITLE
Adjust sidebar icon behavior

### DIFF
--- a/static/js/script.js
+++ b/static/js/script.js
@@ -205,7 +205,7 @@ async function updateAuthLink() {
 
             if (userDropdownContainer) userDropdownContainer.style.display = 'list-item';
             if (userDropdownButton) {
-                userDropdownButton.innerHTML = `<span class="user-icon">&#x1F464;</span> &#9662;`;
+                userDropdownButton.innerHTML = `<span class="user-icon">&#x1F464;</span><span class="dropdown-arrow"> &#9662;</span>`;
                 userDropdownButton.setAttribute('aria-expanded', 'false');
                 userDropdownButton.title = data.user.username;
             }

--- a/static/style.css
+++ b/static/style.css
@@ -90,16 +90,42 @@ nav ul li a:focus {
 
 /* Icons and text handling for sidebar menu */
 #sidebar li .menu-icon {
-    display: inline-block;
+    display: none; /* hide icons when expanded */
     width: 1.2em;
     text-align: center;
     margin-right: 0.5em;
 }
+#sidebar.collapsed li .menu-icon {
+    display: inline-block; /* show only icons when collapsed */
+    margin-right: 0; /* no gap when centered */
+}
+#sidebar li .menu-text {
+    display: inline-block;
+}
 #sidebar.collapsed .menu-text {
-    display: none;
+    display: none; /* hide text when collapsed */
+}
+#sidebar.collapsed #welcome-message-container {
+    display: none !important;
 }
 #sidebar.collapsed li {
     text-align: center;
+}
+#sidebar.collapsed li a {
+    display: flex;
+    justify-content: center; /* center icons horizontally */
+}
+#sidebar.collapsed li button {
+    display: flex;
+    justify-content: center;
+}
+#sidebar.collapsed #theme-toggle {
+    display: flex;
+    justify-content: center;
+}
+#sidebar.collapsed summary {
+    display: flex;
+    justify-content: center;
 }
 
 /* Compact accessibility controls at top */
@@ -122,12 +148,17 @@ nav ul li a:focus {
     display: flex;
     align-items: center;
 }
+#sidebar.collapsed #user-dropdown-button {
+    justify-content: center;
+}
+#sidebar.collapsed .dropdown-arrow {
+    display: none;
+}
 
 main {
-    width: calc(100% - 220px);
-    margin-left: 220px;
-    max-width: 1200px; /* Max width for large screens */
-    margin: 30px auto; /* Keep vertical centering */
+    width: 100%;
+    max-width: none; /* use full available width */
+    margin: 30px auto; /* center content vertically and horizontally */
     background-color: var(--background-color-light);
     padding: 25px; /* Increased padding */
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.08); /* Softer, more modern shadow */
@@ -970,8 +1001,10 @@ body.with-sidebar {
     border: none;
     color: var(--text-color-light);
     cursor: pointer;
-    font-size: 1.2em;
-    margin: 0 0.5em 0.5em;
+    font-size: 1em;
+    margin: 0.5em auto;
+    display: flex;
+    justify-content: center;
 }
 
 #sidebar ul {
@@ -983,12 +1016,24 @@ body.with-sidebar {
 #sidebar ul li {
     padding: 0.5em 1em;
     white-space: nowrap;
+    font-size: 0.9rem;
 }
 
 #sidebar ul li a {
     color: var(--text-color-light);
     text-decoration: none;
     display: block;
+}
+#sidebar ul li button {
+    background: none;
+    border: none;
+    color: var(--text-color-light);
+    cursor: pointer;
+    width: 100%;
+    padding: 0.5em 0;
+    text-align: left;
+    font-weight: bold;
+    font-size: inherit;
 }
 
 body.with-sidebar #main-content {

--- a/templates/base.html
+++ b/templates/base.html
@@ -32,7 +32,7 @@
             {# Container for Admin Maps link - shown by JS if admin #}
         <li id="admin-menu-item" style="display:none;">
             <details id="admin-section">
-                <summary>Admin</summary>
+                <summary><span class="menu-icon" aria-hidden="true">⚙️</span><span class="menu-text">{{ _('Admin') }}</span></summary>
                 <ul class="admin-menu">
                 <li id="admin-maps-nav-link" style="display: none;">
                     <a href="{{ url_for('serve_admin_maps') }}">{{ _('Admin Maps') }}</a>
@@ -67,7 +67,7 @@
             {# Container for user dropdown (Profile, Logout) - shown by JS when logged in #}
             <li id="user-dropdown-container" style="display: none; position: relative; margin-left:auto;">
                 <button id="user-dropdown-button" aria-haspopup="true" aria-expanded="false" style="background: none; border: none; color: white; font-size: 1em; cursor: pointer; padding: 10px; font-weight: bold; display:flex; align-items:center;">
-                    <span class="user-icon" style="font-size:1.2em;">&#x1F464;</span> &#9662;
+                    <span class="user-icon" style="font-size:1.2em;">&#x1F464;</span><span class="dropdown-arrow"> &#9662;</span>
                 </button>
                 <div class="dropdown-menu" id="user-dropdown-menu" style="display: none; position: absolute; top: 100%; left: 0; background-color: #333; border: 1px solid #555; min-width: 160px; z-index: 1000; list-style-type: none; padding: 0; margin: 0; box-shadow: 0 2px 5px rgba(0,0,0,0.2);">
                     <a class="dropdown-item" href="{{ url_for('serve_profile_page') }}" style="display: block; padding: 10px 15px; text-decoration: none; color: white;">{{ _('Profile') }}</a>


### PR DESCRIPTION
## Summary
- hide icons when sidebar expanded and center icons when collapsed
- show admin menu icon on collapsed sidebar
- use full width for main content
- tweak sidebar button alignment and hide welcome message when collapsed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683abbc95f4c8324b07f80c1edad6430