### PR TITLE
Refine: Update backup completion messages for UI consistency

### DIFF
--- a/azure_backup.py
+++ b/azure_backup.py
@@ -540,9 +540,9 @@ def create_full_backup(timestamp_str, map_config_data=None, socketio_instance=No
             # overall_success might be set to False here if manifest is critical, but current plan implies it's best effort after successful backup.
 
     if overall_success:
-        _emit_progress(socketio_instance, task_id, 'backup_progress', 'Backup Completed Successfully.', 'SUCCESS')
+        _emit_progress(socketio_instance, task_id, 'backup_progress', f'Backup completed with overall success: True', 'SUCCESS')
     else:
-        _emit_progress(socketio_instance, task_id, 'backup_progress', 'Backup Failed. Check server logs for details.', 'ERROR')
+        _emit_progress(socketio_instance, task_id, 'backup_progress', f'Backup completed with overall success: False. Check server logs for details.', 'ERROR')
     return overall_success
 
 

--- a/templates/admin_backup_restore.html
+++ b/templates/admin_backup_restore.html
@@ -249,7 +249,7 @@
             backupStatusMessageEl.className = `alert alert-${messageType === 'error' ? 'danger' : (messageType === 'success' ? 'success' : 'info')}`;
 
 
-            if (data.status === "Backup Completed Successfully." || data.status === "Backup Failed. Check server logs for details.") {
+            if (data.status === "Backup completed with overall success: True" || data.status.startsWith("Backup completed with overall success: False")) {
                 // backupButton.disabled = false; // Re-enable all relevant buttons
                 document.querySelectorAll('.restore-btn, .restore-dry-run-btn, .verify-backup-btn, .delete-backup-btn, #one-click-backup-btn').forEach(btn => btn.disabled = false);
                 console.log('Final backup status displayed:', backupStatusMessageEl.textContent);


### PR DESCRIPTION
This commit addresses your feedback to display a more specific message on the web UI upon backup completion.

Changes include:
1. Modified `azure_backup.py`:
   - The `create_full_backup` function now emits Socket.IO messages stating "Backup completed with overall success: True" for success, and "Backup completed with overall success: False. Check server logs for details." for failures.

2. Modified `templates/admin_backup_restore.html`:
   - The JavaScript `socket.on('backup_progress', ...)` handler's completion condition has been updated to precisely match these new status strings. This ensures that the UI accurately reflects the final status as desired and avoids any ambiguity with intermediate progress messages.

This ensures the web status directly reflects the 'completed with overall success: True/False' state.