### PR TITLE
Fix: Resolve UndefinedError for pagination on Backup & Restore page

### DIFF
--- a/routes/admin_ui.py
+++ b/routes/admin_ui.py
@@ -115,10 +115,10 @@ def serve_backup_restore_page():
         'admin_backup_restore.html',
         full_backups=full_backups,
         booking_csv_backups=paginated_booking_csv_backups,
-        booking_csv_pagination_current_page=page,
-        booking_csv_pagination_total_pages=total_pages,
-        booking_csv_pagination_has_prev=has_prev,
-        booking_csv_pagination_has_next=has_next
+        booking_csv_page=page,
+        booking_csv_total_pages=total_pages,
+        booking_csv_has_prev=has_prev,
+        booking_csv_has_next=has_next
     )
 
 @admin_ui_bp.route('/admin/restore_booking_csv/<timestamp_str>', methods=['POST'])


### PR DESCRIPTION
Corrects a `jinja2.exceptions.UndefinedError` on the /admin/backup_restore page caused by a mismatch in pagination variable names between the `serve_backup_restore_page` route in `routes/admin_ui.py` and the `admin_backup_restore.html` template.

The route was passing variables like `booking_csv_pagination_total_pages` while the template expected `booking_csv_total_pages`.

This commit updates the `render_template` call in `routes/admin_ui.py` to use the shorter variable names (e.g., `booking_csv_total_pages`, `booking_csv_page`, `booking_csv_has_prev`, `booking_csv_has_next`) to match the template's expectations, resolving the error.