### PR TITLE
Fix: Provide Flask app context to scheduler jobs

### DIFF
--- a/app_factory.py
+++ b/app_factory.py
@@ -164,11 +164,11 @@ def create_app(config_object=config):
 
         # Add jobs from scheduler_tasks.py
         if cancel_unchecked_bookings:
-            scheduler.add_job(cancel_unchecked_bookings, 'interval', minutes=app.config.get('AUTO_CANCEL_CHECK_INTERVAL_MINUTES', 5))
+            scheduler.add_job(cancel_unchecked_bookings, 'interval', minutes=app.config.get('AUTO_CANCEL_CHECK_INTERVAL_MINUTES', 5), args=[app])
         if apply_scheduled_resource_status_changes:
-            scheduler.add_job(apply_scheduled_resource_status_changes, 'interval', minutes=1)
+            scheduler.add_job(apply_scheduled_resource_status_changes, 'interval', minutes=1, args=[app])
         if run_scheduled_backup_job:
-            scheduler.add_job(run_scheduled_backup_job, 'interval', minutes=app.config.get('SCHEDULER_BACKUP_JOB_INTERVAL_MINUTES', 60)) # New config option
+            scheduler.add_job(run_scheduled_backup_job, 'interval', minutes=app.config.get('SCHEDULER_BACKUP_JOB_INTERVAL_MINUTES', 60), args=[app]) # New config option
 
         if azure_backup_if_changed: # Legacy Azure backup
              scheduler.add_job(azure_backup_if_changed, 'interval', minutes=app.config.get('AZURE_BACKUP_INTERVAL_MINUTES', 60))


### PR DESCRIPTION
Modified scheduled task functions in `scheduler_tasks.py` to accept an explicit `app` argument and use it to create an application context (e.g., `with app.app_context():`). Access to `app.logger` and `app.config` now also uses the passed `app` instance instead of `current_app`.

Updated `app_factory.py` to pass the Flask `app` instance to these scheduler jobs using the `args=[app]` parameter in `scheduler.add_job()`.

This resolves the `RuntimeError: Working outside of application context.` that occurred when scheduled jobs tried to access Flask application features without an active context.