### PR TITLE
Fix: Ensure text wraps within calendar event cells

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1129,15 +1129,16 @@ nav#sidebar {
 
 /* Ensure event content in month view does not overflow */
 .fc-daygrid-event .fc-event-main-frame {
-    overflow: hidden; /* This will clip content that's too large */
+    overflow: visible; /* Allow content to be visible, enabling wrapping */
     position: relative; /* For text-overflow to work correctly with children */
+    white-space: normal; /* Ensure text wrapping for all content */
 }
 
 .fc-daygrid-event .fc-event-main-frame b { /* Targeting the title */
     display: block; /* Make it a block to control overflow */
     white-space: normal; /* Allow text to wrap */
     /* overflow: hidden; */ /* Not needed here, parent will clip */
-    /* text-overflow: ellipsis; */ /* Not needed if wrapping */
+    /* text-overflow: ellipsis; */ /* Not needed if wrapping - text will wrap due to parent */
     max-width: 100%; /* Ensure it respects container width */
 }
 


### PR DESCRIPTION
The booking details in the FullCalendar month view were overflowing their cells instead of wrapping. This was due to `overflow: hidden` on the event's main frame.

This commit addresses the issue by:
1. Modifying `static/style.css` for `.fc-daygrid-event .fc-event-main-frame`:
    - Changed `overflow: hidden;` to `overflow: visible;` to allow the event container to expand if its content requires more height.
    - Ensured `white-space: normal;` is applied so that text (both title and time) wraps to new lines.
2. Verified that the `eventContent` function in `static/js/calendar.js` produces a simple HTML structure that is conducive to text wrapping.

These changes ensure that long event titles and their associated times will wrap within the calendar cell boundaries, preventing text from being cut off.