### PR TITLE
Fix: Correct url_for call in profile template

### DIFF
--- a/templates/profile.html
+++ b/templates/profile.html
@@ -27,6 +27,6 @@
         <p><strong>{{ _('Username:') }}</strong> {{ username }}</p>
         <p><strong>{{ _('Email:') }}</strong> {{ email }}</p>
     </div>
-    <p><a href="{{ url_for('serve_edit_profile_page') }}">{{ _('Edit Profile') }}</a></p>
+    <p><a href="{{ url_for('ui.serve_edit_profile_page') }}">{{ _('Edit Profile') }}</a></p>
 </div>
 {% endblock %}


### PR DESCRIPTION
The url_for call for 'serve_edit_profile_page' in templates/profile.html was missing the blueprint namespace. This caused a werkzeug BuildError when rendering the profile page.

This commit fixes the error by changing the call to url_for('ui.serve_edit_profile_page'), correctly referencing the endpoint within the 'ui' blueprint.