### PR TITLE
Fix: Correct attribute for FloorMap join in analytics endpoint

### DIFF
--- a/routes/admin_ui.py
+++ b/routes/admin_ui.py
@@ -551,7 +551,7 @@ def analytics_bookings_data():
             extract('month', Booking.start_time).label('booking_month')
         ).join(Resource, Booking.resource_id == Resource.id) \
          .join(User, Booking.user_name == User.username) \
-         .outerjoin(FloorMap, Resource.map_id == FloorMap.id) # Use outerjoin in case a resource is not mapped
+         .outerjoin(FloorMap, Resource.floor_map_id == FloorMap.id) # Use outerjoin in case a resource is not mapped
 
         all_bookings_for_aggregation = base_query.all()
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -636,11 +636,11 @@ class TestAdminFunctionality(AppTests): # Renamed from AppTests to avoid confusi
         
         # Resources
         # Resource 1: On FloorMap 1, specific equipment, tags, status
-        res1 = Resource(id=301, name='Room 101', capacity=10, equipment='Projector,Whiteboard', tags='meeting,large', status='published', map_id=fm1.id)
+        res1 = Resource(id=301, name='Room 101', capacity=10, equipment='Projector,Whiteboard', tags='meeting,large', status='published', floor_map_id=fm1.id)
         # Resource 2: On FloorMap 2, different attributes
-        res2 = Resource(id=302, name='Room 202', capacity=4, equipment='TV', tags='small,focus', status='maintenance', map_id=fm2.id)
+        res2 = Resource(id=302, name='Room 202', capacity=4, equipment='TV', tags='small,focus', status='maintenance', floor_map_id=fm2.id)
         # Resource 3: Not on any map
-        res3 = Resource(id=303, name='Standalone Booth', capacity=1, equipment='Phone', tags='focus', status='published', map_id=None)
+        res3 = Resource(id=303, name='Standalone Booth', capacity=1, equipment='Phone', tags='focus', status='published', floor_map_id=None)
 
         # Bookings
         # Booking 1: User1, Res1. Start: today 10:00 for 1 hr. (For hour, DOW, month aggregation)


### PR DESCRIPTION
I resolved an `AttributeError: type object 'Resource' has no attribute 'map_id'` in your `/admin/analytics/data` endpoint.

The error was caused by an incorrect attribute name (`map_id`) being used in the SQLAlchemy query when joining the `Resource` model with the `FloorMap` model. The correct attribute for the foreign key is `floor_map_id`.

The fix involves updating the `outerjoin` condition in `routes/admin_ui.py` to use `Resource.floor_map_id == FloorMap.id`.

I also updated the corresponding test (`test_admin_analytics_data_endpoint_new_structure` in `tests/test_app.py`) to use `floor_map_id` in its mock `Resource` object setup, ensuring consistency between the test and application code.