### PR TITLE
feat: Update calendar page UI and time slot options

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -3,7 +3,7 @@
   "Home": "Home",
   "New Booking": "New Booking",
   "View Resources": "View Resources",
-  "Calendar": "Calendar",
+  "Calendar": "My Calendar",
   "Login": "Login",
   "My Bookings": "My Bookings",
   "Admin Maps": "Admin Maps",

--- a/locales/es.json
+++ b/locales/es.json
@@ -3,7 +3,7 @@
   "Home": "Inicio",
   "New Booking": "Nueva Reserva",
   "View Resources": "Ver Recursos",
-  "Calendar": "Calendario",
+  "Calendar": "Mi Calendario",
   "Login": "Iniciar sesión",
   "My Bookings": "Mis Reservas",
   "Admin Maps": "Mapas de Admin",

--- a/locales/th.json
+++ b/locales/th.json
@@ -3,7 +3,7 @@
   "Home": "หน้าแรก",
   "New Booking": "การจองใหม่",
   "View Resources": "ดูทรัพยากร",
-  "Calendar": "ปฏิทิน",
+  "Calendar": "ปฏิทินของฉัน",
   "Login": "เข้าสู่ระบบ",
   "My Bookings": "การจองของฉัน",
   "Admin Maps": "แผนที่สำหรับผู้ดูแลระบบ",

--- a/static/js/calendar.js
+++ b/static/js/calendar.js
@@ -43,26 +43,50 @@ document.addEventListener('DOMContentLoaded', () => {
         try {
             const availableSlots = await apiCall(`/api/resources/${resourceId}/available_slots?date=${dateStr}`);
 
-            slotsSelect.innerHTML = '<option value="">Select a time slot</option>'; // Reset
+            // Reset the select element
+            slotsSelect.innerHTML = '<option value="">-- Select a time slot --</option>'; // Reset
 
-            if (availableSlots && availableSlots.length > 0) {
-                availableSlots.forEach(slot => {
-                    const optionValue = `${slot.start_time},${slot.end_time}`; // e.g., "09:00,09:30"
-                    const optionText = `${slot.start_time} - ${slot.end_time} UTC`; // e.g., "09:00 - 09:30 UTC"
-                    const option = new Option(optionText, optionValue);
+            // Define the predefined slots
+            const predefinedSlots = [
+                { text: "08:00 - 12:00 UTC", value: "08:00,12:00" },
+                { text: "13:00 - 17:00 UTC", value: "13:00,17:00" },
+                { text: "08:00 - 17:00 UTC", value: "08:00,17:00" }
+            ];
 
-                    if (selectedStartTimeStr && slot.start_time === selectedStartTimeStr) {
-                        option.selected = true;
-                    }
-                    slotsSelect.add(option);
-                });
-                slotsSelect.disabled = false;
-            } else {
-                slotsSelect.innerHTML = '<option value="">No available slots</option>';
+            // Populate the select element with predefined slots
+            predefinedSlots.forEach(slot => {
+                const option = new Option(slot.text, slot.value);
+                slotsSelect.add(option);
+            });
+            slotsSelect.disabled = false;
+
+            // The original logic for handling empty or error states for availableSlots can be kept
+            // or adapted if the API call itself is still meaningful for other purposes (e.g. general availability check)
+            if (!availableSlots) { // Example: if API call failed or indicated resource is generally unavailable
+                 console.warn('API call for slots succeeded but returned no data, or resource might be unavailable. Proceeding with predefined slots.');
             }
-            if (statusMessage) statusMessage.textContent = '';
+            // if (availableSlots && availableSlots.length > 0) { // This block is replaced
+            //     availableSlots.forEach(slot => {
+            //         const optionValue = `${slot.start_time},${slot.end_time}`;
+            //         const optionText = `${slot.start_time} - ${slot.end_time} UTC`;
+            //         const option = new Option(optionText, optionValue);
+            //
+            //         if (selectedStartTimeStr && slot.start_time === selectedStartTimeStr) {
+            //             option.selected = true;
+            //         }
+            //         slotsSelect.add(option);
+            //     });
+            //     slotsSelect.disabled = false;
+            // } else { // This logic might need adjustment if API call result is still used
+            //     slotsSelect.innerHTML = '<option value="">No available slots (using predefined)</option>';
+            //     // Populate with predefined even if API says no specific slots, or handle as error.
+            //     // For now, predefined slots are added regardless of API's slot list.
+            // }
+            if (statusMessage) statusMessage.textContent = ''; // Clear loading/previous status
         } catch (error) {
             console.error('Error fetching available slots:', error);
+            // Even if API fails, we might still want to show predefined slots,
+            // or show an error and not show slots. For now, let's assume error means no slots.
             slotsSelect.innerHTML = '<option value="">Error loading slots</option>';
             if (statusMessage) {
                 statusMessage.textContent = error.message || 'Failed to load available slots.';

--- a/static/style.css
+++ b/static/style.css
@@ -1135,9 +1135,9 @@ nav#sidebar {
 
 .fc-daygrid-event .fc-event-main-frame b { /* Targeting the title */
     display: block; /* Make it a block to control overflow */
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    white-space: normal; /* Allow text to wrap */
+    /* overflow: hidden; */ /* Not needed here, parent will clip */
+    /* text-overflow: ellipsis; */ /* Not needed if wrapping */
     max-width: 100%; /* Ensure it respects container width */
 }
 


### PR DESCRIPTION
This commit introduces three main changes to the calendar functionality:

1.  Updates the navigation menu item for the calendar page from "Calendar" to "My Calendar" in English, Spanish, and Thai localization files.
2.  Modifies the time slot selection in the "Edit Booking" modal to offer three predefined options: "08:00-12:00 UTC", "13:00-17:00 UTC", and "08:00-17:00 UTC", replacing the dynamic slot loading for these specific choices.
3.  Adjusts CSS for FullCalendar month view to ensure that long event titles wrap to multiple lines within the date cell, rather than being truncated with an ellipsis. This improves readability of event details.