### PR TITLE
Fix: Prevent AttributeError in bulk_add_users_pattern

### DIFF
--- a/routes/api_users.py
+++ b/routes/api_users.py
@@ -775,12 +775,12 @@ def bulk_add_users_pattern():
     if not data:
         return jsonify({'error': 'Invalid input. JSON data expected.'}), 400
 
-    username_prefix = data.get('username_prefix', '').strip()
-    username_suffix = data.get('username_suffix', '').strip() # Optional custom suffix for username
+    username_prefix = (data.get('username_prefix') or '').strip()
+    username_suffix = (data.get('username_suffix') or '').strip() # Optional custom suffix for username
     start_number = data.get('start_number')
     count = data.get('count')
-    email_domain = data.get('email_domain', '').strip() # e.g., example.com
-    email_pattern = data.get('email_pattern', '').strip() # e.g., {username}@example.com
+    email_domain = (data.get('email_domain') or '').strip() # e.g., example.com
+    email_pattern = (data.get('email_pattern') or '').strip() # e.g., {username}@example.com
     default_password = data.get('default_password')
     is_admin = data.get('is_admin', False)
     role_ids = data.get('role_ids', [])


### PR DESCRIPTION
Modifies the `bulk_add_users_pattern` endpoint in `routes/api_users.py` to correctly handle cases where optional string fields (`username_prefix`, `username_suffix`, `email_domain`, `email_pattern`) might be `null` in the JSON payload.

The frontend sends `null` for empty optional fields. Previously, your backend code `data.get('key', '').strip()` would result in `None.strip()` if the key's value was `null`, causing an `AttributeError: 'NoneType' object has no attribute 'strip'`.

The fix changes the retrieval logic to `(data.get('key') or '').strip()`, ensuring that a `None` value is converted to an empty string before `.strip()` is called, thus preventing the error.