### PR TITLE
refactor: Relocate modal close button to footer with text label

### DIFF
--- a/templates/my_bookings.html
+++ b/templates/my_bookings.html
@@ -43,7 +43,6 @@
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title" id="updateBookingModalLabel">{{ _('Update Booking') }}</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">
                     <form id="update-booking-form">
@@ -66,6 +65,7 @@
                     </form>
                 </div>
                 <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ _('Close') }}</button>
                     <button type="button" class="btn btn-primary" id="save-booking-title-btn">{{ _('Save Changes') }}</button>
                 </div>
             </div>


### PR DESCRIPTION
Based on your feedback, this commit changes the close button behavior for the "Update Booking" modal on the "My Bookings" page.

- Removed the "X" icon button (btn-close) from the modal header.
- Added a text-labeled "Close" button to the modal footer, styled as a secondary button (`btn-secondary`). This button is positioned before the "Save Changes" button.

This change provides a more explicit, labeled "Close" button in the modal footer, as per your revised preference.