### PR TITLE
Fix: Ensure JSON responses for CSRF errors in API

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,7 +18,7 @@ import logging # Added for logging
 from functools import wraps # For permission_required decorator
 from flask import abort # For permission_required decorator
 from flask import g  # For storing current locale
-from flask_wtf.csrf import CSRFProtect # For CSRF protection
+from flask_wtf.csrf import CSRFProtect, CSRFError # For CSRF protection
 from flask_socketio import SocketIO
 
 try:
@@ -164,6 +164,11 @@ app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', 'dev_secret_key_123!@#')
 
 # Initialize CSRF Protection - AFTER app.config['SECRET_KEY'] is set
 csrf = CSRFProtect(app)
+
+@app.errorhandler(CSRFError)
+def handle_csrf_error(e):
+    app.logger.warning(f"CSRF error encountered: {e.description}")
+    return jsonify({'error': e.description, 'type': 'CSRF_ERROR'}), 400
 
 # Localization configuration
 app.config['LANGUAGES'] = ['en', 'es', 'th']


### PR DESCRIPTION
I've added an error handler for `CSRFError` in `app.py`. This will make sure that if a CSRF validation fails for an API endpoint, a JSON response with a 400 status code is returned instead of the default HTML error page.

This specifically addresses an issue where your `/api/profile` (PUT) endpoint would cause a frontend `SyntaxError` due to receiving HTML on a 400 Bad Request, likely caused by a CSRF issue. The frontend JavaScript expects JSON, and this change ensures the backend API behaves more predictably for such errors.