### PR TITLE
fix: Ensure UTC consistency when editing booking times

### DIFF
--- a/static/js/calendar.js
+++ b/static/js/calendar.js
@@ -134,8 +134,8 @@ document.addEventListener('DOMContentLoaded', () => {
         const [slotStartTime, slotEndTime] = selectedSlotValue.split(',');
 
         // Construct full ISO datetime strings for start and end
-        const localStartDate = new Date(`${bookingDateStr}T${slotStartTime}:00`); // Parsed as local time
-        const localEndDate = new Date(`${bookingDateStr}T${slotEndTime}:00`);   // Parsed as local time
+        const localStartDate = new Date(`${bookingDateStr}T${slotStartTime}:00Z`); // Parsed as UTC
+        const localEndDate = new Date(`${bookingDateStr}T${slotEndTime}:00Z`);   // Parsed as UTC
 
         if (localEndDate <= localStartDate) { // Validation for new slot times
             cebmStatusMessage.textContent = 'End time must be after start time.';


### PR DESCRIPTION
This commit addresses an issue where editing a booking's time slot on the calendar page could lead to incorrect time conversions. The `saveBookingChanges` function in `static/js/calendar.js` was parsing the selected date and time as local time, which, when converted to UTC for saving, resulted in an unintentional time shift.

The fix ensures that when a predefined UTC time slot is selected (e.g., "08:00-12:00 UTC"), the JavaScript Date objects are explicitly constructed as UTC (by appending 'Z' to the ISO string before parsing). This guarantees that all subsequent operations, including generating the ISO string for the backend and updating the FullCalendar event, use the correct UTC time as selected by you, without any local time interference.