### PR TITLE
refactor: Remove Quick Actions section from home page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -31,10 +31,6 @@
             {% endif %}
         </div>
     </section>
-    <section id="quick-actions">
-        <h2>{{ _('Quick Actions') }}</h2>
-        <button>{{ _('Book a Room') }}</button>
-    </section>
 {% endblock %}
 
 {% block footer_extra %}{% endblock %}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1353,6 +1353,8 @@ class TestHomePage(AppTests):
         content = response.data.decode('utf-8')
         self.assertIn('<h2>Upcoming Bookings</h2>', content)
         self.assertIn('No upcoming bookings.', content) # Or translated equivalent
+        self.assertNotIn('Quick Actions', content)
+        self.assertNotIn('Book a Room', content)
 
     def test_home_page_authenticated_with_bookings(self):
         """Test home page when user is authenticated and has upcoming bookings."""
@@ -1395,6 +1397,9 @@ class TestHomePage(AppTests):
         if self.resource2: # resource2 might be None if setup failed, though unlikely here
              self.assertNotIn(self.resource2.name, content)
         # We don't need to check for past_booking times as the title/resource name absence is sufficient
+
+        self.assertNotIn('Quick Actions', content)
+        self.assertNotIn('Book a Room', content)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I've removed the "Quick Actions" section from `templates/index.html` as you requested. I also updated the corresponding tests in `tests/test_app.py` to ensure the section is no longer rendered.