### PR TITLE
Fix: Correctly update backup completion status on web UI

### DIFF
--- a/templates/admin_backup_restore.html
+++ b/templates/admin_backup_restore.html
@@ -249,8 +249,7 @@
             backupStatusMessageEl.className = `alert alert-${messageType === 'error' ? 'danger' : (messageType === 'success' ? 'success' : 'info')}`;
 
 
-            const lowerStatus = data.status.toLowerCase();
-            if (lowerStatus.includes("completed successfully") || lowerStatus.includes("failed") || lowerStatus.includes("finished")) {
+            if (data.status === "Backup Completed Successfully." || data.status === "Backup Failed. Check server logs for details.") {
                 // backupButton.disabled = false; // Re-enable all relevant buttons
                 document.querySelectorAll('.restore-btn, .restore-dry-run-btn, .verify-backup-btn, .delete-backup-btn, #one-click-backup-btn').forEach(btn => btn.disabled = false);
                 console.log('Final backup status displayed:', backupStatusMessageEl.textContent);


### PR DESCRIPTION
The previous implementation had an issue where the frontend JavaScript would prematurely interpret intermediate backup progress messages (like "Main backup process completed...") as the final completion state. This was due to a broad check for keywords like "completed" or "finished".

This commit refines the condition in the `socket.on('backup_progress', ...)` handler within `templates/admin_backup_restore.html`. The check for task completion is now more specific, looking for the exact final status messages emitted by the backend: "Backup Completed Successfully." or "Backup Failed. Check server logs for details.".

This ensures that the UI accurately reflects the true completion status of the backup process and that related UI elements (like button states) are updated only upon actual termination of the backup task.