### PR TITLE
Fix: Initialize LoginManager with the Flask app

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -213,6 +213,7 @@ def api_auth_status():
 
 # --- Initialization Function ---
 def init_auth(app, login_manager_instance, oauth_instance, csrf_instance):
+    login_manager_instance.init_app(app)
     # login_manager is already initialized in extensions.py, just configure it
     login_manager_instance.login_view = 'ui.serve_login' # Assuming serve_login will be in 'ui' blueprint
     login_manager_instance.login_message = 'Please log in to access this page.'


### PR DESCRIPTION
I've added the call `login_manager_instance.init_app(app)` to the `init_auth` function in `auth.py`.

This was missing and caused an `AttributeError: 'Flask' object has no attribute 'login_manager'` when Flask-Login attempted to access `current_app.login_manager` (e.g., during `current_user` access).

Properly initializing the LoginManager instance with the app ensures that Flask-Login is correctly integrated and operational.