### PR TITLE
feat: Add diagnostic script to monitor bootstrap.Modal.show calls

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -136,6 +136,41 @@
     </script>
     <!-- Bootstrap JS Bundle (Popper.js included) -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz" crossorigin="anonymous"></script>
+    <script>
+        // Diagnostic script to monitor bootstrap.Modal.prototype.show calls
+        function attemptToWrapModalShow() {
+            if (window.bootstrap && window.bootstrap.Modal && window.bootstrap.Modal.prototype && window.bootstrap.Modal.prototype.show) {
+                const originalShow = window.bootstrap.Modal.prototype.show;
+                window.bootstrap.Modal.prototype.show = function() {
+                    // Ensure this._element exists and has an ID before logging
+                    let modalId = (this._element && this._element.id) ? this._element.id : 'Unknown Modal';
+                    if (modalId === 'booking-slot-modal') { // Only log for our specific modal
+                        console.warn('Bootstrap Modal .show() called on element:', this._element);
+                        console.trace(); // This will give a stack trace of who called it.
+                    }
+                    originalShow.apply(this, arguments);
+                };
+                console.log('Diagnostic: bootstrap.Modal.prototype.show has been wrapped.');
+            } else {
+                console.log('Diagnostic: bootstrap.Modal or prototype.show not ready for wrapping yet.');
+            }
+        }
+
+        // Attempt to wrap immediately after Bootstrap JS (this script block)
+        // DOMContentLoaded might be too late if other deferred scripts run before this specific logic
+        // but bootstrap.Modal might also only be fully ready on DOMContentLoaded.
+        // Using a robust approach:
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', attemptToWrapModalShow);
+        } else { // DOMContentLoaded has already fired
+            attemptToWrapModalShow(); // Try immediately
+        }
+        // Fallback timeout if Bootstrap loads asynchronously but before other dependent scripts
+        // This helps if Bootstrap itself is somehow deferred or loaded unusually.
+        setTimeout(attemptToWrapModalShow, 100); // Short timeout, adjust if necessary
+
+        console.log('Diagnostic script for Modal.show wrapping initialized.');
+    </script>
     <!-- Socket.IO (if used, currently commented out) -->
     <!-- <script src="/socket.io/socket.io.js"></script> -->
     <script src="{{ url_for('static', filename='js/script.js') }}" defer></script>


### PR DESCRIPTION
Adds a JavaScript snippet to `templates/base.html` that wraps the `bootstrap.Modal.prototype.show` method.

When `show()` is called on the modal with ID `#booking-slot-modal`, this script will log a warning and a stack trace to the browser console.

This is a temporary diagnostic tool to help identify the source of the `#booking-slot-modal` appearing prematurely on the "View Resources" page by revealing the JavaScript call stack that triggers the modal display.

The previously added focus logger also remains active for comprehensive diagnostics.