### PR TITLE
feat: Improve Update Booking modal UX

### DIFF
--- a/static/js/my_bookings.js
+++ b/static/js/my_bookings.js
@@ -271,7 +271,10 @@ document.addEventListener('DOMContentLoaded', () => {
         // Optional: Check if any actual change was made (more complex with new date/slot structure)
         // For now, we assume if "Save" is clicked with valid inputs, an update is intended.
 
-        showLoading(updateModalStatusDiv, 'Saving changes...');
+        const originalButtonText = saveBookingTitleBtn.textContent;
+        saveBookingTitleBtn.textContent = 'Processing...';
+        saveBookingTitleBtn.disabled = true;
+        showLoading(updateModalStatusDiv, 'Saving changes...'); // This might be redundant if button text changes
 
         try {
             const updatedBooking = await apiCall(`/api/bookings/${bookingId}`, {
@@ -302,7 +305,15 @@ document.addEventListener('DOMContentLoaded', () => {
             // fetchAndDisplayBookings(); 
         } catch (error) {
             console.error('Error updating booking:', error);
-            showError(updateModalStatusDiv, error.message || 'Failed to update booking.');
+            // Ensure showError is available or use showStatusMessage
+            if (typeof showError === 'function') {
+                 showError(updateModalStatusDiv, error.message || 'Failed to update booking.');
+            } else {
+                showStatusMessage(updateModalStatusDiv, error.message || 'Failed to update booking.', 'danger');
+            }
+        } finally {
+            saveBookingTitleBtn.textContent = originalButtonText;
+            saveBookingTitleBtn.disabled = false;
         }
     });
 

--- a/templates/my_bookings.html
+++ b/templates/my_bookings.html
@@ -66,7 +66,6 @@
                     </form>
                 </div>
                 <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ _('Close') }}</button>
                     <button type="button" class="btn btn-primary" id="save-booking-title-btn">{{ _('Save Changes') }}</button>
                 </div>
             </div>


### PR DESCRIPTION
Implements UI/UX enhancements for the "Update Booking" modal on the "My Bookings" page based on your feedback.

Changes:

1.  **"Save Changes" Button State:**
    - When the "Save Changes" button is clicked, its text now changes to "Processing..." and the button is disabled.
    - This provides clear visual feedback to you that the action is in progress and prevents multiple submissions.
    - The button text and enabled state are restored after the API call completes (success or failure).
    - Implemented in `static/js/my_bookings.js`.

2.  **Modal Close Button:**
    - Removed the text-based "Close" button from the modal footer.
    - The modal now relies on the standard Bootstrap "X" icon button (btn-close) located in the modal header for closing. This was confirmed to be already present.
    - This change simplifies the modal footer and adheres to common UI patterns for modal dialogs.
    - Modified in `templates/my_bookings.html`.