### PR TITLE
Fix: Improve robustness of Selective Restore Options modal

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -902,7 +902,7 @@ body.high-contrast footer {
 
 .modal { position: fixed; z-index: 1050; /* Higher than header/sidebar */ left: 0; top: 0; width: 100%; height: 100%; overflow: auto; background-color: rgba(0,0,0,0.4); }
 .modal-content { background-color: var(--background-color-light); margin: 10% auto; padding: 20px; border: 1px solid var(--border-color); width: 80%; max-width: 500px; border-radius: 8px; position: relative; }
-.close-modal-btn { color: #aaa; float: right; font-size: 28px; font-weight: bold; }
+.close-modal-btn { color: #aaa; float: right; font-size: 28px; font-weight: bold; pointer-events: auto !important; }
 .close-modal-btn:hover, .close-modal-btn:focus { color: var(--text-color-dark); text-decoration: none; cursor: pointer; }
 .time-slots-container { margin-top: 15px; margin-bottom: 15px; max-height: 200px; overflow-y: auto; border: 1px solid #eee; padding: 10px; }
 .time-slot-item { padding: 8px; margin-bottom: 5px; border-radius: 4px; }

--- a/templates/admin_backup_restore.html
+++ b/templates/admin_backup_restore.html
@@ -641,14 +641,16 @@
         });
 
         // Modal Close Button
-        closeModalBtn.onclick = function() {
-            selectiveRestoreModal.style.display = 'none';
+        if (closeModalBtn) {
+            closeModalBtn.addEventListener('click', function() {
+                selectiveRestoreModal.style.display = 'none';
+            });
         }
-        window.onclick = function(event) { // Close if clicked outside modal content
+        window.addEventListener('click', function(event) { // Close if clicked outside modal content
             if (event.target == selectiveRestoreModal) {
                 selectiveRestoreModal.style.display = 'none';
             }
-        }
+        });
 
         // "ALL COMPONENTS" checkbox logic
         componentAllCheckbox.addEventListener('change', function() {


### PR DESCRIPTION
- Changed modal close button and window click-outside handlers to use addEventListener instead of direct onclick assignment in admin_backup_restore.html. This prevents potential overwriting by other scripts and aligns with modern JavaScript practices.
- Added a null check before attaching the event listener to the close button to prevent errors if the element is not found.
- Added `pointer-events: auto !important;` to the `.close-modal-btn` CSS class as a defensive measure to ensure it remains clickable even if other styles might try to disable pointer events.