### PR TITLE
Fix: Correct Socket.IO script integrity hash

### DIFF
--- a/templates/admin_backup_restore.html
+++ b/templates/admin_backup_restore.html
@@ -4,7 +4,7 @@
 
 {% block head_extra %}
 {{ super() }}
-<script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.7.4/socket.io.min.js" integrity="sha512-CPDRw laudeJEjYqdKq1sW3L3GGLAnL_7A_K9vG2gZf_3DSpC7GjHWTX2r_G2tq2oV_A2/8Bw6J24aO0yL_5jEQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.7.4/socket.io.min.js" integrity="sha512-skuhu6jj+sQnhLq1Txsack8VfnIrX8wL+MTFilYlFFT/NuLJm7eya7zOROs39Jy5cjASMEWqxLzijRVmKhsqWQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 <style>
     .log-area {
         max-height: 200px;


### PR DESCRIPTION
I've updated the SRI integrity hash for the Socket.IO library in `templates/admin_backup_restore.html`. The previous hash was malformed or incorrect, causing the browser to block the script and leading to an `io is not defined` JavaScript error. This error prevented subsequent JavaScript, including modal event handlers, from executing correctly, resulting in an unresponsive UI on your Backup & Restore page. Using the browser-computed correct hash should resolve this script loading issue.