### PR TITLE
Fix: Correct keyword argument in one-click backup

### DIFF
--- a/routes/api_system.py
+++ b/routes/api_system.py
@@ -156,7 +156,7 @@ def api_one_click_backup():
         success = create_full_backup(
             timestamp_str,
             map_config_data=map_config_data,
-            resource_config_data=resource_config_data,
+            resource_configs_data=resource_config_data,
             user_config_data=user_config_data,
             socketio_instance=socketio, # socketio from extensions
             task_id=task_id


### PR DESCRIPTION
The `create_full_backup` function was being called with an incorrect keyword argument `resource_config_data` instead of the expected `resource_configs_data`. This change corrects the typo.

This addresses a TypeError that occurred during the one-click backup process.