### PR TITLE
Fix: Send role permissions as an array from frontend

### DIFF
--- a/static/js/user_management.js
+++ b/static/js/user_management.js
@@ -1196,14 +1196,13 @@ document.addEventListener('DOMContentLoaded', function() {
             const id = roleIdInput.value;
             const name = roleNameInput.value.trim();
             const description = roleDescriptionInput.value.trim();
-            const permissions = getSelectedPermissions().join(',');
 
             if (!name) {
                 showError(roleFormModalStatusDiv, 'Role Name is required.');
                 return;
             }
 
-            const roleData = { name, description, permissions };
+            const roleData = { name, description, permissions: getSelectedPermissions() };
             let response;
             try {
                 if (id) { // Edit Role
@@ -1213,6 +1212,7 @@ document.addEventListener('DOMContentLoaded', function() {
                         body: JSON.stringify(roleData)
                     }, roleFormModalStatusDiv);
                 } else { // Add Role
+                    console.log('Role Data being sent:', JSON.stringify(roleData)); // Added for debugging
                     response = await apiCall('/api/admin/roles', {
                         method: 'POST',
                         headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
The backend expects the 'permissions' field to be an array of strings when creating or updating roles. You were previously joining this array into a comma-separated string.

This commit updates `static/js/user_management.js` to send the 'permissions' as an array directly.

A console.log has also been temporarily added to the role submission logic to help debug the data being sent.