### PR TITLE
Fix: Make calendar event text scrollable within cell

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1129,9 +1129,11 @@ nav#sidebar {
 
 /* Ensure event content in month view does not overflow */
 .fc-daygrid-event .fc-event-main-frame {
-    overflow: visible; /* Allow content to be visible, enabling wrapping */
+    overflow-y: auto;   /* Enable vertical scrollbar if content overflows */
+    max-height: 3.6em;  /* Adjust as needed, allows approx 2-3 lines */
     position: relative; /* For text-overflow to work correctly with children */
     white-space: normal; /* Ensure text wrapping for all content */
+    /* overflow: visible; was here, replaced by overflow-y: auto */
 }
 
 .fc-daygrid-event .fc-event-main-frame b { /* Targeting the title */


### PR DESCRIPTION
Replaces previous fix for overflowing text in FullCalendar month view. The previous attempt (using `overflow: visible`) allowed text to spill outside the cell boundaries.

This commit implements a scrollable overflow:
1. Modified `static/style.css` for event content container (`.fc-daygrid-event .fc-event-main-frame`):
    - Set `overflow-y: auto;` to enable vertical scrolling only when content exceeds the max height.
    - Applied `max-height: 3.6em;` (approx. 2-3 lines) to constrain the visible height of the event content.
    - Ensured `white-space: normal;` is active for text wrapping.
    - Removed conflicting `overflow` properties from previous attempts.

This ensures that long event titles and times will wrap, and if they still exceed the allocated space, the content within the event cell will become vertically scrollable, preventing text from overflowing into adjacent cells and maintaining cell height.