### PR TITLE
Add status message for manual sync

### DIFF
--- a/static/js/script.js
+++ b/static/js/script.js
@@ -2708,13 +2708,17 @@ document.addEventListener('DOMContentLoaded', function() {
     if (resetFontSizeBtn) resetFontSizeBtn.addEventListener('click', resetFontSize);
 
     if (manualBackupBtn) {
+        const manualBackupStatusDiv = document.getElementById('manual-backup-status');
         manualBackupBtn.addEventListener('click', async () => {
+            manualBackupBtn.disabled = true;
+            showLoading(manualBackupStatusDiv, 'Manual sync in progress...');
             try {
-                manualBackupBtn.disabled = true;
                 await apiCall('/api/admin/manual_backup', { method: 'POST' });
-                alert('Backup completed');
+                showSuccess(manualBackupStatusDiv, 'Manual sync completed.');
+                console.log('Manual sync completed');
             } catch (e) {
-                alert('Manual backup failed');
+                showError(manualBackupStatusDiv, 'Manual sync failed.');
+                console.error('Manual sync failed', e);
             } finally {
                 manualBackupBtn.disabled = false;
             }

--- a/templates/base.html
+++ b/templates/base.html
@@ -78,6 +78,7 @@
             {# Example: {% if current_user.is_admin %}<li><a href="{{ url_for('serve_admin_dashboard') }}">{{ _('Admin') }}</a></li>{% endif %} #}
         </ul>
     </nav>
+    <div id="manual-backup-status" class="status-message" style="display:none; margin: 10px;"></div>
     <div id="main-content">
     <main>
         {% with messages = get_flashed_messages(with_categories=true) %}


### PR DESCRIPTION
## Summary
- show manual sync progress on the page
- display manual sync status under the navigation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ac6339e4483249ea8bb2afef98534