### PR TITLE
Add JSON-based admin sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ Run the script with:
 python azure_backup.py
 ```
 All floor map and resource images from `static/` along with `data/site.db` will be uploaded. The script stores hashes of previous uploads so unchanged files are skipped on subsequent runs. During the process, log messages indicate whether `site.db` was uploaded or skipped because it did not change.
+The admin configuration stored in `data/admin_config.json` is backed up together with the images so changes to users or roles are preserved.
 
 ### Automatic Backups
 

--- a/app.py
+++ b/app.py
@@ -20,6 +20,8 @@ from flask import abort # For permission_required decorator
 from flask import g  # For storing current locale
 from flask_wtf.csrf import CSRFProtect # For CSRF protection
 from flask_socketio import SocketIO
+from sqlalchemy import event
+from json_config import export_admin_data
 
 
 try:
@@ -451,6 +453,15 @@ class AuditLog(db.Model):
 
     def __repr__(self):
         return f'<AuditLog {self.timestamp} - {self.username or "System"} - {self.action}>'
+
+
+@event.listens_for(db.session, "after_commit")
+def _export_admin_config(session):
+    """Persist admin data to JSON after any database commit."""
+    try:
+        export_admin_data(db, User, Role)
+    except Exception as exc:  # pragma: no cover - ignore export errors
+        app.logger.error("Failed to export admin config: %s", exc)
 
 # --- Audit Log Helper ---
 def add_audit_log(action: str, details: str, user_id: int = None, username: str = None):

--- a/azure_backup.py
+++ b/azure_backup.py
@@ -20,6 +20,7 @@ STATIC_DIR = os.path.join(BASE_DIR, 'static')
 FLOOR_MAP_UPLOADS = os.path.join(STATIC_DIR, 'floor_map_uploads')
 RESOURCE_UPLOADS = os.path.join(STATIC_DIR, 'resource_uploads')
 HASH_FILE = os.path.join(DATA_DIR, 'backup_hashes.json')
+CONFIG_JSON = os.path.join(DATA_DIR, 'admin_config.json')
 
 # Module-level logger used for backup operations
 logger = logging.getLogger(__name__)
@@ -200,6 +201,15 @@ def backup_if_changed():
                 hashes[rel] = f_hash
                 logger.info("Uploaded media file '%s' to share '%s'", rel, media_share)
 
+    # Admin configuration JSON backup
+    if os.path.exists(CONFIG_JSON):
+        cfg_hash = _hash_file(CONFIG_JSON)
+        cfg_rel = os.path.basename(CONFIG_JSON)
+        if hashes.get(cfg_rel) != cfg_hash:
+            upload_file(media_client, CONFIG_JSON, cfg_rel)
+            hashes[cfg_rel] = cfg_hash
+            logger.info("Uploaded config '%s' to share '%s'", cfg_rel, media_share)
+
     _save_hashes(hashes)
 
 
@@ -223,6 +233,8 @@ def restore_from_share():
                 file_path = f"{prefix}/{item['name']}"
                 dest = os.path.join(STATIC_DIR, prefix, item['name'])
                 download_file(media_client, file_path, dest)
+        # Admin configuration JSON
+        download_file(media_client, os.path.basename(CONFIG_JSON), CONFIG_JSON)
 
 
 def main():

--- a/azure_storage.py
+++ b/azure_storage.py
@@ -11,6 +11,7 @@ DATA_DIR = os.path.join(BASE_DIR, 'data')
 STATIC_DIR = os.path.join(BASE_DIR, 'static')
 FLOOR_MAP_UPLOADS = os.path.join(STATIC_DIR, 'floor_map_uploads')
 RESOURCE_UPLOADS = os.path.join(STATIC_DIR, 'resource_uploads')
+CONFIG_JSON = os.path.join(DATA_DIR, 'admin_config.json')
 
 
 def _get_service_client():
@@ -91,3 +92,30 @@ def download_media():
         download_stream = container_client.download_blob(blob)
         with open(os.path.join(local_dir, fname), 'wb') as f:
             f.write(download_stream.readall())
+
+
+def upload_config():
+    """Upload admin configuration JSON to the media container."""
+    if not os.path.exists(CONFIG_JSON):
+        return None
+    service_client = _get_service_client()
+    container_name = os.environ.get('AZURE_MEDIA_CONTAINER', 'media')
+    container_client = _get_container_client(service_client, container_name)
+    with open(CONFIG_JSON, 'rb') as f:
+        container_client.upload_blob(name=os.path.basename(CONFIG_JSON), data=f, overwrite=True)
+    return os.path.basename(CONFIG_JSON)
+
+
+def download_config():
+    """Download admin configuration JSON from the media container if available."""
+    service_client = _get_service_client()
+    container_name = os.environ.get('AZURE_MEDIA_CONTAINER', 'media')
+    container_client = _get_container_client(service_client, container_name)
+    blob_client = container_client.get_blob_client(os.path.basename(CONFIG_JSON))
+    if not blob_client.exists():
+        raise RuntimeError('Config blob not found in Azure storage')
+    os.makedirs(DATA_DIR, exist_ok=True)
+    download_stream = blob_client.download_blob()
+    with open(CONFIG_JSON, 'wb') as f:
+        f.write(download_stream.readall())
+    return CONFIG_JSON

--- a/init_setup.py
+++ b/init_setup.py
@@ -18,6 +18,12 @@ from app import (
 from werkzeug.security import generate_password_hash
 from datetime import datetime, date, timedelta, time
 from add_resource_tags_column import add_tags_column
+from json_config import (
+    load_config,
+    save_config,
+    import_admin_data,
+    export_admin_data,
+)
 
 AZURE_PRIMARY_STORAGE = bool(os.environ.get("AZURE_PRIMARY_STORAGE"))
 if AZURE_PRIMARY_STORAGE:
@@ -25,8 +31,10 @@ if AZURE_PRIMARY_STORAGE:
         from azure_storage import (
             download_database,
             download_media,
+            download_config,
             upload_database,
             upload_media,
+            upload_config,
         )
     except Exception as exc:  # pragma: no cover - optional
         print(f"Warning: Azure storage unavailable: {exc}")
@@ -115,6 +123,7 @@ def create_required_directories():
         print("Downloading media from Azure storage...")
         try:
             download_media()
+            download_config()
         except Exception as exc:
             print(f"Failed to download media from Azure: {exc}")
 
@@ -354,72 +363,13 @@ def init_db(force=False):
             db.session.rollback()
             app.logger.exception("Error committing deletions during DB initialization:")
 
-        app.logger.info("Adding default users (admin/admin, user/userpass)...")
+        app.logger.info("Importing admin data from JSON configuration...")
         try:
-            default_users = [
-                User(
-                    username='admin',
-                    email='admin@example.com',
-                    password_hash=generate_password_hash('admin', method='pbkdf2:sha256'),
-                    is_admin=True,
-                ),
-                User(
-                    username='user',
-                    email='user@example.com',
-                    password_hash=generate_password_hash('userpass', method='pbkdf2:sha256'),
-                    is_admin=False,
-                ),
-            ]
-            db.session.bulk_save_objects(default_users)
-            db.session.commit()
-            app.logger.info(f"Successfully added {len(default_users)} default users.")
+            import_admin_data(db, User, Role)
+            app.logger.info("Admin users and roles imported from configuration.")
         except Exception as e:
             db.session.rollback()
-            app.logger.exception("Error adding default users during DB initialization:")
-
-        app.logger.info("Adding default roles...")
-        try:
-            admin_role = Role(
-                name="Administrator",
-                description="Full system access",
-                permissions="all_permissions,view_analytics",
-            )
-            standard_role = Role(
-                name="StandardUser",
-                description="Can make bookings and view resources",
-                permissions="make_bookings,view_resources",
-            )
-            db.session.add_all([admin_role, standard_role])
-            db.session.commit()
-            app.logger.info("Successfully added default roles.")
-        except Exception as e:
-            db.session.rollback()
-            app.logger.exception("Error adding default roles during DB initialization:")
-            # Ensure admin_role and standard_role are None if creation failed, to prevent errors below
-            admin_role = None
-            standard_role = None
-
-        app.logger.info("Assigning roles to default users...")
-        admin_user = User.query.filter_by(username='admin').first()
-        standard_user = User.query.filter_by(username='user').first()
-
-        # Fetch roles again in case of session issues or if they were not committed properly
-        if not admin_role:
-            admin_role = Role.query.filter_by(name="Administrator").first()
-        if not standard_role:
-            standard_role = Role.query.filter_by(name="StandardUser").first()
-
-        if admin_user and admin_role:
-            admin_user.roles.append(admin_role)
-        if standard_user and standard_role:
-            standard_user.roles.append(standard_role)
-
-        try:
-            db.session.commit()
-            app.logger.info("Successfully assigned roles to default users.")
-        except Exception as e:
-            db.session.rollback()
-            app.logger.exception("Error assigning roles to default users:")
+            app.logger.exception("Error importing admin configuration:")
 
         admin_user_for_perms = User.query.filter_by(username='admin').first()
         standard_user_for_perms = User.query.filter_by(username='user').first()
@@ -568,6 +518,12 @@ def init_db(force=False):
                 "Could not find sample resources 'Conference Room Alpha' or 'Meeting Room Beta' to create bookings for. Skipping sample booking addition."
             )
 
+        # Export any created users and roles back to the JSON configuration
+        try:
+            export_admin_data(db, User, Role)
+        except Exception:
+            app.logger.exception("Failed to export admin data to configuration:")
+
         app.logger.info("Database initialization script completed.")
 
         if AZURE_PRIMARY_STORAGE:
@@ -575,6 +531,7 @@ def init_db(force=False):
             try:
                 upload_database(versioned=False)
                 upload_media()
+                upload_config()
             except Exception as exc:
                 print(f"Failed to upload data to Azure: {exc}")
 
@@ -585,7 +542,10 @@ def main():
     check_python_version()
     print("-" * 30)
     create_required_directories()
-    print("-" * 30) 
+    # Ensure configuration JSON exists
+    cfg = load_config()
+    save_config(cfg)
+    print("-" * 30)
 
     if os.path.exists(DB_PATH):
         print(f"Existing database found at {DB_PATH}. Verifying structure...")

--- a/json_config.py
+++ b/json_config.py
@@ -1,0 +1,130 @@
+import os
+import json
+
+# Default hashed passwords for sample users
+ADMIN_HASH = (
+    "pbkdf2:sha256:1000000$xc0Zq25M8zJA4unr$ac2921dc12b8592876eee09f6fdf44524949f63ccfa02edc328604fae5d45387"
+)
+USER_HASH = (
+    "pbkdf2:sha256:1000000$X2esCUQh5qZCkHw5$c19af4300a124363c10726e483fecbc7c3fc7a027be2a746b17a9e11c4b78fbc"
+)
+
+BASE_DIR = os.path.abspath(os.path.dirname(__file__))
+DATA_DIR = os.path.join(BASE_DIR, 'data')
+CONFIG_FILE = os.path.join(DATA_DIR, 'admin_config.json')
+
+DEFAULT_CONFIG = {
+    "floor_maps": [],
+    "resources": [],
+    "roles": [
+        {
+            "id": 1,
+            "name": "Administrator",
+            "description": "Full system access",
+            "permissions": "all_permissions,view_analytics",
+        },
+        {
+            "id": 2,
+            "name": "StandardUser",
+            "description": "Can make bookings and view resources",
+            "permissions": "make_bookings,view_resources",
+        },
+    ],
+    "users": [
+        {
+            "id": 1,
+            "username": "admin",
+            "email": "admin@example.com",
+            "password_hash": ADMIN_HASH,
+            "is_admin": True,
+            "roles": [1],
+        },
+        {
+            "id": 2,
+            "username": "user",
+            "email": "user@example.com",
+            "password_hash": USER_HASH,
+            "is_admin": False,
+            "roles": [2],
+        },
+    ],
+}
+
+
+def ensure_default_keys(data):
+    """Ensure all expected keys exist in the configuration."""
+    if data is None:
+        data = {}
+    for key, value in DEFAULT_CONFIG.items():
+        data.setdefault(key, json.loads(json.dumps(value)))
+    return data
+
+def get_config_path():
+    return CONFIG_FILE
+
+
+def load_config():
+    os.makedirs(DATA_DIR, exist_ok=True)
+    if not os.path.exists(CONFIG_FILE):
+        return ensure_default_keys({})
+    try:
+        with open(CONFIG_FILE, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+        return ensure_default_keys(data)
+    except Exception:
+        return ensure_default_keys({})
+
+
+def save_config(data):
+    os.makedirs(DATA_DIR, exist_ok=True)
+    with open(CONFIG_FILE, 'w', encoding='utf-8') as f:
+        json.dump(ensure_default_keys(data), f, indent=2)
+
+
+def import_admin_data(db, User, Role):
+    """Import users and roles from the JSON configuration into the database."""
+    cfg = load_config()
+
+    role_map = {}
+    for r in cfg.get('roles', []):
+        role = Role(name=r['name'], description=r.get('description'), permissions=r.get('permissions', ''))
+        db.session.add(role)
+        db.session.flush()
+        role_map[r.get('id', role.id)] = role
+
+    for u in cfg.get('users', []):
+        user = User(username=u['username'], email=u['email'], password_hash=u.get('password_hash', ''), is_admin=u.get('is_admin', False))
+        db.session.add(user)
+        db.session.flush()
+        for rid in u.get('roles', []):
+            role = role_map.get(rid)
+            if role:
+                user.roles.append(role)
+
+    db.session.commit()
+
+
+def export_admin_data(db, User, Role):
+    """Write users and roles from the database to the JSON configuration."""
+    cfg = load_config()
+    cfg['roles'] = [
+        {
+            'id': r.id,
+            'name': r.name,
+            'description': r.description,
+            'permissions': r.permissions,
+        }
+        for r in Role.query.all()
+    ]
+    cfg['users'] = [
+        {
+            'id': u.id,
+            'username': u.username,
+            'email': u.email,
+            'password_hash': u.password_hash,
+            'is_admin': u.is_admin,
+            'roles': [role.id for role in u.roles],
+        }
+        for u in User.query.all()
+    ]
+    save_config(cfg)


### PR DESCRIPTION
## Summary
- expand `json_config` with example data and helpers for import/export
- load admin users and roles from JSON during initialization
- write admin changes back to `admin_config.json` after commits
- document JSON configuration backup in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683acc5810c08324be917a4af9aad56e