### PR TITLE
Chore: Remove debug console.log from role management

### DIFF
--- a/static/js/user_management.js
+++ b/static/js/user_management.js
@@ -1212,7 +1212,6 @@ document.addEventListener('DOMContentLoaded', function() {
                         body: JSON.stringify(roleData)
                     }, roleFormModalStatusDiv);
                 } else { // Add Role
-                    console.log('Role Data being sent:', JSON.stringify(roleData)); // Added for debugging
                     response = await apiCall('/api/admin/roles', {
                         method: 'POST',
                         headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
I removed the temporary console.log statement that was added to `static/js/user_management.js` for debugging the role creation payload. The underlying issue has been resolved and tested.