### PR TITLE
Fix: Correct payload key for bulk resource edit

### DIFF
--- a/static/js/resource_management.js
+++ b/static/js/resource_management.js
@@ -405,7 +405,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 await apiCall('/api/admin/resources/bulk', {
                     method: 'PUT',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ ids, fields })
+                    body: JSON.stringify({ ids, changes: fields })
                 }, bulkEditFormStatus);
                 await fetchAndDisplayResources();
                 setTimeout(() => { bulkEditModal.style.display = 'none'; }, 500);


### PR DESCRIPTION
The frontend was sending `fields` instead of `changes` in the bulk edit payload, causing a 400 error. This commit updates `static/js/resource_management.js` to use the correct key `changes`.