### PR TITLE
Refactor: Streamline admin sidebar content

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -36,17 +36,8 @@
     <nav id="sidebar" class="collapsed">
         <button id="sidebar-toggle" aria-label="{{ _('Toggle menu') }}">&#9776;</button>
         <ul>
-
-            <li><a href="{{ url_for('serve_index') }}"><span class="menu-icon" aria-hidden="true">🏠</span><span class="menu-text">{{ _('Home') }}</span></a></li>
-            <li><a href="{{ url_for('serve_resources') }}"><span class="menu-icon" aria-hidden="true">📁</span><span class="menu-text">{{ _('View Resources') }}</span></a></li>
-            <li><a href="{{ url_for('serve_calendar') }}"><span class="menu-icon" aria-hidden="true">📅</span><span class="menu-text">{{ _('Calendar') }}</span></a></li>
-            
-            {# General links visible to all - JavaScript will manage the display of login/logout and user info #}
-
-            {# Container for 'My Bookings' - shown by JS when logged in #}
-            <li>
-                 <a href="{{ url_for('serve_my_bookings_page') }}"><span class="menu-icon" aria-hidden="true">📖</span><span class="menu-text">{{ _('My Bookings') }}</span></a>
-            </li>
+            {# General navigation links (Home, View Resources, Calendar, My Bookings) are now in the header only. #}
+            {# The sidebar, when visible for admins, should only contain admin-specific links. #}
             
             {# Container for Admin Maps link - shown by JS if admin #}
 


### PR DESCRIPTION
I removed general navigation links (Home, View Resources, Calendar, My Bookings) from the admin sidebar in `templates/base.html`. These links are already available in the main header.

This change makes the admin sidebar exclusively focused on admin-specific functionalities, reducing redundancy and clarifying its purpose.

The sidebar remains visible only to admin users, and its visibility is controlled by existing Jinja templating and JavaScript logic. Non-admin users will continue to have no sidebar and use the header for navigation.

Note: The issue regarding non-functional 'Export/Import Map Configuration' buttons was investigated. These buttons and their corresponding backend APIs were found to be missing from the current implementation. Addressing this would require new feature development.