### PR TITLE
Fix: Address ParentNotFound in backup and unpacking error in restore

### DIFF
--- a/app.py
+++ b/app.py
@@ -4167,7 +4167,7 @@ def api_one_click_restore():
         if socketio:
             socketio.emit('restore_progress', {'task_id': task_id, 'status': 'Restore process starting...', 'detail': f'Timestamp: {backup_timestamp}'})
 
-        restored_db_path, map_config_json_path = restore_full_backup(
+        restored_db_path, map_config_json_path, _ = restore_full_backup(
             backup_timestamp,
             socketio_instance=socketio,
             task_id=task_id


### PR DESCRIPTION
- In `azure_backup.py`, I improved the creation logic for the base media backup directory (`MEDIA_BACKUPS_DIR_BASE`) to be more explicit and robust, aiming to resolve `ParentNotFound` errors during media backup to Azure File Share.
- In `app.py`, I corrected the `api_one_click_restore` function to properly unpack the three values returned by `azure_backup.restore_full_backup`, fixing a `ValueError: too many values to unpack (expected 2)`.