### PR TITLE
Fix: Ensure calendar event time is below title by styling event anchor

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1127,6 +1127,14 @@ nav#sidebar {
 }
 */
 
+/* Ensure the main event anchor tag behaves as a block */
+a.fc-daygrid-event.fc-event { /* Targeting the <a> tag specifically */
+    display: block;
+    width: 100%; /* Ensure it takes full width of its cell container */
+    /* Note: FullCalendar's own CSS might have padding or other box model properties.
+       This change focuses on making the anchor itself a block-level element. */
+}
+
 /* Styling for FullCalendar event content container */
 /* Properties like display and position are kept for basic layout. */
 /* Text wrapping, overflow, and max-height are removed as JS now handles truncation. */


### PR DESCRIPTION
This commit addresses the persistent layout issue where the event time string appeared on the same line as the event title in FullCalendar's month view. The root cause was identified as the main event container, an anchor `<a>` tag, being `display: inline;` by default.

This commit implements the following:
1. Modified `static/style.css` to target the event anchor tag (e.g., `a.fc-daygrid-event.fc-event`).
    - Set its `display` property to `block;`.
    - Set its `width` to `100%;`. This makes the entire event container a block-level element.

2. Verified that existing styles for the inner title element (`<b>` tag or `.fc-event-title`) correctly set `display: block;` and `width: 100%;`. This ensures the title takes the full width *within* the now block-level anchor tag.

With the anchor tag behaving as a block, and the title within it also behaving as a block, the `<br>` tag in the JavaScript-generated HTML (`<b>TITLE</b><br>TIME`) now correctly forces the time string to appear on the line below the title.

JavaScript-based text truncation for long titles/times remains active.