### PR TITLE
Fix: Update calendar page functionality and display

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1127,4 +1127,23 @@ nav#sidebar {
 }
 */
 
+/* Ensure event content in month view does not overflow */
+.fc-daygrid-event .fc-event-main-frame {
+    overflow: hidden; /* This will clip content that's too large */
+    position: relative; /* For text-overflow to work correctly with children */
+}
+
+.fc-daygrid-event .fc-event-main-frame b { /* Targeting the title */
+    display: block; /* Make it a block to control overflow */
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 100%; /* Ensure it respects container width */
+}
+
+/* For the time part, allow wrapping or also truncate if necessary */
+/* This part is trickier as it's a text node after a <br>. */
+/* We might rely on the parent's overflow:hidden for the time part,
+   or if it becomes an issue, wrap the time in a span within eventContent. */
+/* For now, let's assume the title is the primary concern for truncation. */
 ```

--- a/templates/calendar.html
+++ b/templates/calendar.html
@@ -25,18 +25,21 @@
         <h3 id="cebm-title">{{ _('Edit Booking') }}</h3>
         <p>{{ _('Resource:') }} <strong id="cebm-resource-name">N/A</strong></p>
         <input type="hidden" id="cebm-booking-id">
+        <input type="hidden" id="cebm-resource-id">
         <div>
             <label for="cebm-booking-title">{{ _('Booking Title:') }}</label>
             <input type="text" id="cebm-booking-title" name="booking_title" class="form-control">
         </div>
-        <div>
-            <label for="cebm-start-time">{{ _('Start Time:') }}</label>
-            <input type="datetime-local" id="cebm-start-time" name="start_time" class="form-control">
-        </div>
-        <div>
-            <label for="cebm-end-time">{{ _('End Time:') }}</label>
-            <input type="datetime-local" id="cebm-end-time" name="end_time" class="form-control">
-        </div>
+       <div>
+           <label for="cebm-booking-date">{{ _('Date:') }}</label>
+           <input type="date" id="cebm-booking-date" name="booking_date" class="form-control">
+       </div>
+       <div>
+           <label for="cebm-available-slots-select">{{ _('Available Time Slots:') }}</label>
+           <select id="cebm-available-slots-select" name="available_slots" class="form-select">
+               <option value="">-- {{ _('Select a time slot') }} --</option>
+           </select>
+       </div>
         <button id="cebm-save-changes-btn" class="button" style="margin-top: 15px;">{{ _('Save Changes') }}</button>
         <div id="cebm-status-message" class="status-message" style="margin-top:10px;"></div>
     </div>


### PR DESCRIPTION
This commit addresses three issues on the Calendar page:

1.  **Edit Booking with Available Slots:**
    - When editing a booking, you are now presented with a date picker and a dropdown of available 30-minute time slots for the selected resource and date.
    - This replaces the previous direct `datetime-local` inputs for start and end times.
    - A new API endpoint `/api/resources/<resource_id>/available_slots?date=YYYY-MM-DD` was added to provide these slots, considering existing bookings and resource maintenance.
    - Frontend modal (`templates/calendar.html`) and JavaScript (`static/js/calendar.js`) were updated to implement this new selection method.

2.  **Default Calendar View to Month:**
    - The calendar view on the Calendar page now defaults to 'month' view instead of 'week' view.
    - This change was made in `static/js/calendar.js` by updating the `initialView` option in FullCalendar.

3.  **Booking Detail Display in Month View:**
    - Added CSS rules in `static/style.css` to improve the display of booking details within month view calendar slots.
    - This aims to prevent text overflow by truncating long event titles and ensuring content fits within the cell.