### PR TITLE
Add JSON config with Azure backup

### DIFF
--- a/azure_backup.py
+++ b/azure_backup.py
@@ -20,6 +20,7 @@ STATIC_DIR = os.path.join(BASE_DIR, 'static')
 FLOOR_MAP_UPLOADS = os.path.join(STATIC_DIR, 'floor_map_uploads')
 RESOURCE_UPLOADS = os.path.join(STATIC_DIR, 'resource_uploads')
 HASH_FILE = os.path.join(DATA_DIR, 'backup_hashes.json')
+CONFIG_JSON = os.path.join(DATA_DIR, 'admin_config.json')
 
 # Module-level logger used for backup operations
 logger = logging.getLogger(__name__)
@@ -200,6 +201,15 @@ def backup_if_changed():
                 hashes[rel] = f_hash
                 logger.info("Uploaded media file '%s' to share '%s'", rel, media_share)
 
+    # Admin configuration JSON backup
+    if os.path.exists(CONFIG_JSON):
+        cfg_hash = _hash_file(CONFIG_JSON)
+        cfg_rel = os.path.basename(CONFIG_JSON)
+        if hashes.get(cfg_rel) != cfg_hash:
+            upload_file(media_client, CONFIG_JSON, cfg_rel)
+            hashes[cfg_rel] = cfg_hash
+            logger.info("Uploaded config '%s' to share '%s'", cfg_rel, media_share)
+
     _save_hashes(hashes)
 
 
@@ -223,6 +233,8 @@ def restore_from_share():
                 file_path = f"{prefix}/{item['name']}"
                 dest = os.path.join(STATIC_DIR, prefix, item['name'])
                 download_file(media_client, file_path, dest)
+        # Admin configuration JSON
+        download_file(media_client, os.path.basename(CONFIG_JSON), CONFIG_JSON)
 
 
 def main():

--- a/azure_storage.py
+++ b/azure_storage.py
@@ -11,6 +11,7 @@ DATA_DIR = os.path.join(BASE_DIR, 'data')
 STATIC_DIR = os.path.join(BASE_DIR, 'static')
 FLOOR_MAP_UPLOADS = os.path.join(STATIC_DIR, 'floor_map_uploads')
 RESOURCE_UPLOADS = os.path.join(STATIC_DIR, 'resource_uploads')
+CONFIG_JSON = os.path.join(DATA_DIR, 'admin_config.json')
 
 
 def _get_service_client():
@@ -91,3 +92,30 @@ def download_media():
         download_stream = container_client.download_blob(blob)
         with open(os.path.join(local_dir, fname), 'wb') as f:
             f.write(download_stream.readall())
+
+
+def upload_config():
+    """Upload admin configuration JSON to the media container."""
+    if not os.path.exists(CONFIG_JSON):
+        return None
+    service_client = _get_service_client()
+    container_name = os.environ.get('AZURE_MEDIA_CONTAINER', 'media')
+    container_client = _get_container_client(service_client, container_name)
+    with open(CONFIG_JSON, 'rb') as f:
+        container_client.upload_blob(name=os.path.basename(CONFIG_JSON), data=f, overwrite=True)
+    return os.path.basename(CONFIG_JSON)
+
+
+def download_config():
+    """Download admin configuration JSON from the media container if available."""
+    service_client = _get_service_client()
+    container_name = os.environ.get('AZURE_MEDIA_CONTAINER', 'media')
+    container_client = _get_container_client(service_client, container_name)
+    blob_client = container_client.get_blob_client(os.path.basename(CONFIG_JSON))
+    if not blob_client.exists():
+        raise RuntimeError('Config blob not found in Azure storage')
+    os.makedirs(DATA_DIR, exist_ok=True)
+    download_stream = blob_client.download_blob()
+    with open(CONFIG_JSON, 'wb') as f:
+        f.write(download_stream.readall())
+    return CONFIG_JSON

--- a/init_setup.py
+++ b/init_setup.py
@@ -18,6 +18,7 @@ from app import (
 from werkzeug.security import generate_password_hash
 from datetime import datetime, date, timedelta, time
 from add_resource_tags_column import add_tags_column
+from json_config import load_config, save_config
 
 AZURE_PRIMARY_STORAGE = bool(os.environ.get("AZURE_PRIMARY_STORAGE"))
 if AZURE_PRIMARY_STORAGE:
@@ -25,8 +26,10 @@ if AZURE_PRIMARY_STORAGE:
         from azure_storage import (
             download_database,
             download_media,
+            download_config,
             upload_database,
             upload_media,
+            upload_config,
         )
     except Exception as exc:  # pragma: no cover - optional
         print(f"Warning: Azure storage unavailable: {exc}")
@@ -115,6 +118,7 @@ def create_required_directories():
         print("Downloading media from Azure storage...")
         try:
             download_media()
+            download_config()
         except Exception as exc:
             print(f"Failed to download media from Azure: {exc}")
 
@@ -575,6 +579,7 @@ def init_db(force=False):
             try:
                 upload_database(versioned=False)
                 upload_media()
+                upload_config()
             except Exception as exc:
                 print(f"Failed to upload data to Azure: {exc}")
 
@@ -585,7 +590,10 @@ def main():
     check_python_version()
     print("-" * 30)
     create_required_directories()
-    print("-" * 30) 
+    # Ensure configuration JSON exists
+    cfg = load_config()
+    save_config(cfg)
+    print("-" * 30)
 
     if os.path.exists(DB_PATH):
         print(f"Existing database found at {DB_PATH}. Verifying structure...")

--- a/json_config.py
+++ b/json_config.py
@@ -1,0 +1,31 @@
+import os
+import json
+
+BASE_DIR = os.path.abspath(os.path.dirname(__file__))
+DATA_DIR = os.path.join(BASE_DIR, 'data')
+CONFIG_FILE = os.path.join(DATA_DIR, 'admin_config.json')
+
+DEFAULT_CONFIG = {
+    "floor_maps": [],
+    "resources": []
+}
+
+def get_config_path():
+    return CONFIG_FILE
+
+
+def load_config():
+    os.makedirs(DATA_DIR, exist_ok=True)
+    if not os.path.exists(CONFIG_FILE):
+        return DEFAULT_CONFIG.copy()
+    try:
+        with open(CONFIG_FILE, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    except Exception:
+        return DEFAULT_CONFIG.copy()
+
+
+def save_config(data):
+    os.makedirs(DATA_DIR, exist_ok=True)
+    with open(CONFIG_FILE, 'w', encoding='utf-8') as f:
+        json.dump(data, f, indent=2)


### PR DESCRIPTION
## Summary
- introduce `json_config.py` for storing admin config in JSON
- back up `admin_config.json` to Azure file shares
- support uploading/downloading config in `azure_storage`
- init setup now downloads/uploads config and ensures file exists

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683acc5810c08324be917a4af9aad56e