### PR TITLE
Fix: Correct permissions format for role management

### DIFF
--- a/static/js/user_management.js
+++ b/static/js/user_management.js
@@ -18,6 +18,32 @@ document.addEventListener('DOMContentLoaded', function() {
     const importUsersFile = document.getElementById('import-users-file');
     const deleteSelectedUsersBtn = document.getElementById('delete-selected-users-btn');
     const selectAllUsersCheckbox = document.getElementById('select-all-users');
+    const bulkEditUsersBtn = document.getElementById('bulk-edit-users-btn'); // New
+
+    // Bulk Edit Modal Elements
+    const bulkEditUserModal = document.getElementById('bulk-edit-user-modal'); // New
+    const bulkEditUserForm = document.getElementById('bulk-edit-user-form'); // New
+    const bulkSetAdminSelect = document.getElementById('bulk-set-admin'); // New
+    const bulkAddRolesContainer = document.getElementById('bulk-add-roles-container'); // New
+    const bulkRemoveRolesContainer = document.getElementById('bulk-remove-roles-container'); // New
+    const bulkEditUserModalStatusDiv = document.getElementById('bulk-edit-user-modal-status'); // New
+    const bulkEditSelectedCountSpan = document.getElementById('bulk-edit-selected-count'); // New
+    const closeBulkEditModalBtn = bulkEditUserModal ? bulkEditUserModal.querySelector('.close-modal-btn') : null; //New
+
+    // Bulk Add Users (Pattern) Modal Elements
+    const bulkAddUsersBtn = document.getElementById('bulk-add-users-btn'); // New
+    const bulkAddUserModal = document.getElementById('bulk-add-user-modal'); // New
+    const bulkAddUserForm = document.getElementById('bulk-add-user-form'); // New
+    const bulkAddUsernamePatternInput = document.getElementById('bulk-add-username-pattern'); // New
+    const bulkAddStartIndexInput = document.getElementById('bulk-add-start-index'); // New
+    const bulkAddCountInput = document.getElementById('bulk-add-count'); // New
+    const bulkAddDefaultPasswordInput = document.getElementById('bulk-add-default-password'); // New
+    const bulkAddEmailPatternInput = document.getElementById('bulk-add-email-pattern'); // New
+    const bulkAddIsAdminCheckbox = document.getElementById('bulk-add-is-admin'); // New
+    const bulkAddRolesContainer = document.getElementById('bulk-add-roles-container'); // New
+    const bulkAddUserModalStatusDiv = document.getElementById('bulk-add-user-modal-status'); // New
+    const closeBulkAddModalBtn = bulkAddUserModal ? bulkAddUserModal.querySelector('.close-modal-btn') : null; // New
+
 
     const userIdInput = document.getElementById('user-id');
     const usernameInput = document.getElementById('username');
@@ -548,7 +574,207 @@ document.addEventListener('DOMContentLoaded', function() {
         if (event.target === roleFormModal) {
             if (roleFormModal) roleFormModal.style.display = 'none';
         }
+        if (event.target === bulkEditUserModal) { // New for bulk edit modal
+            if (bulkEditUserModal) bulkEditUserModal.style.display = 'none';
+        }
+        if (event.target === bulkAddUserModal) { // New for bulk add modal
+            if (bulkAddUserModal) bulkAddUserModal.style.display = 'none';
+        }
     });
+
+    // --- Bulk User Edit Functionality ---
+    function populateRolesForBulkEditModal(selectedAddIds = [], selectedRemoveIds = []) {
+        if (!bulkAddRolesContainer || !bulkRemoveRolesContainer) return;
+
+        showLoading(bulkAddRolesContainer, 'Loading roles...');
+        showLoading(bulkRemoveRolesContainer, 'Loading roles...');
+
+        // Use cached roles if available, otherwise fetch
+        const rolesPromise = allAvailableRolesCache ? Promise.resolve(allAvailableRolesCache) : apiCall('/api/admin/roles');
+
+        rolesPromise.then(roles => {
+            if (!allAvailableRolesCache) {
+                allAvailableRolesCache = roles; // Cache them if fetched now
+            }
+
+            bulkAddRolesContainer.innerHTML = ''; // Clear previous
+            bulkRemoveRolesContainer.innerHTML = '';
+
+            if (!roles || roles.length === 0) {
+                const noRolesMsg = '<small>No roles available.</small>';
+                bulkAddRolesContainer.innerHTML = noRolesMsg;
+                bulkRemoveRolesContainer.innerHTML = noRolesMsg;
+                return;
+            }
+
+            roles.forEach(role => {
+                // Populate Add Roles Container
+                const addCheckboxDiv = document.createElement('div');
+                addCheckboxDiv.classList.add('checkbox-item');
+                const addCheckbox = document.createElement('input');
+                addCheckbox.type = 'checkbox';
+                addCheckbox.id = `bulk-add-role-${role.id}`;
+                addCheckbox.value = role.id;
+                addCheckbox.name = 'bulk_add_role_ids';
+                if (selectedAddIds.includes(role.id)) addCheckbox.checked = true;
+
+                const addLabel = document.createElement('label');
+                addLabel.htmlFor = `bulk-add-role-${role.id}`;
+                addLabel.textContent = role.name;
+
+                addCheckboxDiv.appendChild(addCheckbox);
+                addCheckboxDiv.appendChild(addLabel);
+                bulkAddRolesContainer.appendChild(addCheckboxDiv);
+
+                // Populate Remove Roles Container
+                const removeCheckboxDiv = document.createElement('div');
+                removeCheckboxDiv.classList.add('checkbox-item');
+                const removeCheckbox = document.createElement('input');
+                removeCheckbox.type = 'checkbox';
+                removeCheckbox.id = `bulk-remove-role-${role.id}`;
+                removeCheckbox.value = role.id;
+                removeCheckbox.name = 'bulk_remove_role_ids';
+                if (selectedRemoveIds.includes(role.id)) removeCheckbox.checked = true;
+
+                const removeLabel = document.createElement('label');
+                removeLabel.htmlFor = `bulk-remove-role-${role.id}`;
+                removeLabel.textContent = role.name;
+
+                removeCheckboxDiv.appendChild(removeCheckbox);
+                removeCheckboxDiv.appendChild(removeLabel);
+                bulkRemoveRolesContainer.appendChild(removeCheckboxDiv);
+            });
+        }).catch(error => {
+            showError(bulkAddRolesContainer, 'Failed to load roles.');
+            showError(bulkRemoveRolesContainer, 'Failed to load roles.');
+            console.error("Error populating roles for bulk edit:", error);
+        });
+    }
+
+    if (bulkEditUsersBtn) {
+        bulkEditUsersBtn.addEventListener('click', async () => {
+            const selectedUserIds = Array.from(usersTableBody.querySelectorAll('.select-user-checkbox:checked'))
+                                       .map(cb => parseInt(cb.dataset.userId, 10));
+
+            if (selectedUserIds.length === 0) {
+                showError(userManagementStatusDiv, 'No users selected for bulk edit.');
+                return;
+            }
+
+            if (bulkEditUserForm) bulkEditUserForm.reset();
+            if (bulkEditUserModalStatusDiv) hideMessage(bulkEditUserModalStatusDiv);
+            if (bulkSetAdminSelect) bulkSetAdminSelect.value = ""; // Reset to "No Change"
+            if (bulkEditSelectedCountSpan) bulkEditSelectedCountSpan.textContent = selectedUserIds.length;
+
+
+            // Populate roles (this will also fetch if cache is empty)
+            // Ensure roles are loaded before showing the modal if they aren't cached
+            if (!allAvailableRolesCache) {
+                try {
+                    showLoading(userManagementStatusDiv, "Loading roles for bulk edit...");
+                    allAvailableRolesCache = await apiCall('/api/admin/roles');
+                    hideMessage(userManagementStatusDiv);
+                } catch (error) {
+                    showError(userManagementStatusDiv, `Failed to load roles: ${error.message}. Please try again.`);
+                    return;
+                }
+            }
+            populateRolesForBulkEditModal([], []); // Populate with no roles pre-selected
+
+            if (bulkEditUserModal) bulkEditUserModal.style.display = 'block';
+        });
+    }
+
+    if (closeBulkEditModalBtn) {
+        closeBulkEditModalBtn.addEventListener('click', () => {
+            if (bulkEditUserModal) bulkEditUserModal.style.display = 'none';
+        });
+    }
+
+    if (bulkEditUserForm) {
+        bulkEditUserForm.addEventListener('submit', async (event) => {
+            event.preventDefault();
+            showLoading(bulkEditUserModalStatusDiv, 'Applying bulk changes...');
+
+            const selectedUserIds = Array.from(usersTableBody.querySelectorAll('.select-user-checkbox:checked'))
+                                       .map(cb => parseInt(cb.dataset.userId, 10));
+
+            if (selectedUserIds.length === 0) {
+                showError(bulkEditUserModalStatusDiv, 'No users selected. Please select users from the table first.');
+                return; // Should not happen if modal was opened correctly, but as a safeguard
+            }
+
+            const setAdminValue = bulkSetAdminSelect.value;
+            let setAdmin = null;
+            if (setAdminValue === "true") setAdmin = true;
+            else if (setAdminValue === "false") setAdmin = false;
+
+            const addRoleIds = Array.from(bulkAddRolesContainer.querySelectorAll('input[name="bulk_add_role_ids"]:checked'))
+                                    .map(cb => parseInt(cb.value, 10));
+            const removeRoleIds = Array.from(bulkRemoveRolesContainer.querySelectorAll('input[name="bulk_remove_role_ids"]:checked'))
+                                     .map(cb => parseInt(cb.value, 10));
+
+            // Client-side validation for overlapping roles
+            const commonRoles = addRoleIds.filter(id => removeRoleIds.includes(id));
+            if (commonRoles.length > 0) {
+                const commonRoleNames = allAvailableRolesCache
+                    .filter(role => commonRoles.includes(role.id))
+                    .map(role => role.name)
+                    .join(', ');
+                showError(bulkEditUserModalStatusDiv, `Cannot add and remove the same roles in one operation. Conflicting roles: ${commonRoleNames}.`);
+                return;
+            }
+
+            // Ensure at least one action is selected
+            if (setAdmin === null && addRoleIds.length === 0 && removeRoleIds.length === 0) {
+                showError(bulkEditUserModalStatusDiv, 'No changes specified. Please select an admin status or roles to add/remove.');
+                return;
+            }
+
+
+            const actions = {
+                set_admin: setAdmin,
+                add_role_ids: addRoleIds.length > 0 ? addRoleIds : null,
+                remove_role_ids: removeRoleIds.length > 0 ? removeRoleIds : null
+            };
+
+            try {
+                const response = await apiCall('/api/admin/users/bulk', {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ ids: selectedUserIds, actions: actions })
+                }, bulkEditUserModalStatusDiv); // Pass status div to apiCall
+
+                // Check if apiCall handled the message display based on its logic.
+                // If not, or if we want a more specific message for 207:
+                if (response) { // apiCall returns response on success
+                    let message = response.message || `Bulk update processed. ${response.updated_count || 0} users affected.`;
+                    if (response.errors && response.errors.length > 0) {
+                        message += ` Some operations had issues: ${response.errors.map(e => `User ${e.id || 'N/A'}: ${e.error}`).join(', ')}`;
+                        showError(userManagementStatusDiv, message); // Show detailed errors on main page status
+                    } else {
+                        showSuccess(userManagementStatusDiv, message);
+                    }
+                }
+                // If apiCall showed a message in bulkEditUserModalStatusDiv and it was an error,
+                // we might not want to immediately hide the modal. But for now, let's assume success leads to hiding.
+
+                if (bulkEditUserModal && (!bulkEditUserModalStatusDiv.textContent || bulkEditUserModalStatusDiv.style.color === 'green' || bulkEditUserModalStatusDiv.style.color === 'var(--success-color)')) {
+                    bulkEditUserModal.style.display = 'none';
+                }
+                fetchAndDisplayUsers(currentFilters); // Refresh user list
+                if (selectAllUsersCheckbox) selectAllUsersCheckbox.checked = false; // Uncheck select all
+
+            } catch (error) {
+                // apiCall should have displayed the error in bulkEditUserModalStatusDiv.
+                // If for some reason it didn't, or for additional logging:
+                console.error("Bulk edit submission failed:", error);
+                if (!bulkEditUserModalStatusDiv.textContent || bulkEditUserModalStatusDiv.style.display === 'none') {
+                    showError(bulkEditUserModalStatusDiv, `Operation failed: ${error.message}`);
+                }
+            }
+        });
+    }
 
     // Event Delegation for Edit/Delete Role buttons
     if (rolesTableBody) {
@@ -601,14 +827,14 @@ document.addEventListener('DOMContentLoaded', function() {
             const id = roleIdInput.value;
             const name = roleNameInput.value.trim();
             const description = roleDescriptionInput.value.trim();
-            const permissions = getSelectedPermissions().join(',');
+            const permissionsArray = getSelectedPermissions();
 
             if (!name) {
                 showError(roleFormModalStatusDiv, 'Role Name is required.');
                 return;
             }
 
-            const roleData = { name, description, permissions };
+            const roleData = { name, description, permissions: permissionsArray };
             let response;
             try {
                 if (id) { // Edit Role
@@ -643,5 +869,187 @@ document.addEventListener('DOMContentLoaded', function() {
 
     // Initial load for roles
     if (roleFormModal) roleFormModal.style.display = 'none';
-    fetchAndDisplayRoles();
+    if (bulkEditUserModal) bulkEditUserModal.style.display = 'none'; // Ensure bulk modal hidden initially
+    if (bulkAddUserModal) bulkAddUserModal.style.display = 'none'; // Ensure bulk add modal hidden initially
+
+
+    // --- Bulk Add Users (Pattern) Functionality ---
+
+    // Helper to populate roles in a generic container (used by bulk add)
+    async function populateRolesInContainer(containerElement, checkboxNamePrefix, selectedRoleIds = []) {
+        if (!containerElement) return;
+        showLoading(containerElement, 'Loading roles...');
+
+        try {
+            if (!allAvailableRolesCache) { // Ensure cache is populated
+                allAvailableRolesCache = await apiCall('/api/admin/roles');
+            }
+            containerElement.innerHTML = ''; // Clear previous
+
+            if (!allAvailableRolesCache || allAvailableRolesCache.length === 0) {
+                containerElement.innerHTML = '<small>No roles available.</small>';
+                return;
+            }
+
+            allAvailableRolesCache.forEach(role => {
+                const checkboxDiv = document.createElement('div');
+                checkboxDiv.classList.add('checkbox-item');
+                const checkbox = document.createElement('input');
+                checkbox.type = 'checkbox';
+                checkbox.id = `${checkboxNamePrefix}-role-${role.id}`;
+                checkbox.value = role.id;
+                checkbox.name = `${checkboxNamePrefix}_role_ids`;
+                if (selectedRoleIds.includes(role.id)) {
+                    checkbox.checked = true;
+                }
+
+                const label = document.createElement('label');
+                label.htmlFor = `${checkboxNamePrefix}-role-${role.id}`;
+                label.textContent = role.name;
+
+                checkboxDiv.appendChild(checkbox);
+                checkboxDiv.appendChild(label);
+                containerElement.appendChild(checkboxDiv);
+            });
+        } catch (error) {
+            showError(containerElement, 'Failed to load roles.');
+            console.error(`Error populating roles for ${checkboxNamePrefix}:`, error);
+        }
+    }
+
+
+    if (bulkAddUsersBtn) {
+        bulkAddUsersBtn.addEventListener('click', async () => {
+            if (bulkAddUserForm) bulkAddUserForm.reset(); // Reset form fields to default/empty
+            if (bulkAddUserModalStatusDiv) hideMessage(bulkAddUserModalStatusDiv);
+
+            // Set default values for pattern fields if needed (or ensure they are in HTML)
+            if(bulkAddUsernamePatternInput) bulkAddUsernamePatternInput.value = 'user###';
+            if(bulkAddStartIndexInput) bulkAddStartIndexInput.value = '1';
+            if(bulkAddCountInput) bulkAddCountInput.value = '10';
+
+
+            // Ensure roles are loaded and populate checkboxes
+            // This reuses the logic from populateRolesForUserForm or a new generic one
+            try {
+                // If roles aren't cached, populateRolesInContainer will fetch them.
+                await populateRolesInContainer(bulkAddRolesContainer, 'bulk-add', []);
+            } catch (error) {
+                showError(bulkAddUserModalStatusDiv, `Failed to load roles for selection: ${error.message}`);
+                // Optionally, don't open modal if roles fail to load, or open with error.
+                // For now, it will open with the error message in the roles container.
+            }
+
+            if (bulkAddUserModal) bulkAddUserModal.style.display = 'block';
+        });
+    }
+
+    if (closeBulkAddModalBtn) {
+        closeBulkAddModalBtn.addEventListener('click', () => {
+            if (bulkAddUserModal) bulkAddUserModal.style.display = 'none';
+        });
+    }
+
+    if (bulkAddUserForm) {
+        bulkAddUserForm.addEventListener('submit', async (event) => {
+            event.preventDefault();
+            showLoading(bulkAddUserModalStatusDiv, 'Processing bulk user creation...');
+
+            const usernamePattern = bulkAddUsernamePatternInput.value.trim();
+            const startIndex = parseInt(bulkAddStartIndexInput.value, 10);
+            const count = parseInt(bulkAddCountInput.value, 10);
+            const defaultPassword = bulkAddDefaultPasswordInput.value; // No trim for password
+            const emailPattern = bulkAddEmailPatternInput.value.trim(); // Optional
+            const isAdmin = bulkAddIsAdminCheckbox.checked;
+            const selectedRoleIds = Array.from(bulkAddRolesContainer.querySelectorAll('input[name="bulk-add_role_ids"]:checked'))
+                                       .map(cb => parseInt(cb.value, 10));
+
+            // --- Client-side Validation ---
+            if (!usernamePattern || !usernamePattern.includes('###')) {
+                showError(bulkAddUserModalStatusDiv, 'Username pattern is required and must include "###".');
+                return;
+            }
+            if (isNaN(startIndex) || startIndex < 0) {
+                showError(bulkAddUserModalStatusDiv, 'Start index must be a non-negative number.');
+                return;
+            }
+            if (isNaN(count) || count <= 0) {
+                showError(bulkAddUserModalStatusDiv, 'Number of users must be a positive number.');
+                return;
+            }
+            if (count > 200) { // Safety limit
+                showError(bulkAddUserModalStatusDiv, 'Cannot create more than 200 users at once.');
+                return;
+            }
+            if (!defaultPassword || defaultPassword.length < 6) {
+                showError(bulkAddUserModalStatusDiv, 'Default password is required and must be at least 6 characters long.');
+                return;
+            }
+            if (emailPattern && !emailPattern.includes('###') && !emailPattern.includes('@')) { // Basic check if pattern looks like an email pattern or just a fixed email
+                 showError(bulkAddUserModalStatusDiv, 'Email pattern, if provided, should ideally include "###" or be a valid email structure.');
+                 // This is a soft warning, backend will do stricter validation if needed or derive email.
+            }
+
+
+            const payload = {
+                username_pattern: usernamePattern,
+                start_index: startIndex,
+                count: count,
+                default_password: defaultPassword,
+                is_admin: isAdmin,
+                role_ids: selectedRoleIds
+            };
+            if (emailPattern) {
+                payload.email_pattern = emailPattern;
+            }
+
+            try {
+                const response = await apiCall('/api/admin/users/bulk_add', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(payload)
+                }, bulkAddUserModalStatusDiv); // Pass status div
+
+                if (response) {
+                    let message = response.message || `Bulk add operation processed.`;
+                    let isError = false;
+
+                    if (response.created_count > 0) {
+                        message += ` Successfully created: ${response.created_count}.`;
+                    }
+                    if (response.failed_count && response.failed_count > 0) {
+                        message += ` Failed: ${response.failed_count}.`;
+                        isError = true; // Consider partial success an error for message styling
+                        if (response.errors && response.errors.length > 0) {
+                            message += " Errors: " + response.errors.map(err => `${err.username_attempt || 'N/A'}: ${err.error}`).join("; ");
+                        }
+                    }
+
+                    if (isError || (response.failed_count && response.failed_count > 0)) {
+                        showError(userManagementStatusDiv, message); // Show detailed errors on main page status
+                    } else {
+                        showSuccess(userManagementStatusDiv, message);
+                    }
+
+                    // Close modal only on full success (HTTP 201 from backend, or if no failures reported in 207)
+                    if (response.created_count > 0 && (!response.failed_count || response.failed_count === 0)) {
+                         if (bulkAddUserModal) bulkAddUserModal.style.display = 'none';
+                    }
+                    fetchAndDisplayUsers(currentFilters); // Refresh user list
+                }
+                // If apiCall itself threw an error, it would be caught below
+                // and displayed in bulkAddUserModalStatusDiv
+
+            } catch (error) {
+                // This catch block is primarily for network errors or if apiCall itself throws
+                console.error("Bulk add submission failed:", error);
+                // apiCall should have already displayed the error in bulkAddUserModalStatusDiv
+                if (!bulkAddUserModalStatusDiv.textContent || bulkAddUserModalStatusDiv.style.display === 'none') {
+                     showError(bulkAddUserModalStatusDiv, `Operation failed: ${error.message}`);
+                }
+            }
+        });
+    }
+
+    fetchAndDisplayRoles(); // This also populates allAvailableRolesCache for user forms
 });

--- a/templates/user_management.html
+++ b/templates/user_management.html
@@ -9,6 +9,8 @@
     <button id="import-users-btn" class="button">{{ _('Import Users') }}</button>
     <input type="file" id="import-users-file" accept="application/json" style="display:none;">
     <button id="delete-selected-users-btn" class="button danger">{{ _('Delete Selected') }}</button>
+    <button id="bulk-edit-users-btn" class="button">{{ _('Bulk Edit Selected') }}</button>
+    <button id="bulk-add-users-btn" class="button success">{{ _('Bulk Add Users (Pattern)') }}</button>
     <div class="filters-section" style="margin-top:15px;">
         <h3>{{ _('Filters') }}</h3>
         <label for="user-filter-username">{{ _('Username:') }}</label>
@@ -145,3 +147,88 @@
     <script src="{{ url_for('static', filename='js/user_management.js') }}" defer></script>
 {% endblock %}
 
+<!-- Modal for Bulk Edit Users -->
+<div id="bulk-edit-user-modal" class="modal" style="display: none;">
+    <div class="modal-content">
+        <span class="close-modal-btn" data-modal-id="bulk-edit-user-modal">&times;</span>
+        <h3 id="bulk-edit-user-modal-title">{{ _('Bulk Edit Users') }}</h3>
+        <div id="bulk-edit-user-modal-status" class="status-message"></div>
+        <form id="bulk-edit-user-form">
+            <p><strong id="bulk-edit-selected-count"></strong> users selected.</p>
+            <hr>
+            <div>
+                <label for="bulk-set-admin">{{ _('Set Admin Status:') }}</label>
+                <select id="bulk-set-admin" name="bulk_set_admin">
+                    <option value="">{{ _('No Change') }}</option>
+                    <option value="true">{{ _('Yes (Set as Admin)') }}</option>
+                    <option value="false">{{ _('No (Remove Admin)') }}</option>
+                </select>
+            </div>
+            <hr>
+            <div>
+                <label>{{ _('Add Roles:') }}</label>
+                <div id="bulk-add-roles-container" class="checkbox-container" style="max-height: 100px; overflow-y: auto; border: 1px solid #ccc; padding: 5px;">
+                    <!-- Role checkboxes will be populated here by JavaScript -->
+                </div>
+            </div>
+            <hr>
+            <div>
+                <label>{{ _('Remove Roles:') }}</label>
+                <div id="bulk-remove-roles-container" class="checkbox-container" style="max-height: 100px; overflow-y: auto; border: 1px solid #ccc; padding: 5px;">
+                    <!-- Role checkboxes will be populated here by JavaScript -->
+                </div>
+            </div>
+            <hr>
+            <button type="submit" class="button primary" style="margin-top: 15px;">{{ _('Apply Changes to Selected Users') }}</button>
+        </form>
+    </div>
+</div>
+
+<!-- Modal for Bulk Add Users (Pattern) -->
+<div id="bulk-add-user-modal" class="modal" style="display: none;">
+    <div class="modal-content large"> <!-- Added 'large' class for more space if needed -->
+        <span class="close-modal-btn" data-modal-id="bulk-add-user-modal">&times;</span>
+        <h3 id="bulk-add-user-modal-title">{{ _('Bulk Add Users (Pattern)') }}</h3>
+        <div id="bulk-add-user-modal-status" class="status-message"></div>
+        <form id="bulk-add-user-form">
+            <div>
+                <label for="bulk-add-username-pattern">{{ _('Username Pattern:') }}</label>
+                <input type="text" id="bulk-add-username-pattern" name="username_pattern" required value="user###" style="width: 95%;">
+                <small>{{ _("Use '###' as a placeholder for numbers (e.g., user###, student##). The number of '#' determines padding.") }}</small>
+            </div>
+            <div class="form-row">
+                <div class="form-group half-width">
+                    <label for="bulk-add-start-index">{{ _('Start Index:') }}</label>
+                    <input type="number" id="bulk-add-start-index" name="start_index" required value="1" min="0">
+                </div>
+                <div class="form-group half-width">
+                    <label for="bulk-add-count">{{ _('Number of Users to Create:') }}</label>
+                    <input type="number" id="bulk-add-count" name="count" required value="10" min="1">
+                </div>
+            </div>
+            <div>
+                <label for="bulk-add-default-password">{{ _('Default Password (min 6 chars):') }}</label>
+                <input type="password" id="bulk-add-default-password" name="default_password" required style="width: 95%;">
+            </div>
+            <div>
+                <label for="bulk-add-email-pattern">{{ _('Email Pattern (optional):') }}</label>
+                <input type="text" id="bulk-add-email-pattern" name="email_pattern" placeholder="user###@example.com" style="width: 95%;">
+                <small>{{ _("If blank, generated as 'username@example.com'. Use '###' for number placeholder.") }}</small>
+            </div>
+            <div>
+                <input type="checkbox" id="bulk-add-is-admin" name="is_admin" value="true">
+                <label for="bulk-add-is-admin" style="display: inline;">{{ _('Set as Admin') }}</label>
+            </div>
+            <hr>
+            <div>
+                <label>{{ _('Assign Roles (optional):') }}</label>
+                <div id="bulk-add-roles-container" class="checkbox-container" style="max-height: 100px; overflow-y: auto; border: 1px solid #ccc; padding: 5px;">
+                    <!-- Role checkboxes will be populated here by JavaScript -->
+                    <small>{{_('Loading roles...')}}</small>
+                </div>
+            </div>
+            <hr>
+            <button type="submit" class="button success" style="margin-top: 15px;">{{ _('Create Users') }}</button>
+        </form>
+    </div>
+</div>


### PR DESCRIPTION
The frontend was sending permissions as a comma-separated string, while the backend expected a list of strings. This commit updates the JavaScript in static/js/user_management.js to send the permissions as an array, resolving the 400 error when creating or updating roles.

Feat: Implement bulk user edit functionality

This commit introduces a bulk user editing feature:
- Adds a new API endpoint PUT /api/admin/users/bulk that allows administrators to modify multiple users simultaneously (set admin status, add/remove roles).
- Implements corresponding frontend components in templates/user_management.html and static/js/user_management.js, including a modal for selecting users and specifying changes.
- Includes error handling for partial successes (207 Multi-Status) and safeguards (e.g., preventing removal of the last admin's privileges).

Feat: Implement bulk user add (with pattern) functionality

This commit adds a feature for bulk user creation using a pattern:
- Adds a new API endpoint POST /api/admin/users/bulk_add that allows generating multiple user accounts based on a username pattern (e.g., user###), start index, count, default password, email pattern, admin status, and roles.
- Implements corresponding frontend components, including a modal for inputting pattern parameters and selecting roles.
- Handles username/email conflicts and provides detailed feedback on successful and failed creations (207 Multi-Status).

I've also added backend unit tests for bulk user operations.

I added a new test class TestAdminBulkUserOperations in tests/test_app.py with comprehensive unit tests for the new bulk edit and bulk add API endpoints. These tests cover success, partial success, failure, and edge case scenarios, verifying API responses and database state changes.