### PR TITLE
Fix manual backup button initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ This will create a `site.db` file in the `data/` directory and set up the tables
 The database is excluded from version control, but the `azure_backup.py` script
 automatically uploads `data/site.db` to Azure File Share whenever its contents
 change.
+After initialization an administrator account is created automatically with the
+credentials **admin/admin**. Log in with this account to access the admin
+features and create additional users.
 You should see messages indicating success.
 Pass `force=True` if you want to **reset and wipe** existing data:
    ```python

--- a/init_setup.py
+++ b/init_setup.py
@@ -354,6 +354,18 @@ def init_db(force=False):
             db.session.rollback()
             app.logger.exception("Error committing deletions during DB initialization:")
 
+        # Create default roles and admin account if starting from an empty DB
+        admin_role = Role(name="Administrator", description="Admin role", permissions="all_permissions")
+        standard_role = Role(name="StandardUser", description="Basic user role")
+        db.session.add_all([admin_role, standard_role])
+        db.session.commit()
+
+        default_admin = User(username="admin", email="admin@example.com", is_admin=True)
+        default_admin.set_password("admin")
+        default_admin.roles.append(admin_role)
+        db.session.add(default_admin)
+        db.session.commit()
+
 
         admin_user_for_perms = User.query.filter_by(username='admin').first()
         standard_user_for_perms = User.query.filter_by(username='user').first()

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -148,7 +148,6 @@ async function updateAuthLink() {
     const userManagementNavLink = document.getElementById('user-management-nav-link');
     const adminMenuItem = document.getElementById('admin-menu-item');
     const manualBackupNavLink = document.getElementById('manual-backup-nav-link');
-    const manualBackupBtn = document.getElementById('manual-backup-btn');
     const welcomeMessageContainer = document.getElementById('welcome-message-container');
     const userDropdownContainer = document.getElementById('user-dropdown-container');
     const userDropdownButton = document.getElementById('user-dropdown-button');
@@ -401,6 +400,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const bookingResultsDiv = document.getElementById('booking-results');
     const loginForm = document.getElementById('login-form');
     const loginMessageDiv = document.getElementById('login-message');
+    const manualBackupBtn = document.getElementById('manual-backup-btn');
 
     // --- New Booking Page Specific Logic ---
     if (bookingForm) {


### PR DESCRIPTION
## Summary
- ensure manual backup button is available globally
- remove unused variable inside `updateAuthLink`
- create default admin user and roles on DB init
- document default credentials in README

## Testing
- `tests/setup.sh`
- `pytest -q` *(interrupted after completion)*

------
https://chatgpt.com/codex/tasks/task_e_683b0692060c8324bdfe04e600881b0c