### PR TITLE
Fix: Revise TypeError fix for Backup & Restore page confirmation

### DIFF
--- a/templates/admin_backup_restore.html
+++ b/templates/admin_backup_restore.html
@@ -222,7 +222,7 @@
                                 </form>
                                 <form method="POST" action="{{ url_for('admin_ui.delete_booking_csv_backup_route', timestamp_str=backup_item.timestamp) }}" style="display: inline; margin-left: 5px;">
                                     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-                                    <button type="submit" class="btn btn-danger btn-sm" onclick="return confirm('{{ _('Are you sure you want to permanently delete the booking CSV backup for file %(filename)s?', filename=backup_item.display_name) }}');">
+                                    <button type="submit" class="btn btn-danger btn-sm" onclick="return confirm('{{ _('Are you sure you want to permanently delete the booking CSV backup for file:') }} ' + '{{ backup_item.display_name | e }}');">
                                         <i class="fas fa-trash-alt"></i> {{ _('Delete') }}
                                     </button>
                                 </form>


### PR DESCRIPTION
This commit revises the approach to fix a TypeError on the Backup & Restore page's booking CSV delete confirmation.

The previous attempt to use `backup_item.display_name` with a named placeholder `%(filename)s` in the translatable string still resulted in a TypeError. This indicated that the translated strings might not consistently include the `%(filename)s` placeholder.

The new approach modifies line 225 of
`templates/admin_backup_restore.html` to separate the main translatable string from the dynamic `backup_item.display_name`. The translated string "Are you sure you want to permanently delete the booking CSV backup for file:" is now concatenated with the escaped display_name directly in JavaScript within the `confirm()` call.

This avoids relying on named placeholders in the translated part of the string, thus preventing the TypeError.