### PR TITLE
feat: Add Close button to update booking modal footer

### DIFF
--- a/templates/my_bookings.html
+++ b/templates/my_bookings.html
@@ -66,6 +66,7 @@
                     </form>
                 </div>
                 <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ _('Close') }}</button>
                     <button type="button" class="btn btn-primary" id="save-booking-title-btn">{{ _('Save Changes') }}</button>
                 </div>
             </div>


### PR DESCRIPTION
This commit introduces a 'Close' button to the footer of the 'Update Booking' modal on the 'My Bookings' page.

The new button is styled using Bootstrap's 'btn-secondary' class and is positioned to the left of the existing 'Save Changes' button. The 'data-bs-dismiss="modal"' attribute ensures that clicking the button will close the modal without requiring additional JavaScript.