### PR TITLE
Allow host/port configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,16 @@ To run the application:
 4.  Open your web browser and navigate to `http://127.0.0.1:5000/`.
     You should see the application's home page.
 
+When deploying to platforms like Azure App Service, the host and port are
+typically provided via environment variables. The application now reads `PORT`
+and `HOST` so you can run:
+
+```bash
+HOST=0.0.0.0 PORT=8000 python app.py
+```
+
+or configure these variables in your hosting environment.
+
 ### Initializing the Database
 
 The application uses an SQLite database to store resource information. If you haven't already, initialize the database and create the necessary tables (this also adds sample resources):

--- a/app.py
+++ b/app.py
@@ -3256,7 +3256,10 @@ if __name__ == "__main__":
         app.logger.exception("Failed to start background scheduler")
     # Avoid using _() here because no request context exists at startup
     app.logger.info(translator.gettext("Flask app starting...", translator.default_locale))
-    socketio.run(app, debug=True, allow_unsafe_werkzeug=True)
+    host = os.environ.get("HOST", "0.0.0.0")
+    port = int(os.environ.get("PORT", 5000))
+    debug = os.environ.get("FLASK_DEBUG", "False").lower() in ("1", "true", "yes")
+    socketio.run(app, host=host, port=port, debug=debug, allow_unsafe_werkzeug=True)
 
 @app.route('/api/resources/<int:resource_id>/all_bookings', methods=['GET'])
 @login_required

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,7 +1,11 @@
+import os
 from app import app, socketio
 
 if __name__ == "__main__":
     # Allow usage of the Werkzeug development server when running this script
     # directly, even though Flask-SocketIO discourages it for production.
-    socketio.run(app, allow_unsafe_werkzeug=True)
+    host = os.environ.get("HOST", "0.0.0.0")
+    port = int(os.environ.get("PORT", 5000))
+    debug = os.environ.get("FLASK_DEBUG", "False").lower() in ("1", "true", "yes")
+    socketio.run(app, host=host, port=port, debug=debug, allow_unsafe_werkzeug=True)
 


### PR DESCRIPTION
## Summary
- let Flask read HOST/PORT env vars so it can bind externally
- document the new environment variables in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b14397b388324aded29bdb1fdb903