### PR TITLE
Fix: Resolve ImportError in init_setup.py

### DIFF
--- a/routes/ui.py
+++ b/routes/ui.py
@@ -5,9 +5,9 @@ from flask_login import login_required, current_user, logout_user
 from datetime import datetime, timezone
 
 # Assuming Booking model is in models.py
-from ..models import Booking
+from models import Booking
 # Assuming add_audit_log is in utils.py
-from ..utils import add_audit_log
+from utils import add_audit_log
 
 # The template_folder is specified relative to the blueprint's location.
 # If app.py sets a global template_folder, and this blueprint's templates


### PR DESCRIPTION
I've changed the relative imports in `routes/ui.py` to absolute imports.
- `from ..models import Booking` is now `from models import Booking`
- `from ..utils import add_audit_log` is now `from utils import add_audit_log`

This resolves the `ImportError: attempted relative import beyond top-level package` that occurred when running `init_setup.py` directly. The script, being at the project root, establishes the root as the top-level package, and absolute imports from this root are now used.