### PR TITLE
Fix: Add APScheduler to dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ gunicorn
 
 azure-storage-file-share
 
+APScheduler


### PR DESCRIPTION
Added `APScheduler` to `requirements.txt` to resolve the `ModuleNotFoundError: No module named 'apscheduler'` that occurred when running `init_setup.py`.

The `app_factory.py` file imports `APScheduler`, indicating it is a required dependency for the project.