### PR TITLE
feat: Add UI buttons for troubleshooting tools

### DIFF
--- a/routes/api_system.py
+++ b/routes/api_system.py
@@ -599,7 +599,7 @@ def init_api_system_routes(app):
 def api_admin_view_db_raw_top100():
     """Fetches top 100 records from key database tables."""
     current_app.logger.info(f"User {current_user.username} requested raw top 100 DB records.")
-    
+
     models_to_query = {
         "User": User,
         "Booking": Booking,
@@ -608,9 +608,9 @@ def api_admin_view_db_raw_top100():
         "AuditLog": AuditLog,
         "Role": Role
     }
-    
+
     raw_data = {}
-    
+
     try:
         for model_name, ModelClass in models_to_query.items():
             records = ModelClass.query.limit(100).all()
@@ -627,10 +627,10 @@ def api_admin_view_db_raw_top100():
                         record_dict[column.name] = val
                 serialized_records.append(record_dict)
             raw_data[model_name] = serialized_records
-            
+
         current_app.logger.info(f"Successfully fetched raw DB data for {current_user.username}.")
         return jsonify({'success': True, 'data': raw_data}), 200
-        
+
     except Exception as e:
         current_app.logger.error(f"Error fetching raw DB data for {current_user.username}: {e}", exc_info=True)
         return jsonify({'success': False, 'message': f'Failed to fetch raw database data: {str(e)}'}), 500
@@ -643,7 +643,7 @@ def api_admin_view_db_raw_top100():
 def api_admin_cleanup_system_data():
     """Cleans up database records and uploaded files."""
     current_app.logger.info(f"User {current_user.username} initiated system data cleanup.")
-    
+
     try:
         # Database Cleanup
         num_bookings_deleted = Booking.query.delete()
@@ -657,7 +657,7 @@ def api_admin_cleanup_system_data():
         num_floormaps_deleted = FloorMap.query.delete()
         add_audit_log(action="DB_CLEANUP", details=f"Deleted {num_floormaps_deleted} records from FloorMap table.", user_id=current_user.id)
         current_app.logger.info(f"Deleted {num_floormaps_deleted} records from FloorMap table.")
-        
+
         db.session.commit()
         current_app.logger.info("Database cleanup committed.")
 
@@ -665,12 +665,12 @@ def api_admin_cleanup_system_data():
         # Construct paths relative to the application's root directory
         floor_map_uploads_path = os.path.join(current_app.root_path, 'static', 'floor_map_uploads')
         resource_uploads_path = os.path.join(current_app.root_path, 'static', 'resource_uploads')
-        
+
         paths_to_clean = {
             "Floor Map Uploads": floor_map_uploads_path,
             "Resource Uploads": resource_uploads_path
         }
-        
+
         files_deleted_count = 0
         deletion_errors = []
 
@@ -697,15 +697,15 @@ def api_admin_cleanup_system_data():
                     err_msg = f"Failed to delete file {file_path}: {str(e_file)}"
                     current_app.logger.error(err_msg)
                     deletion_errors.append(err_msg)
-        
+
         add_audit_log(action="FILE_CLEANUP", details=f"Deleted {files_deleted_count} uploaded files. Errors: {len(deletion_errors)}.", user_id=current_user.id)
         current_app.logger.info(f"Uploaded files cleanup completed. Deleted: {files_deleted_count}. Errors: {len(deletion_errors)}.")
 
         if deletion_errors:
             return jsonify({'success': False, 'message': f'Cleanup partially completed. Database cleared. File deletion errors: {"; ".join(deletion_errors)}'}), 500
-            
+
         return jsonify({'success': True, 'message': 'System data cleanup completed successfully.'}), 200
-        
+
     except Exception as e:
         db.session.rollback()
         current_app.logger.error(f"Error during system data cleanup by {current_user.username}: {e}", exc_info=True)
@@ -720,7 +720,7 @@ def api_admin_cleanup_system_data():
 def api_admin_reload_configurations():
     """Attempts to reload certain configurations from their sources."""
     current_app.logger.info(f"User {current_user.username} initiated configuration reload.")
-    
+
     try:
         # Reload Map Configuration
         current_app.logger.info("Attempting to re-fetch map configuration data.")
@@ -737,10 +737,10 @@ def api_admin_reload_configurations():
         current_app.config['BACKUP_SCHEDULE_CONFIG'] = schedule_data # Assuming scheduler reads from here
         current_app.logger.info(f"Backup schedule configuration reloaded into app.config: {schedule_data}")
         add_audit_log(action="RELOAD_CONFIG_SCHEDULE", details=f"Reloaded backup schedule configuration: {schedule_data}", user_id=current_user.id)
-        
+
         add_audit_log(action="RELOAD_CONFIGURATIONS_FINISHED", details="Configuration reload attempt finished.", user_id=current_user.id)
         return jsonify({'success': True, 'message': 'Configuration reload attempt finished. Note: Full effect for map configurations may require deeper application integration or restart.'}), 200
-        
+
     except Exception as e:
         current_app.logger.error(f"Error during configuration reload by {current_user.username}: {e}", exc_info=True)
         add_audit_log(action="RELOAD_CONFIGURATIONS_ERROR", details=f"Error: {str(e)}", user_id=current_user.id)

--- a/templates/admin_backup_restore.html
+++ b/templates/admin_backup_restore.html
@@ -146,6 +146,39 @@
         </div>
         <button type="submit" id="save-schedule-btn" class="btn btn-success">{{ _('Save Schedule') }}</button>
     </form>
+
+    <hr>
+    <section id="troubleshooting-tools-section" class="mb-5">
+        <h2>{{ _('System Troubleshooting Tools') }}</h2>
+
+        <div class="card mb-3">
+            <div class="card-body">
+                <h5 class="card-title">{{ _('View Database Records') }}</h5>
+                <p class="card-text">{{ _('Fetch and display the top 100 records from key database tables.') }}</p>
+                <button id="view-db-records-btn" class="btn btn-info">{{ _('View DB Records') }}</button>
+                <div id="view-db-records-status" class="mt-2"></div>
+                <pre id="view-db-records-output" class="log-area" style="display: none; max-height: 400px;"></pre>
+            </div>
+        </div>
+
+        <div class="card mb-3">
+            <div class="card-body">
+                <h5 class="card-title">{{ _('Reload Configurations') }}</h5>
+                <p class="card-text">{{ _('Attempt to reload system configurations like the backup schedule and map data. Note: Full effect may require deeper application integration for some configurations.') }}</p>
+                <button id="reload-configurations-btn" class="btn btn-warning">{{ _('Reload Configurations') }}</button>
+                <div id="reload-configurations-status" class="mt-2"></div>
+            </div>
+        </div>
+
+        <div class="card mb-3">
+            <div class="card-body">
+                <h5 class="card-title">{{ _('Cleanup System Data') }}</h5>
+                <p class="card-text text-danger"><strong>{{ _('Warning:') }}</strong> {{ _('This will delete all bookings, resources, and floor maps from the database, and remove all uploaded floor map and resource images. This action is irreversible.') }}</p>
+                <button id="cleanup-system-data-btn" class="btn btn-danger">{{ _('Cleanup System Data') }}</button>
+                <div id="cleanup-system-data-status" class="mt-2"></div>
+            </div>
+        </div>
+    </section>
 </div>
 
 <script>
@@ -182,6 +215,16 @@
         const componentCheckboxes = document.querySelectorAll('#selective-restore-form input[name="components"]');
         const componentAllCheckbox = document.getElementById('component-all');
 
+        // Troubleshooting Tools Elements
+        const viewDbRecordsBtn = document.getElementById('view-db-records-btn');
+        const viewDbRecordsStatusEl = document.getElementById('view-db-records-status');
+        const viewDbRecordsOutputEl = document.getElementById('view-db-records-output');
+
+        const reloadConfigurationsBtn = document.getElementById('reload-configurations-btn');
+        const reloadConfigurationsStatusEl = document.getElementById('reload-configurations-status');
+
+        const cleanupSystemDataBtn = document.getElementById('cleanup-system-data-btn');
+        const cleanupSystemDataStatusEl = document.getElementById('cleanup-system-data-status');
 
         let currentBackupTaskId = null;
         let currentRestoreTaskId = null;
@@ -991,6 +1034,117 @@
             });
         });
         loadBackupSchedule(); // Initial Load
+
+        // --- Troubleshooting Tools Event Listeners ---
+        if (viewDbRecordsBtn) {
+            viewDbRecordsBtn.addEventListener('click', function() {
+                viewDbRecordsStatusEl.textContent = "{{ _('Fetching DB records...') }}";
+                viewDbRecordsStatusEl.className = 'alert alert-info';
+                viewDbRecordsOutputEl.style.display = 'none';
+                viewDbRecordsOutputEl.textContent = '';
+                viewDbRecordsBtn.disabled = true;
+
+                fetch('/api/admin/view_db_raw_top100', {
+                    method: 'GET',
+                    headers: { 'X-CSRFToken': csrfToken, 'Accept': 'application/json' }
+                })
+                .then(response => response.json())
+                .then(data => {
+                    if (data.success) {
+                        viewDbRecordsOutputEl.textContent = JSON.stringify(data.data, null, 2);
+                        viewDbRecordsOutputEl.style.display = 'block';
+                        viewDbRecordsStatusEl.textContent = "{{ _('DB records fetched successfully.') }}";
+                        viewDbRecordsStatusEl.className = 'alert alert-success';
+                    } else {
+                        viewDbRecordsStatusEl.textContent = "{{ _('Failed to fetch DB records:') }} " + (data.message || "{{ _('Unknown error.') }}");
+                        viewDbRecordsStatusEl.className = 'alert alert-danger';
+                    }
+                })
+                .catch(error => {
+                    console.error('View DB Records error:', error);
+                    viewDbRecordsStatusEl.textContent = "{{ _('Error fetching DB records:') }} " + error.toString();
+                    viewDbRecordsStatusEl.className = 'alert alert-danger';
+                })
+                .finally(() => {
+                    viewDbRecordsBtn.disabled = false;
+                });
+            });
+        }
+
+        if (reloadConfigurationsBtn) {
+            reloadConfigurationsBtn.addEventListener('click', function() {
+                reloadConfigurationsStatusEl.textContent = "{{ _('Attempting to reload configurations...') }}";
+                reloadConfigurationsStatusEl.className = 'alert alert-info';
+                reloadConfigurationsBtn.disabled = true;
+
+                fetch('/api/admin/reload_configurations', {
+                    method: 'POST',
+                    headers: { 'X-CSRFToken': csrfToken, 'Accept': 'application/json' }
+                })
+                .then(response => response.json())
+                .then(data => {
+                    if (data.success) {
+                        reloadConfigurationsStatusEl.textContent = "{{ _('Configuration reload attempt finished.') }} " + (data.message || "");
+                        reloadConfigurationsStatusEl.className = 'alert alert-success';
+                    } else {
+                        reloadConfigurationsStatusEl.textContent = "{{ _('Failed to reload configurations:') }} " + (data.message || "{{ _('Unknown error.') }}");
+                        reloadConfigurationsStatusEl.className = 'alert alert-danger';
+                    }
+                })
+                .catch(error => {
+                    console.error('Reload Configurations error:', error);
+                    reloadConfigurationsStatusEl.textContent = "{{ _('Error reloading configurations:') }} " + error.toString();
+                    reloadConfigurationsStatusEl.className = 'alert alert-danger';
+                })
+                .finally(() => {
+                    reloadConfigurationsBtn.disabled = false;
+                });
+            });
+        }
+
+        if (cleanupSystemDataBtn) {
+            cleanupSystemDataBtn.addEventListener('click', function() {
+                const confirmationPrompt = "{{ _('Type CONFIRM to delete bookings, resources, floor maps, and all uploaded floor map/resource images. This action is irreversible.') }}";
+                const userInput = prompt(confirmationPrompt);
+
+                if (userInput === "CONFIRM") {
+                    cleanupSystemDataStatusEl.textContent = "{{ _('Processing cleanup...') }}";
+                    cleanupSystemDataStatusEl.className = 'alert alert-info';
+                    cleanupSystemDataBtn.disabled = true;
+
+                    fetch('/api/admin/cleanup_system_data', {
+                        method: 'POST',
+                        headers: { 'X-CSRFToken': csrfToken, 'Accept': 'application/json' }
+                    })
+                    .then(response => response.json())
+                    .then(data => {
+                        if (data.success) {
+                            cleanupSystemDataStatusEl.textContent = "{{ _('System data cleanup successful.') }} " + (data.message || "");
+                            cleanupSystemDataStatusEl.className = 'alert alert-success';
+                            // Optionally, refresh parts of the page or prompt user to refresh
+                            loadAvailableBackups(); // For example, if cleanup affects backup list display consistency
+                        } else {
+                            cleanupSystemDataStatusEl.textContent = "{{ _('Cleanup failed or partially failed:') }} " + (data.message || "{{ _('Unknown error.') }}");
+                            cleanupSystemDataStatusEl.className = 'alert alert-danger';
+                        }
+                    })
+                    .catch(error => {
+                        console.error('Cleanup System Data error:', error);
+                        cleanupSystemDataStatusEl.textContent = "{{ _('Error during cleanup:') }} " + error.toString();
+                        cleanupSystemDataStatusEl.className = 'alert alert-danger';
+                    })
+                    .finally(() => {
+                        cleanupSystemDataBtn.disabled = false;
+                    });
+                } else if (userInput !== null) { // User typed something other than CONFIRM
+                    cleanupSystemDataStatusEl.textContent = "{{ _('Cleanup cancelled. Confirmation not received.') }}";
+                    cleanupSystemDataStatusEl.className = 'alert alert-warning';
+                } else { // User clicked cancel on the prompt
+                     cleanupSystemDataStatusEl.textContent = "{{ _('Cleanup cancelled.') }}";
+                     cleanupSystemDataStatusEl.className = 'alert alert-info';
+                }
+            });
+        }
     });
 </script>
 {% endblock %}


### PR DESCRIPTION
Adds buttons to the 'Backup & Restore' admin page (`templates/admin_backup_restore.html`) for the following troubleshooting features:

1.  **View DB Records (Top 100):**
    - Button triggers a GET request to `/api/admin/view_db_raw_top100`.
    - Displays the returned JSON data in a `<pre>` tag.

2.  **Reload Configurations:**
    - Button triggers a POST request to `/api/admin/reload_configurations`.
    - Displays success/error messages.

3.  **Cleanup System Data:**
    - Button triggers a POST request to `/api/admin/cleanup_system_data`.
    - Implements a JavaScript `prompt()` for strong confirmation before sending the API request.
    - Displays success/error messages.

Includes JavaScript for handling these button clicks, making API calls, and updating status messages. Manual verification steps have been outlined.