### PR TITLE
Fix: Correct Flask-Mail initialization and usage

### DIFF
--- a/init_setup.py
+++ b/init_setup.py
@@ -381,6 +381,12 @@ def init_db(force=False):
             admin_user.roles.append(admin_role)
             standard_user.roles.append(standard_role)
             db.session.add_all([admin_role, standard_role, admin_user, standard_user])
+            # Add warning for default admin user
+            app.logger.warning(
+                "IMPORTANT SECURITY WARNING: A default admin user ('admin') with a default password ('admin') "
+                "has been created. This password MUST be changed immediately in a production or shared environment. "
+                "Leaving default credentials poses a significant security risk."
+            )
             db.session.commit()
             app.logger.info("Default roles and users created.")
         except Exception:


### PR DESCRIPTION
- I've initialized the Flask-Mail `mail` object with the app context.
- I've updated the `send_email` function to use `mail.send()` for actual email delivery, retaining logging and error handling.
- I've ensured direct calls to `mail.send()` use the initialized object.

Sec: Strengthen CSRF protection for JSON APIs

- I've added a CSRF token meta tag to `base.html` for frontend JavaScript to use in AJAX requests.
- I've ensured `/api/auth/login` is CSRF exempt; other state-changing JSON APIs are now implicitly protected by Flask-WTF expecting a token in headers from AJAX calls.

Refactor: Make Google OAuth Redirect URI dynamic

- I've removed the hardcoded Google OAuth `REDIRECT_URI`.
- The redirect URI is now dynamically generated using `url_for('_external=True')` within the `get_google_flow` function, making it suitable for different deployment environments.

Docs: Add warning for default admin password

- I've added a logger warning during `init_db` if the default 'admin' user and password are created, advising an immediate change for security.