### PR TITLE
Fix: Correct AttributeError for strftime in analytics endpoint

### DIFF
--- a/routes/admin_ui.py
+++ b/routes/admin_ui.py
@@ -511,10 +511,10 @@ def analytics_bookings_data():
         thirty_days_ago = datetime.utcnow().date() - timedelta(days=30)
         daily_counts_query = db.session.query(
             Resource.name.label("resource_name"),
-            func.date(Booking.start_time).label('booking_date'),
+            cast(func.date(Booking.start_time), db.Date).label('booking_date'), # Ensure booking_date is a Date object
             func.count(Booking.id).label('booking_count')
         ).join(Resource, Booking.resource_id == Resource.id) \
-        .filter(func.date(Booking.start_time) >= thirty_days_ago) \
+        .filter(cast(func.date(Booking.start_time), db.Date) >= thirty_days_ago) \
         .group_by(Resource.name, func.date(Booking.start_time)) \
         .order_by(Resource.name, func.date(Booking.start_time)) \
         .all()
@@ -522,6 +522,7 @@ def analytics_bookings_data():
         daily_counts_data = {}
         for row in daily_counts_query:
             resource_name = row.resource_name
+            # row.booking_date should now be a date object due to cast in query
             booking_date_str = row.booking_date.strftime('%Y-%m-%d')
             if resource_name not in daily_counts_data:
                 daily_counts_data[resource_name] = []


### PR DESCRIPTION
I resolved an `AttributeError: 'str' object has no attribute 'strftime'` in your `/admin/analytics/data` endpoint.

The error occurred because the `booking_date` field, derived from `func.date(Booking.start_time)`, was sometimes being returned as a string by the database instead of a date object.

The fix involves explicitly casting `func.date(Booking.start_time)` to `db.Date` within the SQLAlchemy query for the `daily_counts_last_30_days` aggregation. This ensures that `booking_date` is consistently a Python `datetime.date` object before `strftime` is called on it.

The corresponding test (`test_admin_analytics_data_endpoint_new_structure`) was reviewed and confirmed to already use `datetime.date` objects for mocking this field, so no changes to your tests were required.