### PR TITLE
Fix: Hide Selective Restore modal on page load

### DIFF
--- a/templates/admin_backup_restore.html
+++ b/templates/admin_backup_restore.html
@@ -79,7 +79,7 @@
     <hr>
 
     <!-- Selective Restore Modal -->
-    <div id="selective-restore-modal" class="modal">
+    <div id="selective-restore-modal" class="modal" style="display: none !important;">
         <div class="modal-content">
             <span class="close-modal-btn" id="close-selective-restore-modal">&times;</span>
             <h3>{{ _('Selective Restore Options') }}</h3>


### PR DESCRIPTION
The "Selective Restore Options" modal was incorrectly appearing when the Backup & Restore page was first loaded.

This commit ensures the modal is hidden by default by adding an inline style `display: none !important;` to the modal's main div. The existing JavaScript logic for the "Restore" button correctly overrides this style to `display: block;` when you click the button, ensuring the modal appears only when intended.