### PR TITLE
fix: Remove header close button from update booking modal

### DIFF
--- a/templates/my_bookings.html
+++ b/templates/my_bookings.html
@@ -43,7 +43,6 @@
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title" id="updateBookingModalLabel">{{ _('Update Booking') }}</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">
                     <form id="update-booking-form">


### PR DESCRIPTION
This commit removes the 'X' close button from the header of the 'Update Booking' modal. This change is made based on your feedback to simplify the modal interface, leaving the footer 'Close' button as the primary way to dismiss the modal.