### PR TITLE
Style: Bold 'Configuration' in admin sidebar menu

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -48,7 +48,7 @@
 
         <li id="admin-menu-item" style="display:none;"> <!-- Container for Configuration -->
             <details id="admin-section" open>
-                <summary><span class="menu-text">{{ _('Configuration') }}</span></summary> <!-- Icon removed, text changed -->
+                <summary><span class="menu-text"><b>{{ _('Configuration') }}</b></span></summary> <!-- Icon removed, text changed, text now bold -->
                 <ul class="admin-menu">
                     <li id="user-management-nav-link" style="display: none;">
                         <a href="{{ url_for('admin_ui.serve_user_management_page') }}">{{ _('Users') }}</a> <!-- Icon removed, text changed -->


### PR DESCRIPTION
Wrapped the 'Configuration' text in the admin sidebar menu summary tag with `<b>` tags to make it bold, as per your request. Level 2 menu items under Configuration and other Level 1 items retain their normal font weight.