### PR TITLE
Refactor: Update calendar edit booking UX

### DIFF
--- a/static/js/calendar.js
+++ b/static/js/calendar.js
@@ -154,7 +154,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // Function to handle saving changes from the modal
     async function saveBookingChanges(bookingId, title, calendarEventToUpdate) { // Signature updated
         cebmSaveChangesBtn.disabled = true;
-        cebmSaveChangesBtn.textContent = 'Saving...';
+        cebmSaveChangesBtn.textContent = 'Processing...';
         cebmStatusMessage.textContent = '';
         cebmStatusMessage.className = 'status-message';
 
@@ -205,13 +205,14 @@ document.addEventListener('DOMContentLoaded', () => {
 
             cebmStatusMessage.textContent = response.message || 'Booking updated successfully!';
             cebmStatusMessage.className = 'status-message success-message'; // Ensure you have .success-message CSS
+            calendar.refetchEvents(); // Refresh calendar events
 
-            // Redirect and clear message after a short delay
+            // Close modal and clear message after a short delay
             setTimeout(() => {
                 calendarEditBookingModal.style.display = 'none';
                 cebmStatusMessage.textContent = ''; // Clear message
                 cebmStatusMessage.className = 'status-message'; // Reset class
-                window.location.href = '/my_bookings';
+                // window.location.href = '/my_bookings'; // REMOVED
             }, 1500);
 
         } catch (error) {
@@ -219,11 +220,13 @@ document.addEventListener('DOMContentLoaded', () => {
             if (error.message && error.message.includes("No changes supplied.")) {
                 cebmStatusMessage.textContent = 'No changes detected. Booking details are already up to date.';
                 cebmStatusMessage.className = 'status-message success-message'; // Treat as success
+                calendar.refetchEvents(); // Refresh calendar events
+
                 setTimeout(() => {
                     calendarEditBookingModal.style.display = 'none';
                     cebmStatusMessage.textContent = ''; // Clear message
                     cebmStatusMessage.className = 'status-message'; // Reset class
-                    window.location.href = '/my_bookings';
+                    // window.location.href = '/my_bookings'; // REMOVED
                 }, 1500);
             } else {
                 cebmStatusMessage.textContent = error.message || 'Failed to update booking.';


### PR DESCRIPTION
This commit implements user feedback for the booking edit modal on the calendar page:

1.  Button Behavior:
    - The 'Save Changes' button text is now 'Processing...' (was 'Saving...') during the API call.
    - Confirmed that the button is disabled upon submission and re-enabled in the `finally` block.

2.  Post-Submission Flow:
    - Removed the redirect to '/my_bookings' after a booking is successfully updated or when "No changes supplied" is detected.
    - You now stay on the calendar page.
    - `calendar.refetchEvents()` is called in both success scenarios to update the calendar display in place, ensuring you see the most current booking information without a page reload.