### PR TITLE
Fix: Gracefully handle 'No changes supplied' on booking edit

### DIFF
--- a/static/js/calendar.js
+++ b/static/js/calendar.js
@@ -206,18 +206,29 @@ document.addEventListener('DOMContentLoaded', () => {
             cebmStatusMessage.textContent = response.message || 'Booking updated successfully!';
             cebmStatusMessage.className = 'status-message success-message'; // Ensure you have .success-message CSS
 
-            window.location.href = '/my_bookings'; // Redirect after successful save
-
+            // Redirect and clear message after a short delay
             setTimeout(() => {
                 calendarEditBookingModal.style.display = 'none';
                 cebmStatusMessage.textContent = ''; // Clear message
-                 cebmStatusMessage.className = 'status-message';
-            }, 1500); // Close modal after a short delay
+                cebmStatusMessage.className = 'status-message'; // Reset class
+                window.location.href = '/my_bookings';
+            }, 1500);
 
         } catch (error) {
             console.error('Error updating booking:', error);
-            cebmStatusMessage.textContent = error.message || 'Failed to update booking.';
-            cebmStatusMessage.className = 'status-message error-message';
+            if (error.message && error.message.includes("No changes supplied.")) {
+                cebmStatusMessage.textContent = 'No changes detected. Booking details are already up to date.';
+                cebmStatusMessage.className = 'status-message success-message'; // Treat as success
+                setTimeout(() => {
+                    calendarEditBookingModal.style.display = 'none';
+                    cebmStatusMessage.textContent = ''; // Clear message
+                    cebmStatusMessage.className = 'status-message'; // Reset class
+                    window.location.href = '/my_bookings';
+                }, 1500);
+            } else {
+                cebmStatusMessage.textContent = error.message || 'Failed to update booking.';
+                cebmStatusMessage.className = 'status-message error-message';
+            }
         } finally {
             cebmSaveChangesBtn.disabled = false;
             cebmSaveChangesBtn.textContent = 'Save Changes';


### PR DESCRIPTION
This commit refines the behavior of the booking edit modal in the calendar:

- Modifies `static/js/calendar.js` in the `saveBookingChanges` function's error handling.
- When the backend API returns a "No changes supplied." message (typically a 400 Bad Request), the frontend now treats this as a successful user interaction.
- Instead of showing an error, it displays a message like "No changes detected. Booking details are already up to date.", closes the modal, and redirects to the 'My Bookings' page.
- This improves the user experience by providing clear feedback when no actual database update was necessary, rather than presenting it as an error.
- Standard error handling applies for other types of errors.