### PR TITLE
fix: Add missing CSRF token to booking settings form

### DIFF
--- a/templates/admin_booking_settings.html
+++ b/templates/admin_booking_settings.html
@@ -6,8 +6,7 @@
     <h1>{{ _('Booking Settings') }}</h1>
 
     <form method="POST" action="{{ url_for('admin_ui.update_booking_settings') }}" class="form-stacked">
-        {# CSRF token if using Flask-WTF or similar #}
-        {# {{ form.csrf_token }} #}
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
 
         <div class="form-group">
             <input type="checkbox" id="allow_past_bookings" name="allow_past_bookings" {% if settings.allow_past_bookings %}checked{% endif %}>


### PR DESCRIPTION
This commit resolves a CSRF error that occurred when submitting the admin booking settings form. The `csrf_token()` was missing from the `admin_booking_settings.html` template.

Changes:
- Added `<input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>` to the form in `templates/admin_booking_settings.html`.
- Verified that CSRF protection is initialized in `app_factory.py`, confirming `csrf_token()` is the correct method.

This ensures that the form submission includes the necessary CSRF token, allowing settings to be updated without error.