### PR TITLE
Fix: Ensure correct button reference for UI updates in calendar modal

### DIFF
--- a/static/js/calendar.js
+++ b/static/js/calendar.js
@@ -152,9 +152,9 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     // Function to handle saving changes from the modal
-    async function saveBookingChanges(bookingId, title, calendarEventToUpdate) { // Signature updated
-        cebmSaveChangesBtn.disabled = true;
-        cebmSaveChangesBtn.textContent = 'Processing...';
+    async function saveBookingChanges(buttonElement, bookingId, title, calendarEventToUpdate) { // Signature updated
+        buttonElement.disabled = true;
+        buttonElement.textContent = 'Processing...';
         cebmStatusMessage.textContent = '';
         cebmStatusMessage.className = 'status-message';
 
@@ -233,8 +233,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 cebmStatusMessage.className = 'status-message error-message';
             }
         } finally {
-            cebmSaveChangesBtn.disabled = false;
-            cebmSaveChangesBtn.textContent = 'Save Changes';
+            buttonElement.disabled = false;
+            buttonElement.textContent = 'Save Changes';
         }
     }
 
@@ -308,6 +308,7 @@ document.addEventListener('DOMContentLoaded', () => {
             if (currentSaveBtn) {
                 currentSaveBtn.onclick = () => {
                     saveBookingChanges(
+                        currentSaveBtn, // Pass the button instance
                         cebmBookingId.value,
                         cebmBookingTitle.value,
                         info.event


### PR DESCRIPTION
This commit resolves an issue where the 'Save Changes' button in the calendar's edit booking modal was not correctly visually updating its disabled state and text content (e.g., to 'Processing...') during an AJAX call.

The `saveBookingChanges` function in `static/js/calendar.js` has been refactored to accept the button DOM element as a direct parameter. The `eventClick` handler, which sets up the `onclick` event for the save button (potentially a cloned button), now passes the correct button reference to `saveBookingChanges`.

This ensures that all UI manipulations (disabling, changing text to 'Processing...', and re-enabling) are performed on the actual button instance that you interact with, providing correct visual feedback.