### PR TITLE
Add delete and pagination functionality to Backup & Restore page

### DIFF
--- a/templates/admin_backup_restore.html
+++ b/templates/admin_backup_restore.html
@@ -67,6 +67,13 @@
                 <!-- Backup items will be loaded here by JavaScript -->
             </tbody>
         </table>
+        <nav aria-label="Backup pagination" id="backup-pagination-nav" style="display: none;">
+            <ul class="pagination justify-content-center">
+                <li class="page-item" id="backup-prev-page"><a class="page-link" href="#">{{ _('Previous') }}</a></li>
+                <li class="page-item" id="backup-next-page"><a class="page-link" href="#">{{ _('Next') }}</a></li>
+            </ul>
+            <p class="text-center" id="backup-page-info"></p>
+        </nav>
     </section>
 
     <hr>
@@ -179,6 +186,12 @@
         let currentBackupTaskId = null;
         let currentRestoreTaskId = null;
         let currentVerifyTaskId = null; // Added for verification tasks
+        let currentDeleteTaskId = null; // Added for deletion tasks
+
+        let currentPage = 1;
+        const backupsPerPage = 5; // Or any other number you prefer
+        let allBackups = [];
+
 
         socket.on('connect', () => {
             console.log('Socket.IO connected for backup/restore logs.');
@@ -238,8 +251,8 @@
 
             const lowerStatus = data.status.toLowerCase();
             if (lowerStatus.includes("completed successfully") || lowerStatus.includes("failed") || lowerStatus.includes("finished")) {
-                backupButton.disabled = false;
-                // Log the message that *should* be persistent
+                // backupButton.disabled = false; // Re-enable all relevant buttons
+                document.querySelectorAll('.restore-btn, .restore-dry-run-btn, .verify-backup-btn, .delete-backup-btn, #one-click-backup-btn').forEach(btn => btn.disabled = false);
                 console.log('Final backup status displayed:', backupStatusMessageEl.textContent);
                 currentBackupTaskId = null; // Clear task ID after processing final message
                 if (messageType === 'success' || (data.detail && data.detail.toUpperCase().includes("SUCCESS"))) { // also check data.detail for success for loadAvailableBackups
@@ -261,10 +274,9 @@
             restoreStatusMessageEl.className = `alert alert-${messageType === 'error' ? 'danger' : (messageType === 'success' ? 'success' : 'info')}`;
 
             const lowerStatus = data.status.toLowerCase();
-            if (lowerStatus.includes("fully completed") || lowerStatus.includes("failed") || lowerStatus.includes("error")) {
-                document.querySelectorAll('.restore-btn, .restore-dry-run-btn, .verify-backup-btn').forEach(btn => btn.disabled = false);
-                backupButton.disabled = false;
-                // Log the message that *should* be persistent
+            if (lowerStatus.includes("fully completed") || lowerStatus.includes("failed") || lowerStatus.includes("error") || lowerStatus.includes("critical error") || lowerStatus.includes("finished")) {
+                document.querySelectorAll('.restore-btn, .restore-dry-run-btn, .verify-backup-btn, .delete-backup-btn, #one-click-backup-btn').forEach(btn => btn.disabled = false);
+                // backupButton.disabled = false;
                 console.log('Final restore status displayed:', restoreStatusMessageEl.textContent);
                 currentRestoreTaskId = null; // Clear task ID after processing final message
             }
@@ -319,8 +331,9 @@
                 backupStatusMessageEl.className = `alert alert-${messageType}`;
 
                 if (!data.success) {
-                    backupButton.disabled = false;
-                    document.querySelectorAll('.restore-btn').forEach(btn => btn.disabled = false);
+                    // backupButton.disabled = false;
+                    // document.querySelectorAll('.restore-btn').forEach(btn => btn.disabled = false);
+                    document.querySelectorAll('.restore-btn, .restore-dry-run-btn, .verify-backup-btn, .delete-backup-btn, #one-click-backup-btn').forEach(btn => btn.disabled = false);
                 }
             })
             .catch(error => {
@@ -328,8 +341,9 @@
                 appendLog('backup-log-area', "{{ _('Backup request failed:') }}", error.message, 'error');
                 backupStatusMessageEl.textContent = "{{ _('Backup request failed:') }} " + error.toString();
                 backupStatusMessageEl.className = 'alert alert-danger';
-                backupButton.disabled = false;
-                document.querySelectorAll('.restore-btn').forEach(btn => btn.disabled = false);
+                // backupButton.disabled = false;
+                // document.querySelectorAll('.restore-btn').forEach(btn => btn.disabled = false);
+                document.querySelectorAll('.restore-btn, .restore-dry-run-btn, .verify-backup-btn, .delete-backup-btn, #one-click-backup-btn').forEach(btn => btn.disabled = false);
             });
         });
 
@@ -354,8 +368,10 @@
 
             // Disable buttons
             confirmSelectiveRestoreBtn.disabled = true;
-            document.querySelectorAll('.restore-btn, .restore-dry-run-btn').forEach(btn => btn.disabled = true);
-            backupButton.disabled = true;
+            // document.querySelectorAll('.restore-btn, .restore-dry-run-btn').forEach(btn => btn.disabled = true);
+            // backupButton.disabled = true;
+            document.querySelectorAll('.restore-btn, .restore-dry-run-btn, .verify-backup-btn, .delete-backup-btn, #one-click-backup-btn').forEach(btn => btn.disabled = true);
+
 
             restoreStatusMessageEl.textContent = `{{ _('Initiating selective restore...') }}`;
             restoreStatusMessageEl.className = 'alert alert-info';
@@ -392,9 +408,10 @@
                     selectiveRestoreModal.style.display = 'none'; // Close modal on successful initiation
                 } else {
                     // Re-enable buttons if initiation failed
-                    confirmSelectiveRestoreBtn.disabled = false;
-                    document.querySelectorAll('.restore-btn, .restore-dry-run-btn').forEach(btn => btn.disabled = false);
-                    backupButton.disabled = false;
+                    // confirmSelectiveRestoreBtn.disabled = false;
+                    // document.querySelectorAll('.restore-btn, .restore-dry-run-btn').forEach(btn => btn.disabled = false);
+                    // backupButton.disabled = false;
+                    document.querySelectorAll('.restore-btn, .restore-dry-run-btn, .verify-backup-btn, .delete-backup-btn, #one-click-backup-btn, #confirm-selective-restore-btn').forEach(btn => btn.disabled = false);
                 }
             })
             .catch(error => {
@@ -407,16 +424,18 @@
                 selectiveRestoreModalStatusEl.className = 'alert alert-danger';
 
                 // Re-enable buttons on catch
-                confirmSelectiveRestoreBtn.disabled = false;
-                document.querySelectorAll('.restore-btn, .restore-dry-run-btn').forEach(btn => btn.disabled = false);
-                backupButton.disabled = false;
+                // confirmSelectiveRestoreBtn.disabled = false;
+                // document.querySelectorAll('.restore-btn, .restore-dry-run-btn').forEach(btn => btn.disabled = false);
+                // backupButton.disabled = false;
+                document.querySelectorAll('.restore-btn, .restore-dry-run-btn, .verify-backup-btn, .delete-backup-btn, #one-click-backup-btn, #confirm-selective-restore-btn').forEach(btn => btn.disabled = false);
             });
         });
 
-        function loadAvailableBackups() { /* ... existing loadAvailableBackups ... */
+        function loadAvailableBackups() {
             restoreStatusMessageEl.textContent = "{{ _('Fetching available backups...') }}";
             restoreStatusMessageEl.className = 'alert alert-info';
             availableBackupsTbody.innerHTML = '<tr><td colspan="2">{{ _("Loading...") }}</td></tr>';
+            document.getElementById('backup-pagination-nav').style.display = 'none'; // Hide pagination during load
 
             fetch('/api/admin/list_backups', {
                 method: 'GET',
@@ -424,67 +443,126 @@
             })
             .then(response => response.json())
             .then(data => {
-                availableBackupsTbody.innerHTML = '';
-                if (data.success && data.backups && data.backups.length > 0) {
-                    data.backups.forEach(timestamp => {
-                        const row = availableBackupsTbody.insertRow();
-                        const cellTimestamp = row.insertCell();
-                        const cellAction = row.insertCell();
-                        let displayTimestamp = timestamp;
-                        try {
-                            const year = timestamp.substring(0,4); const month = timestamp.substring(4,6);
-                            const day = timestamp.substring(6,8); const hour = timestamp.substring(9,11);
-                            const minute = timestamp.substring(11,13); const second = timestamp.substring(13,15);
-                            displayTimestamp = `${year}-${month}-${day} ${hour}:${minute}:${second}`;
-                        } catch (e) { /* ignore */ }
-
-                        cellTimestamp.textContent = displayTimestamp;
-                        const restoreBtn = document.createElement('button');
-                        restoreBtn.textContent = "{{ _('Restore') }}";
-                        restoreBtn.className = 'btn btn-sm btn-warning restore-btn me-2'; // Added me-2 for spacing
-                        restoreBtn.setAttribute('data-timestamp', timestamp);
-                        cellAction.appendChild(restoreBtn);
-
-                        const dryRunBtn = document.createElement('button');
-                        dryRunBtn.textContent = "{{ _('Dry Run') }}";
-                        dryRunBtn.className = 'btn btn-sm btn-info restore-dry-run-btn me-2'; // Added me-2 for spacing
-                        dryRunBtn.setAttribute('data-timestamp', timestamp);
-                        cellAction.appendChild(dryRunBtn);
-
-                        const verifyBtn = document.createElement('button');
-                        verifyBtn.textContent = "{{ _('Verify') }}";
-                        verifyBtn.className = 'btn btn-sm btn-secondary verify-backup-btn';
-                        verifyBtn.setAttribute('data-timestamp', timestamp);
-                        cellAction.appendChild(verifyBtn);
-
-                    });
-                    restoreStatusMessageEl.textContent = "{{ _('Available backups loaded.') }}";
-                    restoreStatusMessageEl.className = 'alert alert-success';
-                } else if (data.success && data.backups && data.backups.length === 0) {
-                    availableBackupsTbody.innerHTML = '<tr><td colspan="2">{{ _("No backups available.") }}</td></tr>';
-                    restoreStatusMessageEl.textContent = "{{ _('No backups found.') }}";
-                    restoreStatusMessageEl.className = 'alert alert-info';
+                if (data.success && data.backups) {
+                    allBackups = data.backups; // Store all fetched backups
+                    currentPage = 1; // Reset to first page
+                    displayBackupsPage(); // Display the first page
+                    if (allBackups.length > 0) {
+                        restoreStatusMessageEl.textContent = "{{ _('Available backups loaded.') }}";
+                        restoreStatusMessageEl.className = 'alert alert-success';
+                    } else {
+                        restoreStatusMessageEl.textContent = "{{ _('No backups found.') }}";
+                        restoreStatusMessageEl.className = 'alert alert-info';
+                    }
                 } else {
+                    allBackups = [];
                     availableBackupsTbody.innerHTML = '<tr><td colspan="2">{{ _("Failed to load backups.") }}</td></tr>';
                     restoreStatusMessageEl.textContent = "{{ _('Failed to load backups:') }} " + (data.message || "{{ _('Unknown error.') }}");
                     restoreStatusMessageEl.className = 'alert alert-danger';
+                    document.getElementById('backup-pagination-nav').style.display = 'none';
                 }
             })
             .catch(error => {
+                allBackups = [];
                 console.error('List backups error:', error);
                 availableBackupsTbody.innerHTML = '<tr><td colspan="2">{{ _("Error loading backups.") }}</td></tr>';
                 restoreStatusMessageEl.textContent = "{{ _('Error fetching backups:') }} " + error.toString();
                 restoreStatusMessageEl.className = 'alert alert-danger';
+                document.getElementById('backup-pagination-nav').style.display = 'none';
             });
         }
 
+        function displayBackupsPage() {
+            availableBackupsTbody.innerHTML = '';
+            const paginationNav = document.getElementById('backup-pagination-nav');
+            const pageInfoEl = document.getElementById('backup-page-info');
+            const prevPageBtn = document.getElementById('backup-prev-page');
+            const nextPageBtn = document.getElementById('backup-next-page');
+
+            if (allBackups.length === 0) {
+                availableBackupsTbody.innerHTML = '<tr><td colspan="2">{{ _("No backups available.") }}</td></tr>';
+                paginationNav.style.display = 'none';
+                return;
+            }
+
+            const startIndex = (currentPage - 1) * backupsPerPage;
+            const endIndex = startIndex + backupsPerPage;
+            const pageBackups = allBackups.slice(startIndex, endIndex);
+
+            pageBackups.forEach(timestamp => {
+                const row = availableBackupsTbody.insertRow();
+                const cellTimestamp = row.insertCell();
+                const cellAction = row.insertCell();
+                let displayTimestamp = timestamp;
+                try {
+                    const year = timestamp.substring(0,4); const month = timestamp.substring(4,6);
+                    const day = timestamp.substring(6,8); const hour = timestamp.substring(9,11);
+                    const minute = timestamp.substring(11,13); const second = timestamp.substring(13,15);
+                    displayTimestamp = `${year}-${month}-${day} ${hour}:${minute}:${second}`;
+                } catch (e) { /* ignore */ }
+
+                cellTimestamp.textContent = displayTimestamp;
+                const restoreBtn = document.createElement('button');
+                restoreBtn.textContent = "{{ _('Restore') }}";
+                restoreBtn.className = 'btn btn-sm btn-warning restore-btn me-2';
+                restoreBtn.setAttribute('data-timestamp', timestamp);
+                cellAction.appendChild(restoreBtn);
+
+                const dryRunBtn = document.createElement('button');
+                dryRunBtn.textContent = "{{ _('Dry Run') }}";
+                dryRunBtn.className = 'btn btn-sm btn-info restore-dry-run-btn me-2';
+                dryRunBtn.setAttribute('data-timestamp', timestamp);
+                cellAction.appendChild(dryRunBtn);
+
+                const verifyBtn = document.createElement('button');
+                verifyBtn.textContent = "{{ _('Verify') }}";
+                verifyBtn.className = 'btn btn-sm btn-secondary verify-backup-btn';
+                verifyBtn.setAttribute('data-timestamp', timestamp);
+                cellAction.appendChild(verifyBtn);
+
+                const deleteBtn = document.createElement('button');
+                deleteBtn.textContent = "{{ _('Delete') }}";
+                deleteBtn.className = 'btn btn-sm btn-danger delete-backup-btn ms-2';
+                deleteBtn.setAttribute('data-timestamp', timestamp);
+                cellAction.appendChild(deleteBtn);
+            });
+
+            // Update pagination controls
+            const totalPages = Math.ceil(allBackups.length / backupsPerPage);
+            if (totalPages > 1) {
+                paginationNav.style.display = 'block';
+                pageInfoEl.textContent = `{{ _('Page') }} ${currentPage} {{ _('of') }} ${totalPages}`;
+                prevPageBtn.classList.toggle('disabled', currentPage === 1);
+                nextPageBtn.classList.toggle('disabled', endIndex >= allBackups.length);
+            } else {
+                paginationNav.style.display = 'none';
+            }
+        }
+
         listBackupsButton.addEventListener('click', loadAvailableBackups);
+
+        document.getElementById('backup-prev-page').addEventListener('click', function(e) {
+            e.preventDefault();
+            if (currentPage > 1) {
+                currentPage--;
+                displayBackupsPage();
+            }
+        });
+
+        document.getElementById('backup-next-page').addEventListener('click', function(e) {
+            e.preventDefault();
+            if ((currentPage * backupsPerPage) < allBackups.length) {
+                currentPage++;
+                displayBackupsPage();
+            }
+        });
 
         availableBackupsTable.addEventListener('click', function (event) {
             const targetButton = event.target;
             let isRestore = targetButton.classList.contains('restore-btn');
             let isDryRun = targetButton.classList.contains('restore-dry-run-btn');
-            let isVerify = targetButton.classList.contains('verify-backup-btn'); // Added
+            let isVerify = targetButton.classList.contains('verify-backup-btn');
+            let isDelete = targetButton.classList.contains('delete-backup-btn'); // Added for delete
 
             if (isVerify) {
                 const timestampToVerify = targetButton.getAttribute('data-timestamp');
@@ -492,14 +570,18 @@
                 // if (!confirm(`{{ _('Perform health check for backup') }} ${timestampToVerify}?`)) return;
 
                 currentVerifyTaskId = null; // Reset verify task ID
+                currentDeleteTaskId = null; // Clear other task IDs
+                currentRestoreTaskId = null;
+                currentBackupTaskId = null;
+
                 restoreLogAreaEl.innerHTML = ''; // Clear main log area (or use a dedicated one)
                 restoreLogAreaEl.style.display = 'block';
                 backupLogAreaEl.style.display = 'none';
                 appendLog('restore-log-area', `VERIFY: Initiating for ${timestampToVerify}...`, '', 'info');
 
                 // Disable all action buttons
-                document.querySelectorAll('.restore-btn, .restore-dry-run-btn, .verify-backup-btn').forEach(btn => btn.disabled = true);
-                backupButton.disabled = true;
+                document.querySelectorAll('.restore-btn, .restore-dry-run-btn, .verify-backup-btn, .delete-backup-btn, #one-click-backup-btn').forEach(btn => btn.disabled = true);
+                // backupButton.disabled = true;
 
                 restoreStatusMessageEl.textContent = `{{ _('Initiating verification for') }} ${timestampToVerify}...`;
                 restoreStatusMessageEl.className = 'alert alert-info';
@@ -522,8 +604,8 @@
                     restoreStatusMessageEl.className = `alert alert-${messageType}`;
 
                     if (!data.success) { // If API call itself fails to initiate
-                        document.querySelectorAll('.restore-btn, .restore-dry-run-btn, .verify-backup-btn').forEach(btn => btn.disabled = false);
-                        backupButton.disabled = false;
+                        document.querySelectorAll('.restore-btn, .restore-dry-run-btn, .verify-backup-btn, .delete-backup-btn, #one-click-backup-btn').forEach(btn => btn.disabled = false);
+                        // backupButton.disabled = false;
                         currentVerifyTaskId = null; // Clear if initiation failed
                     }
                     // Detailed results and final button re-enabling will be handled by the 'verify_backup_progress' socket listener
@@ -534,9 +616,65 @@
                     appendLog('restore-log-area', errorMsg, '', 'error');
                     restoreStatusMessageEl.textContent = errorMsg;
                     restoreStatusMessageEl.className = 'alert alert-danger';
-                    document.querySelectorAll('.restore-btn, .restore-dry-run-btn, .verify-backup-btn').forEach(btn => btn.disabled = false);
-                    backupButton.disabled = false;
+                    document.querySelectorAll('.restore-btn, .restore-dry-run-btn, .verify-backup-btn, .delete-backup-btn, #one-click-backup-btn').forEach(btn => btn.disabled = false);
+                    // backupButton.disabled = false;
                     currentVerifyTaskId = null; // Clear on error
+                });
+
+            } else if (isDelete) {
+                const backup_timestamp = targetButton.getAttribute('data-timestamp');
+                let displayTimestamp = backup_timestamp;
+                 try { // Format for display
+                    const year = backup_timestamp.substring(0,4); const month = backup_timestamp.substring(4,6);
+                    const day = backup_timestamp.substring(6,8); const hour = backup_timestamp.substring(9,11);
+                    const minute = backup_timestamp.substring(11,13); const second = backup_timestamp.substring(13,15);
+                    displayTimestamp = `${year}-${month}-${day} ${hour}:${minute}:${second}`;
+                } catch (e) { /* ignore */ }
+
+                if (!confirm("{{ _('Are you sure you want to delete backup') }} '" + displayTimestamp + "'? {{ _('This action cannot be undone.') }}")) {
+                    return;
+                }
+
+                currentDeleteTaskId = null;
+                currentRestoreTaskId = null; // Clear other task IDs
+                currentVerifyTaskId = null;
+                currentBackupTaskId = null;
+
+                restoreLogAreaEl.innerHTML = '';
+                restoreLogAreaEl.style.display = 'block';
+                backupLogAreaEl.style.display = 'none';
+                appendLog('restore-log-area', "{{ _('Initiating delete request for') }} " + displayTimestamp + "...", '', 'info');
+
+                document.querySelectorAll('.restore-btn, .restore-dry-run-btn, .verify-backup-btn, .delete-backup-btn, #one-click-backup-btn').forEach(btn => btn.disabled = true);
+
+                restoreStatusMessageEl.textContent = "{{ _('Deleting backup...') }}";
+                restoreStatusMessageEl.className = 'alert alert-info';
+
+                fetch('/api/admin/delete_backup/' + backup_timestamp, {
+                    method: 'POST',
+                    headers: { 'X-CSRFToken': csrfToken, 'Accept': 'application/json' }
+                })
+                .then(response => response.json())
+                .then(data => {
+                    currentDeleteTaskId = data.task_id;
+                    const messageType = data.success ? 'info' : 'error';
+                    appendLog('restore-log-area', data.message || (data.success ? `{{ _('Deletion process for ${displayTimestamp} started.') }}` : `{{ _('Failed to start deletion for ${displayTimestamp}.') }}`), `Task ID: ${data.task_id || 'N/A'}`, messageType);
+                    restoreStatusMessageEl.textContent = data.message;
+                    restoreStatusMessageEl.className = `alert alert-${messageType}`;
+
+                    if (!data.success) { // If API call itself fails to initiate
+                         document.querySelectorAll('.restore-btn, .restore-dry-run-btn, .verify-backup-btn, .delete-backup-btn, #one-click-backup-btn').forEach(btn => btn.disabled = false);
+                         currentDeleteTaskId = null;
+                    }
+                    // Socket listener 'backup_delete_progress' will handle final re-enable and list refresh
+                })
+                .catch(error => {
+                    console.error('Delete backup error:', error);
+                    appendLog('restore-log-area', `{{ _('Delete request for ${displayTimestamp} failed:') }}`, error.message, 'error');
+                    restoreStatusMessageEl.textContent = `{{ _('Delete request for ${displayTimestamp} failed:') }} ${error.toString()}`;
+                    restoreStatusMessageEl.className = 'alert alert-danger';
+                    document.querySelectorAll('.restore-btn, .restore-dry-run-btn, .verify-backup-btn, .delete-backup-btn, #one-click-backup-btn').forEach(btn => btn.disabled = false);
+                    currentDeleteTaskId = null;
                 });
 
             } else if (isRestore || isDryRun) { // Logic for Restore and Dry Run
@@ -548,6 +686,12 @@
                     const minute = timestampToProcess.substring(11,13); const second = timestampToProcess.substring(13,15);
                     displayTimestamp = `${year}-${month}-${day} ${hour}:${minute}:${second}`;
                 } catch (e) { /* ignore */ }
+
+                currentRestoreTaskId = null; // Reset restore task ID
+                currentDeleteTaskId = null; // Clear other task IDs
+                currentVerifyTaskId = null;
+                currentBackupTaskId = null;
+
 
                 let confirmationMessage = "";
                 let endpoint = "";
@@ -567,14 +711,14 @@
                     return;
                 }
 
-                currentRestoreTaskId = null;
+                currentRestoreTaskId = null; // This was already here, ensure it's the active task type
                 restoreLogAreaEl.innerHTML = '';
                 restoreLogAreaEl.style.display = 'block';
                 backupLogAreaEl.style.display = 'none';
                 appendLog('restore-log-area', `{{ _('Initiating') }} ${actionVerb} ${displayTimestamp}...`, '', 'info');
 
-                document.querySelectorAll('.restore-btn, .restore-dry-run-btn').forEach(btn => btn.disabled = true);
-                backupButton.disabled = true;
+                document.querySelectorAll('.restore-btn, .restore-dry-run-btn, .verify-backup-btn, .delete-backup-btn, #one-click-backup-btn').forEach(btn => btn.disabled = true);
+                // backupButton.disabled = true; // Covered by above selector
                 restoreStatusMessageEl.textContent = `{{ _('Initiating') }} ${actionVerb} ${displayTimestamp}... {{ _('This may take a while. Please do not navigate away.') }}`;
                 restoreStatusMessageEl.className = 'alert alert-info';
 
@@ -598,8 +742,9 @@
                     restoreStatusMessageEl.className = `alert alert-${messageType}`;
 
                     if (!data.success) {
-                        document.querySelectorAll('.restore-btn, .restore-dry-run-btn').forEach(btn => btn.disabled = false);
-                        backupButton.disabled = false;
+                        // document.querySelectorAll('.restore-btn, .restore-dry-run-btn').forEach(btn => btn.disabled = false);
+                        // backupButton.disabled = false;
+                        document.querySelectorAll('.restore-btn, .restore-dry-run-btn, .verify-backup-btn, .delete-backup-btn, #one-click-backup-btn').forEach(btn => btn.disabled = false);
                     }
                     // If it's a dry run and successful, display actions from HTTP response for immediate feedback
                     if (isDryRun && data.success && data.actions && Array.isArray(data.actions)) {
@@ -620,10 +765,11 @@
                     appendLog('restore-log-area', `{{ _('Request for ${actionVerb} ${displayTimestamp} failed:') }}`, error.message, 'error');
                     restoreStatusMessageEl.textContent = `{{ _('Request for ${actionVerb} ${displayTimestamp} failed:') }} ${error.toString()}`;
                     restoreStatusMessageEl.className = 'alert alert-danger';
-                    document.querySelectorAll('.restore-btn, .restore-dry-run-btn').forEach(btn => btn.disabled = false);
-                    backupButton.disabled = false;
+                    // document.querySelectorAll('.restore-btn, .restore-dry-run-btn').forEach(btn => btn.disabled = false);
+                    // backupButton.disabled = false;
+                    document.querySelectorAll('.restore-btn, .restore-dry-run-btn, .verify-backup-btn, .delete-backup-btn, #one-click-backup-btn').forEach(btn => btn.disabled = false);
                 });
-            } else if (targetButton.classList.contains('restore-btn')) { // Modified to open modal
+            } else if (targetButton.classList.contains('restore-btn')) { // This is now the entry point for Selective Restore Modal
                 const timestampToRestore = targetButton.getAttribute('data-timestamp');
                 let displayTimestamp = timestampToRestore;
                  try { // Format for display
@@ -721,16 +867,45 @@
                     });
                 }
                 // Re-enable buttons on completion
-                document.querySelectorAll('.restore-btn, .restore-dry-run-btn, .verify-backup-btn').forEach(btn => btn.disabled = false);
-                backupButton.disabled = false;
+                document.querySelectorAll('.restore-btn, .restore-dry-run-btn, .verify-backup-btn, .delete-backup-btn, #one-click-backup-btn').forEach(btn => btn.disabled = false);
+                // backupButton.disabled = false; // Covered by above
                 currentVerifyTaskId = null;
-            } else if (data.status && (data.status.toLowerCase().includes("failed") || data.status.toLowerCase().includes("error") || data.status.toLowerCase().includes("missing"))) {
+            } else if (data.status && (data.status.toLowerCase().includes("failed") || data.status.toLowerCase().includes("error") || data.status.toLowerCase().includes("missing") || data.status.toLowerCase().includes("critical") )) {
                  // Re-enable buttons if an intermediate error message implies failure for the task
-                document.querySelectorAll('.restore-btn, .restore-dry-run-btn, .verify-backup-btn').forEach(btn => btn.disabled = false);
-                backupButton.disabled = false;
+                document.querySelectorAll('.restore-btn, .restore-dry-run-btn, .verify-backup-btn, .delete-backup-btn, #one-click-backup-btn').forEach(btn => btn.disabled = false);
+                // backupButton.disabled = false; // Covered by above
                 currentVerifyTaskId = null;
             }
         });
+
+        // Listener for Backup Deletion Progress
+        socket.on('backup_delete_progress', function(data) {
+            console.log('Backup delete progress event:', data);
+            if (data.task_id !== currentDeleteTaskId) return;
+
+            let messageType = 'info';
+            if (data.detail && data.detail.toUpperCase().includes('ERROR')) messageType = 'error';
+            else if (data.detail && data.detail.toUpperCase().includes('SUCCESS')) messageType = 'success';
+            else if (data.status && data.status.toLowerCase().includes('failed')) messageType = 'error';
+
+
+            appendLog('restore-log-area', data.status, data.detail, messageType);
+            restoreStatusMessageEl.textContent = `${data.status}${data.detail ? ' ('+data.detail+')':''}`;
+            restoreStatusMessageEl.className = `alert alert-${messageType === 'error' ? 'danger' : (messageType === 'success' ? 'success' : 'info')}`;
+
+            const lowerStatus = data.status.toLowerCase();
+            const lowerDetail = data.detail ? data.detail.toLowerCase() : "";
+
+            if (lowerStatus.includes("finished") || lowerStatus.includes("failed") || lowerStatus.includes("error") || lowerDetail.includes("success") || lowerDetail.includes("failure") || lowerDetail.includes("critical_error")) {
+                document.querySelectorAll('.restore-btn, .restore-dry-run-btn, .verify-backup-btn, .delete-backup-btn, #one-click-backup-btn').forEach(btn => btn.disabled = false);
+                console.log('Final delete status displayed:', restoreStatusMessageEl.textContent);
+                currentDeleteTaskId = null;
+                if (messageType === 'success' || (data.detail && data.detail.toUpperCase().includes("SUCCESS"))) {
+                    loadAvailableBackups(); // Refresh list on successful deletion
+                }
+            }
+        });
+
 
         function toggleDayOfWeekVisibility() { /* ... existing ... */
             if (scheduleTypeSelect.value === 'weekly') {


### PR DESCRIPTION
This commit introduces two main features to the Admin Backup & Restore page:

1.  **Delete Backup Functionality:**
    *   Adds a "Delete" button for each backup listed under "One Click Restore".
    *   Implements a new API endpoint (`/api/admin/delete_backup/<timestamp>`) to handle the deletion request.
    *   The backend logic in `azure_backup.py`'s `delete_backup_set` function was verified and enhanced to ensure it correctly removes all components of a backup set (database, map configuration, media files, and manifest) from Azure File Share.
    *   Frontend JavaScript handles user confirmation, API calls, and updates the UI based on the response, including SocketIO progress messages.
    *   Audit logs are created for deletion attempts and outcomes.

2.  **Pagination for Backup List:**
    *   The list of available backups is now paginated, displaying 5 backups per page.
    *   Client-side JavaScript handles the pagination logic, including "Previous" and "Next" navigation controls.
    *   This improves usability for sites with a large number of backups.

Both features include appropriate error handling, logging, and user feedback mechanisms.