### PR TITLE
Fix: Truncate calendar event text via JavaScript

### DIFF
--- a/static/js/calendar.js
+++ b/static/js/calendar.js
@@ -350,7 +350,16 @@ document.addEventListener('DOMContentLoaded', () => {
         },
         eventContent: function(arg) {
             if (arg.view.type === 'dayGridMonth') {
-                let eventHtml = `<b>${arg.event.title}</b>`;
+                const MAX_TITLE_LENGTH = 20;
+                const MAX_TIME_LENGTH = 18; // Max length for "HH:MM - HH:MM UTC"
+
+                let displayTitle = arg.event.title;
+                if (arg.event.title.length > MAX_TITLE_LENGTH) {
+                    displayTitle = arg.event.title.substring(0, MAX_TITLE_LENGTH - 3) + "...";
+                }
+
+                let eventHtml = `<b>${displayTitle}</b>`;
+
                 if (arg.event.start) {
                     const startHours = arg.event.start.getUTCHours().toString().padStart(2, '0');
                     const startMinutes = arg.event.start.getUTCMinutes().toString().padStart(2, '0');
@@ -363,19 +372,36 @@ document.addEventListener('DOMContentLoaded', () => {
                         endTimeUTC = `${endHours}:${endMinutes}`;
                     }
 
-                    // Show time if not an all-day event or if time is not midnight
+                    let fullTimeString = '';
+                    // Construct the time string only if it's not an all-day event or if time is not midnight
                     if (!arg.event.allDay || (startTimeUTC !== '00:00' || (endTimeUTC && endTimeUTC !== '00:00'))) {
-                        eventHtml += `<br>${startTimeUTC}`;
+                        fullTimeString = startTimeUTC;
                         if (endTimeUTC && endTimeUTC !== startTimeUTC) {
-                            eventHtml += ` - ${endTimeUTC}`;
+                            fullTimeString += ` - ${endTimeUTC}`;
                         }
-                        eventHtml += ' UTC'; // Append UTC label
+                        fullTimeString += ' UTC';
+                    }
+
+                    if (fullTimeString) {
+                        let displayTime = fullTimeString;
+                        if (fullTimeString.length > MAX_TIME_LENGTH) {
+                            displayTime = fullTimeString.substring(0, MAX_TIME_LENGTH - 3) + "...";
+                        }
+                        eventHtml += `<br>${displayTime}`;
                     }
                 }
                 return { html: eventHtml };
             }
             // For other views, retain original behavior (bold title, FC handles time)
-            return { html: `<b>${arg.event.title}</b>` }; 
+            // Consider applying similar truncation for title here if needed for consistency
+            let displayTitleOtherView = arg.event.title;
+            // const MAX_TITLE_LENGTH_OTHER_VIEW = 30; // Example for other views
+            // if (arg.event.title.length > MAX_TITLE_LENGTH_OTHER_VIEW) {
+            //     displayTitleOtherView = arg.event.title.substring(0, MAX_TITLE_LENGTH_OTHER_VIEW - 3) + "...";
+            // }
+            // return { html: `<b>${displayTitleOtherView}</b>` };
+            // For now, keeping it as it was for other views, only month view is in scope
+            return { html: `<b>${arg.event.title}</b>` };
         }
     });
 

--- a/static/style.css
+++ b/static/style.css
@@ -1127,37 +1127,39 @@ nav#sidebar {
 }
 */
 
-/* Ensure event content in month view does not overflow and is scrollable */
+/* Styling for FullCalendar event content container */
+/* Properties like display and position are kept for basic layout. */
+/* Text wrapping, overflow, and max-height are removed as JS now handles truncation. */
 .fc-daygrid-event .fc-event-main-frame {
-    display: block; /* Ensure block context for overflow properties */
-    position: relative; /* Usually good for containing elements */
-    white-space: normal !important;
-    overflow-wrap: break-word !important; /* For long words */
-    word-wrap: break-word !important; /* Older browsers */
-    max-height: 3.6em !important; /* Approx 2-3 lines, !important to override other FC styles */
-    overflow-y: auto !important; /* Enable vertical scrollbar, !important to override */
+    display: block;
+    position: relative;
+    /* white-space: normal !important; */ /* Removed */
+    /* overflow-wrap: break-word !important; */ /* Removed */
+    /* word-wrap: break-word !important; */ /* Removed */
+    /* max-height: 3.6em !important; */ /* Removed */
+    /* overflow-y: auto !important; */ /* Removed */
+    /* FullCalendar's default overflow behavior will apply (usually hidden for event segments) */
 }
 
-/* If FullCalendar uses a specific class for the event title container or the title itself */
-/* This applies wrapping rules directly to common FullCalendar title class. */
+/* Styling for FullCalendar event titles */
+/* Text wrapping properties removed. */
 .fc-daygrid-event .fc-event-title { /* Common class for event titles */
-    white-space: normal !important;
-    overflow-wrap: break-word !important;
-    word-wrap: break-word !important;
-    display: block; /* Assuming title should behave as a block for consistent layout with <b> */
-    /* max-height and overflow-y are typically on the container (.fc-event-main-frame) */
+    display: block; /* Kept, as titles often benefit from block display */
+    /* white-space: normal !important; */ /* Removed */
+    /* overflow-wrap: break-word !important; */ /* Removed */
+    /* word-wrap: break-word !important; */ /* Removed */
 }
 
-/* Ensure the bold tag used in calendar.js for the title also wraps aggressively */
-/* This directly targets the <b> tag within the event frame. */
+/* Styling for the bold tag used for the title in calendar.js */
+/* Text wrapping properties removed. Max-width and display are kept. */
 .fc-daygrid-event .fc-event-main-frame b {
-    display: block; /* Make it a block to control overflow and ensure it takes its own line if needed */
-    white-space: normal !important; /* Force wrapping */
-    overflow-wrap: break-word !important; /* Force break for long words */
-    word-wrap: break-word !important; /* Older browsers */
-    max-width: 100%; /* Ensure it respects container width */
+    display: block;
+    max-width: 100%; /* Can be useful to prevent breaking out of cell if FC doesn't handle it */
+    /* white-space: normal !important; */ /* Removed */
+    /* overflow-wrap: break-word !important; */ /* Removed */
+    /* word-wrap: break-word !important; */ /* Removed */
 }
 
-/* For the time part (text node after <br>), it should inherit wrapping from .fc-event-main-frame. */
-/* No specific rule needed unless further issues are observed. */
+/* Time part (text node) will inherit default text handling. */
+/* JavaScript truncation now manages its length. */
 ```


### PR DESCRIPTION
This commit changes the strategy for handling long event text in the FullCalendar month view. Previous CSS-based attempts to force text wrapping and scrolling were unsuccessful in reliably preventing text overflow.

This commit implements JavaScript-based text truncation:
1. Modified the `eventContent` function in `static/js/calendar.js`:
    - Event titles are truncated to a maximum of 20 characters, with "..." appended if longer.
    - Event time strings are truncated to a maximum of 18 characters, with "..." appended if longer.
2. Simplified `static/style.css` by removing/commenting out the previously added CSS rules for `white-space`, `overflow-wrap`, `max-height`, and `overflow-y` that were intended for text wrapping and scrolling, as they were ineffective.

This approach directly controls the length of the text being rendered, preventing it from overflowing cell boundaries.