### PR TITLE
Make Admin sidebar menu always expanded for admins

### DIFF
--- a/static/js/script.js
+++ b/static/js/script.js
@@ -256,6 +256,23 @@ async function updateAuthLink() {
                 if (sidebarToggleBtn) sidebarToggleBtn.style.display = 'none'; // Hide toggle for admin
                 document.body.classList.remove('no-sidebar');
                 document.body.classList.remove('sidebar-collapsed');
+
+                // Prevent admin menu details from collapsing
+                const adminSectionDetails = document.getElementById('admin-section');
+                if (adminSectionDetails) {
+                    const adminSectionSummary = adminSectionDetails.querySelector('summary');
+                    if (adminSectionSummary) {
+                        // Ensure this listener is added only once
+                        if (!adminSectionSummary.dataset.clickListenerAdded) {
+                            adminSectionSummary.addEventListener('click', function(event) {
+                                if (adminSectionDetails.hasAttribute('open')) {
+                                    event.preventDefault();
+                                }
+                            });
+                            adminSectionSummary.dataset.clickListenerAdded = 'true';
+                        }
+                    }
+                }
             } else { // Non-admin user
                 if (sidebar) sidebar.style.display = 'none';
                 if (sidebarToggleBtn) sidebarToggleBtn.style.display = 'none';

--- a/static/style.css
+++ b/static/style.css
@@ -872,7 +872,7 @@ body.high-contrast footer {
 
 /* Ensure admin dropdown in sidebar still looks okay */
 #sidebar details summary {
-    cursor: pointer;
+    /* cursor: pointer; Removed to make it less interactive for always-open admin menu */
     padding: 0.75em 1em; /* Match li padding */
     display: flex;
     align-items: center;

--- a/templates/base.html
+++ b/templates/base.html
@@ -36,7 +36,7 @@
         <button id="sidebar-toggle" aria-label="{{ _('Toggle menu') }}">&#9776;</button>
         <ul>
         <li id="admin-menu-item" style="display:none;">
-            <details id="admin-section">
+            <details id="admin-section" open>
                 <summary><span class="menu-icon" aria-hidden="true">⚙️</span><span class="menu-text">{{ _('Admin') }}</span></summary>
                 <ul class="admin-menu">
                 <li id="admin-maps-nav-link" style="display: none;">


### PR DESCRIPTION
This commit ensures that the 'Admin' section in the sidebar menu is always expanded by default for authenticated admin users, and its collapsibility is removed.

Changes include:
- Modified `templates/base.html`: Added the `open` attribute to the `<details id="admin-section">` tag.
- Adjusted `static/style.css`: Removed `cursor: pointer` from the admin menu's summary to reduce visual cues for collapsing.
- Adjusted `static/js/script.js`: Added an event listener to the admin menu's summary that calls `event.preventDefault()` if the menu is open, preventing it from being collapsed on click by an admin. This is applied only when an admin is logged in.

This enhances usability for administrators by making all admin options immediately visible without requiring an extra click.