### PR TITLE
Fix: Ensure calendar event time appears below title

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1145,6 +1145,7 @@ nav#sidebar {
 /* Text wrapping properties removed. */
 .fc-daygrid-event .fc-event-title { /* Common class for event titles */
     display: block; /* Kept, as titles often benefit from block display */
+    width: 100%; /* Ensure it takes full width to push subsequent content to a new line */
     /* white-space: normal !important; */ /* Removed */
     /* overflow-wrap: break-word !important; */ /* Removed */
     /* word-wrap: break-word !important; */ /* Removed */
@@ -1154,6 +1155,7 @@ nav#sidebar {
 /* Text wrapping properties removed. Max-width and display are kept. */
 .fc-daygrid-event .fc-event-main-frame b {
     display: block;
+    width: 100%; /* Ensure it takes full width to push subsequent content to a new line */
     max-width: 100%; /* Can be useful to prevent breaking out of cell if FC doesn't handle it */
     /* white-space: normal !important; */ /* Removed */
     /* overflow-wrap: break-word !important; */ /* Removed */


### PR DESCRIPTION
This commit addresses a layout issue in the FullCalendar month view where the event time string was appearing to the right of the event title instead of directly below it.

This was resolved by:
1. Modifying `static/style.css` to ensure the event title element (specifically the `<b>` tag generated by `eventContent` and the common `.fc-event-title` class) is styled with:
    - `display: block;`
    - `width: 100%;` This makes the title element take up the full width of its container, forcing the subsequent time string (which is preceded by a `<br>` tag in the JavaScript-generated HTML) to render on the next line.

The JavaScript-based text truncation for long titles and times remains in effect from previous commits. This change purely addresses the positioning of the time relative to the title.