### PR TITLE
Fix: Remove flask_babel and use custom translator

### DIFF
--- a/routes/admin_ui.py
+++ b/routes/admin_ui.py
@@ -20,9 +20,9 @@ from azure_backup import list_available_backups, restore_full_backup, \
 # Removed duplicate model, db, auth, datetime imports that were already covered above or are standard
 import os
 import json
-from flask_babel import _ # For flash messages and other translatable strings
 from apscheduler.jobstores.base import JobLookupError
 from scheduler_tasks import run_scheduled_booking_csv_backup # For re-adding job
+from translations import _ # For flash messages and other translatable strings
 
 admin_ui_bp = Blueprint('admin_ui', __name__, url_prefix='/admin', template_folder='../templates')
 


### PR DESCRIPTION
Resolved a ModuleNotFoundError for 'flask_babel' by removing its usage. The application uses a custom translation system defined in 'translations.py'.

Changes:
- Removed the import of 'flask_babel' from 'routes/admin_ui.py'.
- Added an import for the custom '_' translator from 'translations.py' in 'routes/admin_ui.py' to ensure flash messages and other translatable strings use the application's translation mechanism.
- Verified that 'flask_babel' is not listed in 'requirements.txt'.
- Confirmed that 'flask_babel' is not used in other Python files within the project.