### PR TITLE
Looks like I've added import/export functionality for Resource and Ma…

### DIFF
--- a/templates/admin_maps.html
+++ b/templates/admin_maps.html
@@ -33,6 +33,9 @@
 
     <section id="list-maps-section">
         <h2>{{ _('Existing Floor Maps') }}</h2>
+        <button id="export-map-config-btn" class="button" style="margin-bottom: 10px;">{{ _('Export Map Configuration') }}</button>
+        <input type="file" id="import-map-config-file" accept=".json" style="display: none; margin-left: 10px;">
+        <button id="import-map-config-btn" class="button" style="margin-bottom: 10px; margin-left: 5px;">{{ _('Import Map Configuration') }}</button>
         <div id="admin-maps-list-status"></div>
         <ul id="maps-list">
             <li>{{ _('Loading maps...') }}</li>

--- a/templates/resource_management.html
+++ b/templates/resource_management.html
@@ -8,6 +8,9 @@
     <button id="add-bulk-resource-btn" class="button" style="margin-left:5px;">{{ _('Bulk Add Resources') }}</button>
     <button id="bulk-edit-btn" class="button" style="margin-left:5px;">{{ _('Bulk Edit') }}</button>
     <button id="bulk-delete-btn" class="button danger" style="margin-left:5px;">{{ _('Bulk Delete') }}</button>
+    <button id="export-all-resources-btn" class="button" style="margin-left:5px;">{{ _('Export All Resources') }}</button>
+    <input type="file" id="import-resources-file" accept=".json" style="margin-left: 10px; display: none;">
+    <button id="import-resources-btn" class="button" style="margin-left:5px;">{{ _('Import Resources from JSON') }}</button>
     <div class="filters-section" style="margin-top:15px;">
         <h3>{{ _('Filters') }}</h3>
         <label for="resource-filter-name">{{ _('Name:') }}</label>


### PR DESCRIPTION
…p configurations.

This update introduces the ability for you to import and export configurations for Resource Management and Admin Map settings.

Features:

- Resource Management:
    - Export: You can now export all resource details (including name, capacity, equipment, status, tags, booking restrictions, permissions, maintenance schedules, and map placements) to a JSON file via a new API endpoint `/api/admin/resources/export` and a corresponding UI button.
    - Import: You can import resources from a JSON file using the `/api/admin/resources/import` endpoint. This will create new resources or update existing ones (matched by ID or name), handling all configurable fields.

- Admin Map Configuration:
    - Export: A new endpoint `/api/admin/maps/export_configuration` allows exporting all floor map definitions (`FloorMap` objects) and the mapping details of resources placed on them (including coordinates and permissions like booking restrictions, allowed users, and roles).
    - Import: The `/api/admin/maps/import_configuration` endpoint allows importing this configuration from a JSON file. It creates/updates floor maps and updates resources with their map placements and permissions. You'll want to ensure referenced map image files are present.

- Unit Tests:
    - I've added comprehensive unit tests for all new import and export API endpoints, covering successful operations, updates by ID/name, data validation, error handling, and ensuring data integrity.