### PR TITLE
Fix: Resolve KeyError for UPLOAD_FOLDER in app_factory.py

### DIFF
--- a/app_factory.py
+++ b/app_factory.py
@@ -73,10 +73,6 @@ def create_app(config_object=config):
     # This logic was in app.py; it's better here or in config.py itself.
     # config.py now handles directory creation, so this might be redundant.
     # However, double-checking critical folders controlled by app.config is fine.
-    if not os.path.exists(app.config['UPLOAD_FOLDER']):
-        os.makedirs(app.config['UPLOAD_FOLDER'])
-    if not os.path.exists(app.config['RESOURCE_UPLOAD_FOLDER']):
-        os.makedirs(app.config['RESOURCE_UPLOAD_FOLDER'])
     if not os.path.exists(app.config['DATA_DIR']): # From config.py
         os.makedirs(app.config['DATA_DIR'])
 


### PR DESCRIPTION
Removed lines from `app_factory.py` that attempted to access `app.config['UPLOAD_FOLDER']` and `app.config['RESOURCE_UPLOAD_FOLDER']`. These generic configuration keys are not defined in `config.py`.

The `config.py` file already defines more specific keys like `FLOOR_MAP_UPLOAD_FOLDER` and `RESOURCE_IMAGE_UPLOAD_FOLDER`, and also ensures these directories are created upon loading the configuration.

This change prevents the `KeyError: 'UPLOAD_FOLDER'` that occurred during application initialization when running `app.py`.