### PR TITLE
feat: Refine layout based on your feedback

### DIFF
--- a/static/js/script.js
+++ b/static/js/script.js
@@ -156,10 +156,15 @@ async function updateAuthLink() {
     const myBookingsNavLink = document.getElementById('my-bookings-nav-link'); 
     const analyticsNavLink = document.getElementById('analytics-nav-link');
     const adminBookingsNavLink = document.getElementById('admin-bookings-nav-link');
+    const sidebar = document.getElementById('sidebar'); // Added for sidebar visibility
+    const sidebarToggleBtn = document.getElementById('sidebar-toggle'); // Added for toggle button visibility
 
     const loginUrl = document.body.dataset.loginUrl || '/login';
 
     function setStateLoggedOut() {
+        const localSidebar = document.getElementById('sidebar'); // Ensure access within function
+        const localSidebarToggleBtn = document.getElementById('sidebar-toggle'); // Ensure access
+
         sessionStorage.removeItem('loggedInUserUsername');
         sessionStorage.removeItem('loggedInUserIsAdmin');
         sessionStorage.removeItem('loggedInUserId');
@@ -183,6 +188,11 @@ async function updateAuthLink() {
         if (myBookingsNavLink) myBookingsNavLink.style.display = 'none'; 
         if (analyticsNavLink) analyticsNavLink.style.display = 'none';
         if (adminBookingsNavLink) adminBookingsNavLink.style.display = 'none';
+
+        if (localSidebar) localSidebar.style.display = 'none';
+        if (localSidebarToggleBtn) localSidebarToggleBtn.style.display = 'none';
+        document.body.classList.add('no-sidebar');
+        document.body.classList.remove('sidebar-collapsed');
     }
 
     try {
@@ -228,13 +238,31 @@ async function updateAuthLink() {
                 manualBackupNavLink.style.display = data.user.is_admin ? 'list-item' : 'none';
             }
             if (myBookingsNavLink) { 
-                myBookingsNavLink.style.display = 'list-item'; 
+                myBookingsNavLink.style.display = 'flex'; // Changed from list-item to flex for header
             }
             if (analyticsNavLink) {
-                analyticsNavLink.style.display = data.user.is_admin ? 'list-item' : 'none';
+                analyticsNavLink.style.display = data.user.is_admin ? 'list-item' : 'none'; // Stays list-item if it's inside admin ul
             }
             if (adminBookingsNavLink) {
-                adminBookingsNavLink.style.display = data.user.is_admin ? 'list-item' : 'none';
+                adminBookingsNavLink.style.display = data.user.is_admin ? 'list-item' : 'none'; // Stays list-item
+            }
+
+            // Sidebar and body class management based on admin status
+            if (data.user.is_admin) {
+                if (sidebar) sidebar.style.display = ''; // Or 'block' or 'flex'
+                if (sidebarToggleBtn) sidebarToggleBtn.style.display = '';
+                document.body.classList.remove('no-sidebar');
+                // Ensure sidebar-collapsed state is consistent if sidebar was previously hidden
+                if (sidebar && !sidebar.classList.contains('collapsed')) {
+                    document.body.classList.remove('sidebar-collapsed');
+                } else if (sidebar && sidebar.classList.contains('collapsed')) {
+                    document.body.classList.add('sidebar-collapsed');
+                }
+            } else { // Non-admin user
+                if (sidebar) sidebar.style.display = 'none';
+                if (sidebarToggleBtn) sidebarToggleBtn.style.display = 'none';
+                document.body.classList.add('no-sidebar');
+                document.body.classList.remove('sidebar-collapsed');
             }
 
             if (logoutLinkDropdown) {
@@ -393,11 +421,14 @@ document.addEventListener('DOMContentLoaded', function() {
     updateAuthLink();
 
     const sidebar = document.getElementById('sidebar');
-    const sidebarToggle = document.getElementById('sidebar-toggle');
-    if (sidebar && sidebarToggle) {
+    const sidebarToggle = document.getElementById('sidebar-toggle'); // Already declared as sidebarToggleBtn in updateAuthLink scope
+    if (sidebar && sidebarToggle) { // sidebar is already declared in DOMContentLoaded scope
         sidebarToggle.addEventListener('click', function() {
-            sidebar.classList.toggle('collapsed');
-            document.body.classList.toggle('sidebar-collapsed');
+            // Only toggle if the sidebar is supposed to be visible (i.e., for admins)
+            if (sidebar.style.display !== 'none') {
+                sidebar.classList.toggle('collapsed');
+                document.body.classList.toggle('sidebar-collapsed');
+            }
         });
     }
 

--- a/static/style.css
+++ b/static/style.css
@@ -62,13 +62,46 @@ body {
 
 .header-content {
     display: flex;
+    width: 100%;
     align-items: center;
-    gap: 15px;
+    justify-content: flex-start; /* Default, items start on left */
+    gap: 10px; /* Adjusted gap for items within header-content */
 }
 
-.app-header #user-dropdown-container { /* Specific to header context */
-    margin-left: auto;
+/* Style for the moved navigation links and containers */
+.header-content > a, /* Direct <a> links like Home, Resources, Calendar */
+.header-content > div { /* Wrappers for My Bookings, Welcome, Auth, User Dropdown */
+    color: var(--text-color-light);
+    text-decoration: none;
+    padding: 0.5em 0.75em; /* Uniform padding for clickable areas */
+    border-radius: 4px;
+    display: flex; /* For internal alignment of icon/text */
+    align-items: center;
+}
+
+.header-content > a:hover,
+.header-content > div:hover:not(#user-dropdown-container):not(#welcome-message-container) { /* Avoid hover on non-interactive divs unless they contain an <a> that handles it */
+    background-color: var(--secondary-color);
+}
+/* Specifically target <a> tags within the divs for hover, if the div itself shouldn't have hover */
+.header-content #my-bookings-nav-link a:hover,
+.header-content #auth-link-container a:hover {
+    background-color: var(--secondary-color); /* Apply hover to the link itself */
+    border-radius: 4px; /* Ensure hover matches overall item shape */
+}
+.header-content #my-bookings-nav-link a,
+.header-content #auth-link-container a {
+    padding: 0; /* Remove padding from inner link if parent div has it */
+}
+
+
+.header-content > #user-dropdown-container {
+    margin-left: auto; /* This will push the user dropdown to the far right */
     position: relative; /* Needed for dropdown positioning */
+    padding: 0; /* User dropdown button itself has padding */
+}
+.header-content > #user-dropdown-container:hover {
+    background-color: transparent; /* Prevent hover on the container itself */
 }
 
 .app-header #user-dropdown-button { /* Copied from existing #user-dropdown-button and adapted */
@@ -256,7 +289,7 @@ body {
     padding: 20px;
     height: calc(100vh - var(--header-height) - var(--footer-height));
     overflow-y: auto;
-    transition: margin-left 0.3s;
+    transition: margin-left 0.3s ease-in-out;
     background-color: var(--background-color-light);
     /* flex-grow: 1; REMOVED */
 }
@@ -264,6 +297,11 @@ body {
 /* Adjust margin-left when sidebar is collapsed */
 body.sidebar-collapsed #main-content {
     margin-left: var(--sidebar-collapsed-width);
+}
+
+/* Adjust margin-left when sidebar is not present (e.g., for non-admins) */
+body.no-sidebar #main-content {
+    margin-left: 0;
 }
 
 main { /* The <main> tag inside #main-content */

--- a/templates/base.html
+++ b/templates/base.html
@@ -8,23 +8,33 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
     {% block head_extra %}{% endblock %}
 </head>
-<body>
-    <header class="app-header"><div class="header-content"></div></header>
+<body class="no-sidebar">
+    <header class="app-header">
+        <div class="header-content">
+            <a href="{{ url_for('serve_index') }}"><span class="menu-icon" aria-hidden="true">🏠</span><span class="menu-text">{{ _('Home') }}</span></a>
+            <a href="{{ url_for('serve_resources') }}"><span class="menu-icon" aria-hidden="true">📁</span><span class="menu-text">{{ _('View Resources') }}</span></a>
+            <a href="{{ url_for('serve_calendar') }}"><span class="menu-icon" aria-hidden="true">📅</span><span class="menu-text">{{ _('Calendar') }}</span></a>
+            <div id="my-bookings-nav-link" style="display: none;">
+                 <a href="{{ url_for('serve_my_bookings_page') }}"><span class="menu-icon" aria-hidden="true">📖</span><span class="menu-text">{{ _('My Bookings') }}</span></a>
+            </div>
+            <div id="welcome-message-container" style="display: none; margin-right: 10px; color: white; align-self: center;"></div>
+            <div id="auth-link-container" style="display: none; margin-left:auto;">
+                <a href="{{ url_for('serve_login') }}"><span class="menu-icon" aria-hidden="true">🔑</span><span class="menu-text">{{ _('Login') }}</span></a>
+            </div>
+            <div id="user-dropdown-container" style="display: none; position: relative; margin-left:auto;">
+                <button id="user-dropdown-button" aria-haspopup="true" aria-expanded="false" style="background: none; border: none; color: white; font-size: 1em; cursor: pointer; padding: 10px; font-weight: bold; display:flex; align-items:center;">
+                    <span class="user-icon" style="font-size:1.2em;">&#x1F464;</span><span class="dropdown-arrow"> &#9662;</span>
+                </button>
+                <div class="dropdown-menu" id="user-dropdown-menu" style="display: none; position: absolute; top: 100%; left: 0; background-color: #333; border: 1px solid #555; min-width: 160px; z-index: 1000; list-style-type: none; padding: 0; margin: 0; box-shadow: 0 2px 5px rgba(0,0,0,0.2);">
+                    <a class="dropdown-item" href="{{ url_for('serve_profile_page') }}" style="display: block; padding: 10px 15px; text-decoration: none; color: white;">{{ _('Profile') }}</a>
+                    <a class="dropdown-item" href="{{ url_for('logout_and_redirect') }}" id="logout-link-dropdown" style="display: block; padding: 10px 15px; text-decoration: none; color: white;">{{ _('Logout') }}</a>
+                </div>
+            </div>
+        </div>
+    </header>
     <nav id="sidebar" class="collapsed">
         <button id="sidebar-toggle" aria-label="{{ _('Toggle menu') }}">&#9776;</button>
         <ul>
-            <li><a href="{{ url_for('serve_index') }}"><span class="menu-icon" aria-hidden="true">🏠</span><span class="menu-text">{{ _('Home') }}</span></a></li>
-            <li><a href="{{ url_for('serve_resources') }}"><span class="menu-icon" aria-hidden="true">📁</span><span class="menu-text">{{ _('View Resources') }}</span></a></li>
-            <li><a href="{{ url_for('serve_calendar') }}"><span class="menu-icon" aria-hidden="true">📅</span><span class="menu-text">{{ _('Calendar') }}</span></a></li>
-            
-            {# General links visible to all - JavaScript will manage the display of login/logout and user info #}
-
-            {# Container for 'My Bookings' - shown by JS when logged in #}
-            <li id="my-bookings-nav-link" style="display: none;">
-                 <a href="{{ url_for('serve_my_bookings_page') }}"><span class="menu-icon" aria-hidden="true">📖</span><span class="menu-text">{{ _('My Bookings') }}</span></a>
-            </li>
-            
-            {# Container for Admin Maps link - shown by JS if admin #}
         <li id="admin-menu-item" style="display:none;">
             <details id="admin-section">
                 <summary><span class="menu-icon" aria-hidden="true">⚙️</span><span class="menu-text">{{ _('Admin') }}</span></summary>
@@ -53,11 +63,6 @@
                 </ul>
             </details>
         </li>
-
-            {# Container for user-specific welcome message - populated by JS when logged in #}
-            {# Container for user dropdown (Profile, Logout) - shown by JS when logged in #}
-            {# Links for admin users or specific roles could be added here with appropriate checks #}
-            {# Example: {% if current_user.is_admin %}<li><a href="{{ url_for('serve_admin_dashboard') }}">{{ _('Admin') }}</a></li>{% endif %} #}
         </ul>
     </nav>
     <div id="manual-backup-status" class="status-message" style="display:none; margin: 10px;"></div>


### PR DESCRIPTION
This commit incorporates your feedback on the UI layout:

1.  **Header Navigation:**
    *   Non-admin navigation links (Home, View Resources, Calendar, My Bookings) are now located in the main header on the left side.
    *   Your profile icon and dropdown menu are positioned on the right side of the header.

2.  **Conditional Admin Sidebar:**
    *   The left sidebar, containing the admin menu, is now only visible to you if you have admin privileges.
    *   For non-admin users, the sidebar is hidden, and the main content area expands to use the full width.
    *   The sidebar toggle button is also hidden for non-admin users.

Changes involved:
- Modifying `templates/base.html` to restructure the header and sidebar link placements.
- Updating `static/style.css` to style the new header navigation layout and to adjust main content margins based on sidebar visibility.
- Enhancing `static/js/script.js` (specifically `updateAuthLink` and related functions) to control the visibility of the sidebar and its toggle based on admin status, and to manage a body class (`no-sidebar`) for CSS to adapt the layout.
- Added `no-sidebar` class to `<body>` in `base.html` by default.