### PR TITLE
feat: Add diagnostic script for focus logging

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -114,6 +114,26 @@
     </div>
 
     {% block scripts %}
+    <script>
+        // Diagnostic script to log focus changes
+        document.addEventListener('focusin', function(e) {
+            console.log('%cFocus changed. New focused element:', 'color: blue; font-weight: bold;', e.target);
+            if (e.target && e.target.id) {
+                console.log('    Focused element ID:', e.target.id);
+            }
+            if (e.target && e.target.className) {
+                console.log('    Focused element classes:', e.target.className);
+            }
+            // Check if the focused element is within our modal
+            const modalElement = document.getElementById('booking-slot-modal');
+            if (modalElement && modalElement.contains(e.target)) {
+                console.warn('    ELEMENT FOCUSED INSIDE #booking-slot-modal:', e.target);
+                // You could add a breakpoint here in your browser's debugger
+                // debugger;
+            }
+        }, true); // Use capture phase to ensure this runs early for all focusin events
+        console.log('Focus logging diagnostic script initialized.');
+    </script>
     <!-- Bootstrap JS Bundle (Popper.js included) -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz" crossorigin="anonymous"></script>
     <!-- Socket.IO (if used, currently commented out) -->


### PR DESCRIPTION
Adds a JavaScript snippet to `templates/base.html` that listens for `focusin` events on the document (using the capture phase). This script logs details about the element receiving focus to the browser console.

It specifically logs a warning if an element within the modal `#booking-slot-modal` receives focus.

This is a temporary diagnostic tool to help identify which element, if any, is unexpectedly gaining focus on page load, particularly on the "View Resources" page, which might be related to issues with a modal appearing prematurely and its close button not working.