### PR TITLE
feat: Restrict booking updates to available slots

### DIFF
--- a/templates/my_bookings.html
+++ b/templates/my_bookings.html
@@ -53,20 +53,14 @@
                             <input type="text" class="form-control" id="new-booking-title" required>
                         </div>
                         <div class="mb-3">
-                            <label for="new-booking-start-date" class="form-label">{{ _('New Start Date') }}:</label>
-                            <input type="date" class="form-control" id="new-booking-start-date">
+                            <label for="modal-booking-date" class="form-label">{{ _('New Date') }}:</label>
+                            <input type="date" class="form-control" id="modal-booking-date">
                         </div>
                         <div class="mb-3">
-                            <label for="new-booking-start-time" class="form-label">{{ _('New Start Time') }}:</label>
-                            <input type="time" class="form-control" id="new-booking-start-time">
-                        </div>
-                        <div class="mb-3">
-                            <label for="new-booking-end-date" class="form-label">{{ _('New End Date') }}:</label>
-                            <input type="date" class="form-control" id="new-booking-end-date">
-                        </div>
-                        <div class="mb-3">
-                            <label for="new-booking-end-time" class="form-label">{{ _('New End Time') }}:</label>
-                            <input type="time" class="form-control" id="new-booking-end-time">
+                            <label for="modal-available-slots-select" class="form-label">{{ _('Available Time Slots') }}:</label>
+                            <select class="form-control" id="modal-available-slots-select">
+                                <!-- Options will be populated by JavaScript -->
+                            </select>
                         </div>
                         <div id="update-modal-status" class="alert" style="display:none;"></div>
                     </form>


### PR DESCRIPTION
Implements changes to the "Update Booking" functionality on the "My Bookings" page to only show available time slots to you.

Key changes:

- Modified `static/js/my_bookings.js`:
    - Replaced free-form date/time inputs in the update modal with a date picker and a dropdown for time slots.
    - On date selection, the script now fetches your other bookings and resource maintenance status.
    - It calculates available slots based on predefined intervals (08:00-12:00, 13:00-17:00, 08:00-17:00 UTC).
    - Availability is determined by checking against past dates, resource maintenance periods, and your own existing bookings on other resources for the selected day.
    - The save logic now uses the selected date and time slot.

- Adjusted `templates/my_bookings.html`:
    - Updated the "Update Booking" modal's HTML to use the new date picker and time slot select dropdown, removing the old input fields.

- Enhanced `routes/api_bookings.py`:
    - Added a server-side validation in the `update_booking_by_user` function to prevent you from updating a booking to a time that conflicts with another of your own bookings on a different resource. This provides an additional layer of data integrity.

The available slot calculation logic ensures that you cannot select times that are in the past, conflict with your existing schedule, or are unavailable due to resource maintenance. The server-side checks further ensure booking integrity.