### PR TITLE
Add JSON config with Azure backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,11 +205,11 @@ Run the script with:
 ```bash
 python azure_backup.py
 ```
-All floor map and resource images from `static/` along with `data/site.db` will be uploaded. The script stores hashes of previous uploads so unchanged files are skipped on subsequent runs. During the process, log messages indicate whether `site.db` was uploaded or skipped because it did not change.
+All floor map and resource images from `static/` along with `data/site.db` and `data/admin_config.json` will be uploaded. The script stores hashes of previous uploads so unchanged files are skipped on subsequent runs. During the process, log messages indicate whether each file was uploaded or skipped because it did not change.
 
 ### Automatic Backups
 
-When the app runs, it will attempt to restore `site.db` and uploaded images from the configured Azure File Shares.  A background job then backs up the database and media files at regular intervals.
+When the app runs, it will attempt to restore `site.db`, `data/admin_config.json` and uploaded images from the configured Azure File Shares.  A background job then backs up the database, configuration file and media files at regular intervals.
 
 Configure the interval via the `AZURE_BACKUP_INTERVAL_MINUTES` environment variable (default `60`).  Files are only uploaded when their content changes.
 

--- a/app.py
+++ b/app.py
@@ -20,6 +20,8 @@ from flask import abort # For permission_required decorator
 from flask import g  # For storing current locale
 from flask_wtf.csrf import CSRFProtect # For CSRF protection
 from flask_socketio import SocketIO
+from sqlalchemy import event
+from json_config import export_admin_config
 
 
 try:
@@ -235,6 +237,14 @@ def get_google_flow():
     )
 
 db = SQLAlchemy(app)
+
+
+@event.listens_for(db.session, "after_commit")
+def _sync_config_after_commit(session):
+    try:
+        export_admin_config()
+    except Exception:
+        app.logger.exception("Failed to export admin configuration after commit")
 
 
 # Configure SQLite pragmas (e.g., WAL mode) on the first request

--- a/azure_backup.py
+++ b/azure_backup.py
@@ -20,6 +20,7 @@ STATIC_DIR = os.path.join(BASE_DIR, 'static')
 FLOOR_MAP_UPLOADS = os.path.join(STATIC_DIR, 'floor_map_uploads')
 RESOURCE_UPLOADS = os.path.join(STATIC_DIR, 'resource_uploads')
 HASH_FILE = os.path.join(DATA_DIR, 'backup_hashes.json')
+CONFIG_JSON = os.path.join(DATA_DIR, 'admin_config.json')
 
 # Module-level logger used for backup operations
 logger = logging.getLogger(__name__)
@@ -200,6 +201,15 @@ def backup_if_changed():
                 hashes[rel] = f_hash
                 logger.info("Uploaded media file '%s' to share '%s'", rel, media_share)
 
+    # Admin configuration JSON backup
+    if os.path.exists(CONFIG_JSON):
+        cfg_hash = _hash_file(CONFIG_JSON)
+        cfg_rel = os.path.basename(CONFIG_JSON)
+        if hashes.get(cfg_rel) != cfg_hash:
+            upload_file(media_client, CONFIG_JSON, cfg_rel)
+            hashes[cfg_rel] = cfg_hash
+            logger.info("Uploaded config '%s' to share '%s'", cfg_rel, media_share)
+
     _save_hashes(hashes)
 
 
@@ -223,6 +233,8 @@ def restore_from_share():
                 file_path = f"{prefix}/{item['name']}"
                 dest = os.path.join(STATIC_DIR, prefix, item['name'])
                 download_file(media_client, file_path, dest)
+        # Admin configuration JSON
+        download_file(media_client, os.path.basename(CONFIG_JSON), CONFIG_JSON)
 
 
 def main():

--- a/azure_storage.py
+++ b/azure_storage.py
@@ -11,6 +11,7 @@ DATA_DIR = os.path.join(BASE_DIR, 'data')
 STATIC_DIR = os.path.join(BASE_DIR, 'static')
 FLOOR_MAP_UPLOADS = os.path.join(STATIC_DIR, 'floor_map_uploads')
 RESOURCE_UPLOADS = os.path.join(STATIC_DIR, 'resource_uploads')
+CONFIG_JSON = os.path.join(DATA_DIR, 'admin_config.json')
 
 
 def _get_service_client():
@@ -91,3 +92,30 @@ def download_media():
         download_stream = container_client.download_blob(blob)
         with open(os.path.join(local_dir, fname), 'wb') as f:
             f.write(download_stream.readall())
+
+
+def upload_config():
+    """Upload admin configuration JSON to the media container."""
+    if not os.path.exists(CONFIG_JSON):
+        return None
+    service_client = _get_service_client()
+    container_name = os.environ.get('AZURE_MEDIA_CONTAINER', 'media')
+    container_client = _get_container_client(service_client, container_name)
+    with open(CONFIG_JSON, 'rb') as f:
+        container_client.upload_blob(name=os.path.basename(CONFIG_JSON), data=f, overwrite=True)
+    return os.path.basename(CONFIG_JSON)
+
+
+def download_config():
+    """Download admin configuration JSON from the media container if available."""
+    service_client = _get_service_client()
+    container_name = os.environ.get('AZURE_MEDIA_CONTAINER', 'media')
+    container_client = _get_container_client(service_client, container_name)
+    blob_client = container_client.get_blob_client(os.path.basename(CONFIG_JSON))
+    if not blob_client.exists():
+        raise RuntimeError('Config blob not found in Azure storage')
+    os.makedirs(DATA_DIR, exist_ok=True)
+    download_stream = blob_client.download_blob()
+    with open(CONFIG_JSON, 'wb') as f:
+        f.write(download_stream.readall())
+    return CONFIG_JSON

--- a/init_setup.py
+++ b/init_setup.py
@@ -18,6 +18,7 @@ from app import (
 from werkzeug.security import generate_password_hash
 from datetime import datetime, date, timedelta, time
 from add_resource_tags_column import add_tags_column
+from json_config import load_config, save_config
 
 AZURE_PRIMARY_STORAGE = bool(os.environ.get("AZURE_PRIMARY_STORAGE"))
 if AZURE_PRIMARY_STORAGE:
@@ -25,8 +26,10 @@ if AZURE_PRIMARY_STORAGE:
         from azure_storage import (
             download_database,
             download_media,
+            download_config,
             upload_database,
             upload_media,
+            upload_config,
         )
     except Exception as exc:  # pragma: no cover - optional
         print(f"Warning: Azure storage unavailable: {exc}")
@@ -115,6 +118,7 @@ def create_required_directories():
         print("Downloading media from Azure storage...")
         try:
             download_media()
+            download_config()
         except Exception as exc:
             print(f"Failed to download media from Azure: {exc}")
 
@@ -298,6 +302,10 @@ def init_db(force=False):
         app.logger.info("Creating database tables (if they don't exist)...")
         db.create_all()
         app.logger.info("Database tables creation/verification step completed.")
+
+        # Populate from JSON configuration if database is empty
+        from json_config import import_admin_config
+        import_admin_config()
 
         if not force:
             existing = any([
@@ -575,6 +583,7 @@ def init_db(force=False):
             try:
                 upload_database(versioned=False)
                 upload_media()
+                upload_config()
             except Exception as exc:
                 print(f"Failed to upload data to Azure: {exc}")
 
@@ -585,7 +594,10 @@ def main():
     check_python_version()
     print("-" * 30)
     create_required_directories()
-    print("-" * 30) 
+    # Ensure configuration JSON exists
+    cfg = load_config()
+    save_config(cfg)
+    print("-" * 30)
 
     if os.path.exists(DB_PATH):
         print(f"Existing database found at {DB_PATH}. Verifying structure...")

--- a/json_config.py
+++ b/json_config.py
@@ -1,0 +1,207 @@
+import os
+import json
+
+BASE_DIR = os.path.abspath(os.path.dirname(__file__))
+DATA_DIR = os.path.join(BASE_DIR, 'data')
+CONFIG_FILE = os.path.join(DATA_DIR, 'admin_config.json')
+
+DEFAULT_CONFIG = {
+    "floor_maps": [
+        {
+            "id": 1,
+            "name": "Main Building",
+            "image_filename": "sample_map.png",
+            "location": "HQ",
+            "floor": "1"
+        }
+    ],
+    "resources": [
+        {
+            "id": 1,
+            "name": "Conference Room",
+            "capacity": 10,
+            "equipment": "Projector",
+            "tags": "large",
+            "booking_restriction": None,
+            "status": "published",
+            "floor_map_id": 1,
+            "map_coordinates": {
+                "type": "rect",
+                "x": 10,
+                "y": 20,
+                "width": 30,
+                "height": 30
+            }
+        }
+    ],
+    "users": [
+        {
+            "id": 1,
+            "username": "admin",
+            "email": "admin@example.com",
+            "password": "admin",
+            "is_admin": True,
+            "roles": [1]
+        },
+        {
+            "id": 2,
+            "username": "user",
+            "email": "user@example.com",
+            "password": "userpass",
+            "is_admin": False,
+            "roles": [2]
+        }
+    ],
+    "roles": [
+        {
+            "id": 1,
+            "name": "Administrator",
+            "description": "Full access",
+            "permissions": "all_permissions"
+        },
+        {
+            "id": 2,
+            "name": "User",
+            "description": "Standard user",
+            "permissions": "book_resource"
+        }
+    ]
+}
+
+def get_config_path():
+    return CONFIG_FILE
+
+
+def load_config():
+    os.makedirs(DATA_DIR, exist_ok=True)
+    if not os.path.exists(CONFIG_FILE):
+        return DEFAULT_CONFIG.copy()
+    try:
+        with open(CONFIG_FILE, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    except Exception:
+        return DEFAULT_CONFIG.copy()
+
+
+def save_config(data):
+    os.makedirs(DATA_DIR, exist_ok=True)
+    with open(CONFIG_FILE, 'w', encoding='utf-8') as f:
+        json.dump(data, f, indent=2)
+
+
+def ensure_keys(data):
+    """Ensure the configuration dictionary has all expected top-level keys."""
+    for key, default_val in DEFAULT_CONFIG.items():
+        data.setdefault(key, [] if isinstance(default_val, list) else default_val)
+    return data
+
+
+def import_admin_config():
+    """Populate the database with data from the JSON config if empty."""
+    from app import db, User, Role, Resource, FloorMap
+
+    config = ensure_keys(load_config())
+
+    if Role.query.count() == 0:
+        for item in config.get("roles", []):
+            role = Role(id=item.get("id"), name=item.get("name"),
+                        description=item.get("description"),
+                        permissions=item.get("permissions"))
+            db.session.add(role)
+        db.session.commit()
+
+    if User.query.count() == 0:
+        for item in config.get("users", []):
+            user = User(id=item.get("id"), username=item.get("username"),
+                        email=item.get("email"),
+                        is_admin=item.get("is_admin", False))
+            user.set_password(item.get("password", "changeme"))
+            for rid in item.get("roles", []):
+                role = Role.query.get(rid)
+                if role:
+                    user.roles.append(role)
+            db.session.add(user)
+        db.session.commit()
+
+    if FloorMap.query.count() == 0:
+        for item in config.get("floor_maps", []):
+            fm = FloorMap(id=item.get("id"), name=item.get("name"),
+                          image_filename=item.get("image_filename"),
+                          location=item.get("location"),
+                          floor=item.get("floor"))
+            db.session.add(fm)
+        db.session.commit()
+
+    if Resource.query.count() == 0:
+        for item in config.get("resources", []):
+            r = Resource(id=item.get("id"), name=item.get("name"),
+                         capacity=item.get("capacity"),
+                         equipment=item.get("equipment"),
+                         tags=item.get("tags"),
+                         booking_restriction=item.get("booking_restriction"),
+                         status=item.get("status", "draft"),
+                         floor_map_id=item.get("floor_map_id"))
+            coords = item.get("map_coordinates")
+            if coords is not None:
+                r.map_coordinates = json.dumps(coords)
+            db.session.add(r)
+        db.session.commit()
+
+
+def export_admin_config():
+    """Write admin data from the database to the JSON config file."""
+    from app import db, User, Role, Resource, FloorMap
+
+    config = ensure_keys(load_config())
+
+    config["roles"] = [
+        {
+            "id": r.id,
+            "name": r.name,
+            "description": r.description,
+            "permissions": r.permissions,
+        }
+        for r in Role.query.all()
+    ]
+
+    config["users"] = [
+        {
+            "id": u.id,
+            "username": u.username,
+            "email": u.email,
+            "password": None,
+            "is_admin": u.is_admin,
+            "roles": [role.id for role in u.roles],
+        }
+        for u in User.query.all()
+    ]
+
+    config["floor_maps"] = [
+        {
+            "id": fm.id,
+            "name": fm.name,
+            "image_filename": fm.image_filename,
+            "location": fm.location,
+            "floor": fm.floor,
+        }
+        for fm in FloorMap.query.all()
+    ]
+
+    config["resources"] = [
+        {
+            "id": res.id,
+            "name": res.name,
+            "capacity": res.capacity,
+            "equipment": res.equipment,
+            "tags": res.tags,
+            "booking_restriction": res.booking_restriction,
+            "status": res.status,
+            "floor_map_id": res.floor_map_id,
+            "map_coordinates": json.loads(res.map_coordinates)
+            if res.map_coordinates
+            else None,
+        }
+        for res in Resource.query.all()
+    ]
+
+    save_config(config)


### PR DESCRIPTION
## Summary
- default admin config lives in `json_config.py`
- DB commits now export admin data to JSON
- init setup populates DB from JSON if empty
- backup notes mention `admin_config.json`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683acc5810c08324be917a4af9aad56e