### PR TITLE
Fix: Aggressively style calendar events for text wrapping and scrolling

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1127,26 +1127,37 @@ nav#sidebar {
 }
 */
 
-/* Ensure event content in month view does not overflow */
+/* Ensure event content in month view does not overflow and is scrollable */
 .fc-daygrid-event .fc-event-main-frame {
-    overflow-y: auto;   /* Enable vertical scrollbar if content overflows */
-    max-height: 3.6em;  /* Adjust as needed, allows approx 2-3 lines */
-    position: relative; /* For text-overflow to work correctly with children */
-    white-space: normal; /* Ensure text wrapping for all content */
-    /* overflow: visible; was here, replaced by overflow-y: auto */
+    display: block; /* Ensure block context for overflow properties */
+    position: relative; /* Usually good for containing elements */
+    white-space: normal !important;
+    overflow-wrap: break-word !important; /* For long words */
+    word-wrap: break-word !important; /* Older browsers */
+    max-height: 3.6em !important; /* Approx 2-3 lines, !important to override other FC styles */
+    overflow-y: auto !important; /* Enable vertical scrollbar, !important to override */
 }
 
-.fc-daygrid-event .fc-event-main-frame b { /* Targeting the title */
-    display: block; /* Make it a block to control overflow */
-    white-space: normal; /* Allow text to wrap */
-    /* overflow: hidden; */ /* Not needed here, parent will clip */
-    /* text-overflow: ellipsis; */ /* Not needed if wrapping - text will wrap due to parent */
+/* If FullCalendar uses a specific class for the event title container or the title itself */
+/* This applies wrapping rules directly to common FullCalendar title class. */
+.fc-daygrid-event .fc-event-title { /* Common class for event titles */
+    white-space: normal !important;
+    overflow-wrap: break-word !important;
+    word-wrap: break-word !important;
+    display: block; /* Assuming title should behave as a block for consistent layout with <b> */
+    /* max-height and overflow-y are typically on the container (.fc-event-main-frame) */
+}
+
+/* Ensure the bold tag used in calendar.js for the title also wraps aggressively */
+/* This directly targets the <b> tag within the event frame. */
+.fc-daygrid-event .fc-event-main-frame b {
+    display: block; /* Make it a block to control overflow and ensure it takes its own line if needed */
+    white-space: normal !important; /* Force wrapping */
+    overflow-wrap: break-word !important; /* Force break for long words */
+    word-wrap: break-word !important; /* Older browsers */
     max-width: 100%; /* Ensure it respects container width */
 }
 
-/* For the time part, allow wrapping or also truncate if necessary */
-/* This part is trickier as it's a text node after a <br>. */
-/* We might rely on the parent's overflow:hidden for the time part,
-   or if it becomes an issue, wrap the time in a span within eventContent. */
-/* For now, let's assume the title is the primary concern for truncation. */
+/* For the time part (text node after <br>), it should inherit wrapping from .fc-event-main-frame. */
+/* No specific rule needed unless further issues are observed. */
 ```


### PR DESCRIPTION
This commit applies more aggressive CSS styling to ensure that event text in the FullCalendar month view wraps correctly and becomes scrollable if it exceeds a defined maximum height. Previous attempts were not sufficient to override default FullCalendar styles or other conflicting rules.

Changes in `static/style.css`:
- Applied `white-space: normal !important;` and `overflow-wrap: break-word !important;` (with `word-wrap` fallback) to `.fc-daygrid-event .fc-event-main-frame`, `.fc-daygrid-event .fc-event-title`, and `.fc-daygrid-event .fc-event-main-frame b` to force text wrapping.
- Set `max-height: 3.6em !important;` and `overflow-y: auto !important;` on `.fc-daygrid-event .fc-event-main-frame` to constrain its height and enable vertical scrolling for overflow.
- Ensured appropriate `display` properties (e.g., `block`) for these elements to support the wrapping and overflow behaviors.

The `eventContent` function in `static/js/calendar.js` was reviewed and confirmed not to add conflicting inline styles.

This approach aims to robustly enforce the desired text handling within calendar event cells.