### PR TITLE
Fix CSRF token error in resource import

### DIFF
--- a/static/js/resource_management.js
+++ b/static/js/resource_management.js
@@ -167,13 +167,16 @@ document.addEventListener('DOMContentLoaded', function() {
             formData.append('file', file);
 
             try {
+                const csrfTokenTag = document.querySelector('meta[name="csrf-token"]');
+                const headers = {};
+                if (csrfTokenTag) {
+                    headers['X-CSRFToken'] = csrfTokenTag.content;
+                }
+
                 const response = await fetch('/api/admin/resources/import', {
                     method: 'POST',
                     body: formData,
-                    headers: {
-                        // 'Content-Type': 'multipart/form-data' is automatically set by browser with FormData
-                        'X-CSRFToken': getCsrfToken() // Assuming you have a function to get CSRF token
-                    }
+                    headers: headers // Use the constructed headers object
                 });
                 const result = await response.json();
 


### PR DESCRIPTION
This commit resolves a JavaScript error "getCsrfToken is not defined" that occurred during the file upload process in the resource import functionality.

The error was caused by a direct call to a non-existent `getCsrfToken()` function within the `fetch` request in `static/js/resource_management.js`.

The fix modifies the `importResourcesFile` event listener to correctly retrieve the CSRF token directly from the `meta[name="csrf-token"]` HTML tag and adds it to the `X-CSRFToken` header for the import request. This aligns with the standard CSRF handling mechanism used elsewhere in the application (e.g., by the global `apiCall` function).