### PR TITLE
Fix: Resolve TypeError in resource availability API

### DIFF
--- a/app.py
+++ b/app.py
@@ -964,9 +964,15 @@ def get_resource_availability(resource_id):
         for booking in bookings_on_date:
             grace = app.config.get('CHECK_IN_GRACE_MINUTES', 15)
             now = datetime.now(timezone.utc)
+
+            # Ensure booking.start_time is offset-aware (UTC) before comparison
+            booking_start_time_aware = booking.start_time
+            if booking_start_time_aware.tzinfo is None:
+                booking_start_time_aware = booking_start_time_aware.replace(tzinfo=timezone.utc)
+
             can_check_in = (
                 booking.checked_in_at is None and
-                booking.start_time - timedelta(minutes=grace) <= now <= booking.start_time + timedelta(minutes=grace)
+                booking_start_time_aware - timedelta(minutes=grace) <= now <= booking_start_time_aware + timedelta(minutes=grace)
             )
             booked_slots.append({
                 'title': booking.title,


### PR DESCRIPTION
Corrected a TypeError that occurred when comparing offset-naive booking start_times with offset-aware current times in the `/api/resources/<id>/availability` endpoint.

The fix ensures that `booking.start_time` is treated as UTC (by making it offset-aware with UTC timezone info if it's naive) before being used in comparisons with `datetime.now(timezone.utc)`.

This resolves the 500 Internal Server Error previously encountered when fetching availability for certain dates.