### PR TITLE
Fix Flask werkzeug setting

### DIFF
--- a/app.py
+++ b/app.py
@@ -3257,7 +3257,7 @@ if __name__ == "__main__":
         app.logger.exception("Failed to start background scheduler")
     # Avoid using _() here because no request context exists at startup
     app.logger.info(translator.gettext("Flask app starting...", translator.default_locale))
-    socketio.run(app, debug=True)
+    socketio.run(app, debug=True, allow_unsafe_werkzeug=True)
 
 @app.route('/api/resources/<int:resource_id>/all_bookings', methods=['GET'])
 @login_required

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,5 +1,7 @@
 from app import app, socketio
 
 if __name__ == "__main__":
-    socketio.run(app)
+    # Allow usage of the Werkzeug development server when running this script
+    # directly, even though Flask-SocketIO discourages it for production.
+    socketio.run(app, allow_unsafe_werkzeug=True)
 


### PR DESCRIPTION
## Summary
- allow Flask app to run with werkzeug in SocketIO

## Testing
- `./tests/setup.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683aca480bb08324ac950bffd8c860b6