### PR TITLE
Fix: Implement hard delete for admin booking removal

### DIFF
--- a/routes/api_bookings.py
+++ b/routes/api_bookings.py
@@ -914,64 +914,60 @@ def reject_booking_admin(booking_id):
     return jsonify({'success': True}), 200
 
 
-@api_bookings_bp.route('/admin/bookings/<int:booking_id>/cancel', methods=['POST'])
+@api_bookings_bp.route('/admin/bookings/<int:booking_id>/delete', methods=['POST'])
 @login_required
 @permission_required('manage_bookings')
-def admin_cancel_booking(booking_id):
-    current_app.logger.info(f"Admin user {current_user.username} attempting to cancel booking ID: {booking_id}")
+def admin_delete_booking(booking_id):
+    current_app.logger.info(f"Admin user {current_user.username} attempting to delete booking ID: {booking_id}")
     try:
         booking = Booking.query.get(booking_id)
 
         if not booking:
-            current_app.logger.warning(f"Admin cancel attempt: Booking ID {booking_id} not found.")
+            current_app.logger.warning(f"Admin delete attempt: Booking ID {booking_id} not found.")
             return jsonify({'error': 'Booking not found.'}), 404
 
-        terminal_statuses = ['cancelled', 'rejected', 'completed', 'checked_out', 'cancelled_by_admin']
-        if booking.status and booking.status.lower() in terminal_statuses:
-            current_app.logger.warning(f"Admin cancel attempt: Booking ID {booking_id} is already in a terminal state: '{booking.status}'. Action aborted.")
-            return jsonify({'error': f'Booking is already in a terminal state ({booking.status}) and cannot be cancelled again.'}), 400
-
-        original_status = booking.status
+        # Store details for audit log BEFORE deleting the booking
+        original_status = booking.status # Keep for audit log context if needed
         resource_name = booking.resource_booked.name if booking.resource_booked else "Unknown Resource"
         booking_title = booking.title or "N/A"
-        booking_date_str = booking.start_time.strftime('%Y-%m-%d')
         user_name_of_booking = booking.user_name
         resource_id_of_booking = booking.resource_id
+        # booking_date_str = booking.start_time.strftime('%Y-%m-%d') # Not strictly needed for delete log
 
-        booking.status = 'cancelled_by_admin'
-        booking.admin_deleted_message = f"This booking for '{booking_title}' on {booking_date_str} for resource '{resource_name}' was cancelled by an administrator."
+        # No need to check terminal_statuses if we are deleting,
+        # unless there's a business rule against deleting already "terminated" bookings.
+        # For now, allowing deletion regardless of status.
 
+        db.session.delete(booking)
         db.session.commit()
 
         audit_details = (
-            f"Admin '{current_user.username}' cancelled booking ID {booking_id}. "
-            f"Original status: '{original_status}', New status: '{booking.status}'. "
+            f"Admin '{current_user.username}' DELETED booking ID {booking_id}. "
+            f"Original status was: '{original_status}'. "
             f"Booked by: '{user_name_of_booking}'. "
             f"Resource: '{resource_name}' (ID: {resource_id_of_booking}). "
-            f"Title: '{booking_title}'. "
-            f"Cancellation reason: '{booking.admin_deleted_message}'."
+            f"Title: '{booking_title}'."
         )
-        add_audit_log(action="ADMIN_CANCEL_BOOKING", details=audit_details)
+        add_audit_log(action="ADMIN_DELETE_BOOKING", details=audit_details)
 
         socketio.emit('booking_updated', {
-            'action': 'cancelled_by_admin',
+            'action': 'deleted_by_admin', # New action
             'booking_id': booking_id,
-            'resource_id': resource_id_of_booking,
-            'status': booking.status,
-            'admin_deleted_message': booking.admin_deleted_message
+            'resource_id': resource_id_of_booking
+            # No status or admin_deleted_message needed as it's deleted
         })
 
-        current_app.logger.info(f"Admin user {current_user.username} successfully cancelled booking ID: {booking_id}. New status: {booking.status}")
-        return jsonify({'message': 'Booking cancelled successfully by admin.', 'booking_id': booking_id, 'new_status': booking.status, 'admin_message': booking.admin_deleted_message}), 200
+        current_app.logger.info(f"Admin user {current_user.username} successfully DELETED booking ID: {booking_id}.")
+        return jsonify({'message': 'Booking deleted successfully by admin.', 'booking_id': booking_id}), 200
 
     except Exception as e:
         db.session.rollback()
         current_app.logger.exception(f"Error during admin deletion of booking ID {booking_id}:")
         add_audit_log(
-            action="ADMIN_CANCEL_BOOKING_FAILED",
-            details=f"Admin '{current_user.username}' failed to cancel booking ID {booking_id}. Error: {str(e)}"
+            action="ADMIN_DELETE_BOOKING_FAILED", # New action name
+            details=f"Admin '{current_user.username}' failed to DELETE booking ID {booking_id}. Error: {str(e)}"
         )
-        return jsonify({'error': 'Failed to cancel booking due to a server error.'}), 500
+        return jsonify({'error': 'Failed to delete booking due to a server error.'}), 500
 
 
 @api_bookings_bp.route('/bookings/<int:booking_id>/clear_admin_message', methods=['POST'])

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1917,43 +1917,44 @@ class TestAdminBookings(AppTests):
         self.assertIn(b'Admin Bookings Management', response_admin.data) # Check for page title/heading
         self.logout()
 
-    def test_admin_delete_booking_success(self):
-        """Test successful deletion of a booking by an admin."""
-        admin_user = self._create_admin_user(username="admindeleteuser", email_ext="admindelete")
+    def test_admin_hard_delete_booking_success(self):
+        """Test successful hard deletion of a booking by an admin."""
+        admin_user = self._create_admin_user(username="adminharddeleteuser", email_ext="adminharddelete")
         self.login(admin_user.username, 'adminpass')
 
-        # Create a booking to be deleted
         booking_owner = User.query.filter_by(username='testuser').first()
         self.assertIsNotNone(booking_owner, "Test user 'testuser' not found for booking creation.")
 
         booking_to_delete = self._create_booking(
             user_name=booking_owner.username,
             resource_id=self.resource1.id,
-            start_offset_hours=24, # Ensure it's in the future and not terminal
-            title="Booking Scheduled for Deletion"
+            start_offset_hours=24,
+            title="Booking To Be Hard Deleted"
         )
         booking_id_to_delete = booking_to_delete.id
-        self.assertIsNotNone(Booking.query.get(booking_id_to_delete), "Booking creation failed for delete test.")
+        original_booking_title = booking_to_delete.title
+        original_resource_name = self.resource1.name
+        original_user_name = booking_owner.username
 
-        # Call the admin delete endpoint (which is currently the 'cancel' route)
-        response = self.client.post(f'/api/admin/bookings/{booking_id_to_delete}/cancel')
+        self.assertIsNotNone(Booking.query.get(booking_id_to_delete), "Booking creation failed for hard delete test.")
+
+        response = self.client.post(f'/api/admin/bookings/{booking_id_to_delete}/delete')
 
         self.assertEqual(response.status_code, 200, f"API call failed: {response.get_data(as_text=True)}")
         response_data = response.get_json()
         self.assertEqual(response_data.get('message'), 'Booking deleted successfully by admin.')
         self.assertEqual(response_data.get('booking_id'), booking_id_to_delete)
 
-        # Verify booking is deleted from DB
         self.assertIsNone(Booking.query.get(booking_id_to_delete), "Booking was not deleted from the database.")
 
-        # Verify audit log
         audit_log = AuditLog.query.filter_by(action="ADMIN_DELETE_BOOKING", user_id=admin_user.id).order_by(AuditLog.id.desc()).first()
         self.assertIsNotNone(audit_log, "ADMIN_DELETE_BOOKING audit log not found.")
-        self.assertIn(f"Admin '{admin_user.username}' deleted booking ID {booking_id_to_delete}", audit_log.details)
-        self.assertIn(f"Booked by: '{booking_owner.username}'", audit_log.details)
-        self.assertIn(f"Resource: '{self.resource1.name}'", audit_log.details)
-        self.assertIn(f"Title: '{booking_to_delete.title}'", audit_log.details)
-        self.assertIn("Deletion message: 'This booking was deleted by an administrator.'", audit_log.details)
+        self.assertIn(f"Admin '{admin_user.username}' DELETED booking ID {booking_id_to_delete}", audit_log.details)
+        self.assertIn(f"Booked by: '{original_user_name}'", audit_log.details)
+        self.assertIn(f"Resource: '{original_resource_name}'", audit_log.details)
+        self.assertIn(f"Title: '{original_booking_title}'", audit_log.details)
+        self.assertNotIn("Deletion message:", audit_log.details) # Ensure no cancellation message part
+        self.assertNotIn("cancelled booking", audit_log.details.lower()) # Ensure it says deleted, not cancelled
 
         self.logout()
 
@@ -1963,7 +1964,7 @@ class TestAdminBookings(AppTests):
         self.login(admin_user.username, 'adminpass')
 
         non_existent_booking_id = 99999
-        response = self.client.post(f'/api/admin/bookings/{non_existent_booking_id}/cancel')
+        response = self.client.post(f'/api/admin/bookings/{non_existent_booking_id}/delete')
         self.assertEqual(response.status_code, 404)
         self.assertIn('Booking not found', response.get_json().get('error', ''))
 
@@ -1971,39 +1972,47 @@ class TestAdminBookings(AppTests):
 
     def test_admin_delete_booking_no_permission(self):
         """Test non-admin (or admin without permission) attempting to delete a booking."""
-        # Create a booking
         booking_to_delete = self._create_booking(user_name='testuser', resource_id=self.resource1.id, start_offset_hours=24)
 
-        # Login as a non-admin user
-        self.login('testuser', 'password') # 'testuser' is not an admin and has no 'manage_bookings' permission
+        self.login('testuser', 'password')
 
-        response = self.client.post(f'/api/admin/bookings/{booking_to_delete.id}/cancel')
+        response = self.client.post(f'/api/admin/bookings/{booking_to_delete.id}/delete')
         self.assertEqual(response.status_code, 403, "Non-admin user should be forbidden to delete bookings via admin route.")
 
-        # Verify booking still exists
         self.assertIsNotNone(Booking.query.get(booking_to_delete.id))
         self.logout()
 
-    def test_admin_delete_already_terminal_booking(self):
-        """Test admin attempting to delete a booking already in a terminal state."""
-        admin_user = self._create_admin_user(username="admin_del_terminal", email_ext="admindelterminal")
+    def test_admin_delete_completed_booking_success(self):
+        """Test admin deleting a booking that is already 'completed'."""
+        admin_user = self._create_admin_user(username="admin_del_completed", email_ext="admindelcompleted")
         self.login(admin_user.username, 'adminpass')
 
-        booking = self._create_booking(user_name='testuser', resource_id=self.resource1.id, start_offset_hours=1, title="Terminal Test")
+        booking_owner = User.query.filter_by(username='testuser').first()
+        booking = self._create_booking(user_name=booking_owner.username, resource_id=self.resource1.id, start_offset_hours=1, title="Completed Deletable Test")
         booking_id = booking.id
-
-        # Manually set booking to a terminal status, e.g., 'completed' or 'cancelled'
-        booking.status = 'completed'
+        booking.status = 'completed' # Set to a terminal status
         db.session.commit()
 
-        response = self.client.post(f'/api/admin/bookings/{booking_id}/cancel') # Attempt delete
-        self.assertEqual(response.status_code, 400)
-        json_data = response.get_json()
-        self.assertIn(f"Booking is already in a terminal state ({booking.status}) and cannot be deleted this way.", json_data.get('error', ''))
+        original_booking_title = booking.title
+        original_resource_name = self.resource1.name
 
-        # Verify booking was not hard-deleted in this case
-        self.assertIsNotNone(Booking.query.get(booking_id))
-        self.assertEqual(Booking.query.get(booking_id).status, 'completed') # Status should remain 'completed'
+        self.assertIsNotNone(Booking.query.get(booking_id), "Booking setup failed.")
+
+        response = self.client.post(f'/api/admin/bookings/{booking_id}/delete')
+        self.assertEqual(response.status_code, 200, f"API call failed: {response.get_data(as_text=True)}")
+        response_data = response.get_json()
+        self.assertEqual(response_data.get('message'), 'Booking deleted successfully by admin.')
+        self.assertEqual(response_data.get('booking_id'), booking_id)
+
+        self.assertIsNone(Booking.query.get(booking_id), "Completed booking was not deleted from the database.")
+
+        audit_log = AuditLog.query.filter_by(action="ADMIN_DELETE_BOOKING", user_id=admin_user.id).order_by(AuditLog.id.desc()).first()
+        self.assertIsNotNone(audit_log, "ADMIN_DELETE_BOOKING audit log not found for completed booking.")
+        self.assertIn(f"Admin '{admin_user.username}' DELETED booking ID {booking_id}", audit_log.details)
+        self.assertIn(f"Original status was: 'completed'", audit_log.details)
+        self.assertIn(f"Booked by: '{booking_owner.username}'", audit_log.details)
+        self.assertIn(f"Resource: '{original_resource_name}'", audit_log.details)
+        self.assertIn(f"Title: '{original_booking_title}'", audit_log.details)
 
         self.logout()
 
@@ -2027,140 +2036,28 @@ class TestAdminBookings(AppTests):
 
         self.assertIn(booking1.title, html_content)
         self.assertIn(booking1.user_name, html_content) # testuser
-        self.assertIn(self.resource1.name, html_content) # Room A
+        self.assertIn(self.resource1.name, html_content)
 
         self.assertIn(booking2.title, html_content)
-        self.assertIn(booking2.user_name, html_content) # testuser2
-        self.assertIn(self.resource2.name, html_content) # Room B
+        self.assertIn(booking2.user_name, html_content)
+        self.assertIn(self.resource2.name, html_content)
         self.logout()
 
-    def test_admin_cancel_booking_permission(self):
-        """Test permissions for the admin cancel booking API endpoint."""
+    def test_admin_delete_booking_permission(self):
+        """Test permissions for the admin delete booking API endpoint."""
         booking = self._create_booking(user_name='testuser', resource_id=self.resource1.id, start_offset_hours=1)
 
         # Unauthenticated
-        response_unauth = self.client.post(f'/api/admin/bookings/{booking.id}/cancel')
-        self.assertEqual(response_unauth.status_code, 401) # Expect 401 for API if not logged in
+        response_unauth = self.client.post(f'/api/admin/bookings/{booking.id}/delete')
+        self.assertEqual(response_unauth.status_code, 401)
 
         # Non-admin login
         self.login('testuser', 'password')
-        response_non_admin = self.client.post(f'/api/admin/bookings/{booking.id}/cancel')
+        response_non_admin = self.client.post(f'/api/admin/bookings/{booking.id}/delete')
         self.assertEqual(response_non_admin.status_code, 403)
         self.logout()
 
-        # Admin with permission should be tested in functionality test
-
-    def test_admin_cancel_booking_functionality(self):
-        """Test functionality of admin cancelling a booking."""
-        admin = self._create_admin_user()
-        self.login(admin.username, 'adminpass')
-
-        booking_user = User.query.filter_by(username='testuser').first()
-        booking = self._create_booking(user_name=booking_user.username, resource_id=self.resource1.id, start_offset_hours=1, title="To Be Cancelled")
-        initial_status = booking.status
-        self.assertNotEqual(initial_status, 'cancelled')
-
-        response = self.client.post(f'/api/admin/bookings/{booking.id}/cancel')
-        self.assertEqual(response.status_code, 200)
-        json_data = response.get_json()
-        self.assertTrue(json_data.get('message'), 'Booking cancelled successfully')
-        self.assertEqual(json_data.get('new_status'), 'cancelled')
-
-        # Verify booking status in DB
-        updated_booking = Booking.query.get(booking.id)
-        self.assertEqual(updated_booking.status, 'cancelled')
-
-        # Verify audit log
-        audit_log = AuditLog.query.filter(
-            AuditLog.action == "ADMIN_CANCEL_BOOKING",
-            AuditLog.user_id == admin.id
-        ).order_by(AuditLog.id.desc()).first()
-
-        self.assertIsNotNone(audit_log)
-        self.assertIn(f"Admin '{admin.username}' cancelled booking ID {booking.id}", audit_log.details)
-        self.assertIn(f"Booked by: '{booking_user.username}'", audit_log.details)
-        self.assertIn(f"Resource: '{self.resource1.name}'", audit_log.details)
-        self.assertIn(f"Title: '{booking.title}'", audit_log.details)
-        # The admin_deleted_message is set on the object before deletion, so the old audit log details for cancellation
-        # would not have included it. The new ADMIN_DELETE_BOOKING action does.
-        # If we were testing the old cancel, this assertion would be fine.
-        # The admin_deleted_message is now part of the cancellation process.
-        self.assertIn(f"Cancellation reason: 'This booking for '{booking.title}'", audit_log.details)
-        self.assertIn("was cancelled by an administrator.'", audit_log.details)
-
-        self.logout()
-
-    def test_admin_cancel_booking_retains_record(self):
-        """Test that admin cancelling a booking retains the record and sets status."""
-        admin_user = self._create_admin_user(username="admin_retain_user", email_ext="adminretain")
-        self.login(admin_user.username, 'adminpass')
-
-        regular_user = User.query.filter_by(username='testuser').first()
-        booking_to_cancel = self._create_booking(
-            user_name=regular_user.username,
-            resource_id=self.resource1.id,
-            start_offset_hours=24,
-            title="Booking for Status Check"
-        )
-        booking_id = booking_to_cancel.id
-        original_title = booking_to_cancel.title
-        booking_date_str = booking_to_cancel.start_time.strftime('%Y-%m-%d')
-
-
-        response = self.client.post(f'/api/admin/bookings/{booking_id}/cancel')
-
-        self.assertEqual(response.status_code, 200)
-        json_data = response.get_json()
-        self.assertEqual(json_data.get('new_status'), 'cancelled_by_admin')
-
-        # Verify booking still exists in DB
-        cancelled_booking_db = Booking.query.get(booking_id)
-        self.assertIsNotNone(cancelled_booking_db)
-
-        # Verify status and message
-        self.assertEqual(cancelled_booking_db.status, 'cancelled_by_admin')
-        self.assertIsNotNone(cancelled_booking_db.admin_deleted_message)
-        expected_message_part = f"This booking for '{original_title}' on {booking_date_str} for resource '{self.resource1.name}' was cancelled by an administrator."
-        self.assertEqual(cancelled_booking_db.admin_deleted_message, expected_message_part)
-
-        # Verify audit log
-        audit_log = AuditLog.query.filter(
-            AuditLog.action == "ADMIN_CANCEL_BOOKING",
-            AuditLog.user_id == admin_user.id
-        ).order_by(AuditLog.id.desc()).first()
-        self.assertIsNotNone(audit_log)
-        self.assertIn(f"Admin '{admin_user.username}' cancelled booking ID {booking_id}", audit_log.details)
-        self.assertIn(f"New status: 'cancelled_by_admin'", audit_log.details)
-        self.assertIn(f"Cancellation reason: '{expected_message_part}'", audit_log.details)
-
-        self.logout()
-
-    def test_admin_cancel_already_cancelled_booking(self):
-        """Test attempting to cancel/delete an already cancelled booking by admin."""
-        admin = self._create_admin_user(username="admin_cancel_cancelled", email_ext="admincancelcancelled")
-        self.login(admin.username, 'adminpass')
-
-        booking = self._create_booking(user_name='testuser', resource_id=self.resource1.id, start_offset_hours=1)
-        booking_id = booking.id
-
-        # Set status to 'cancelled' to simulate an already cancelled booking
-        booking.status = 'cancelled'
-        db.session.commit()
-
-        # Attempt to "cancel" (which is now delete) this booking
-        response = self.client.post(f'/api/admin/bookings/{booking_id}/cancel')
-
-        # The endpoint logic checks for terminal status.
-        self.assertEqual(response.status_code, 400)
-        json_data = response.get_json()
-        # The error message might have changed if the action is 'cancel' vs 'delete'
-        self.assertIn(f"Booking is already in a terminal state (cancelled) and cannot be cancelled again.", json_data.get('error', ''))
-
-        # Verify booking was not modified further
-        self.assertIsNotNone(Booking.query.get(booking_id))
-        self.assertEqual(Booking.query.get(booking_id).status, 'cancelled') # Should remain 'cancelled'
-        self.assertIsNone(Booking.query.get(booking_id).admin_deleted_message) # Should not have admin message if it was user-cancelled
-        self.logout()
+        # Admin with permission is tested in test_admin_hard_delete_booking_success
 
     def test_admin_clear_booking_message_success(self):
         """Test admin clearing a 'cancelled_by_admin' booking's message."""


### PR DESCRIPTION
Previously, the admin function to remove a booking would only mark it as 'cancelled_by_admin' and add a message. This meant the booking record still existed and would appear in your booking list, albeit with a cancellation notice.

This commit changes the behavior to perform a true hard delete of the booking record from the database when an admin deletes a booking.

Changes include:
- Modified the `admin_delete_booking` function (previously `admin_cancel_booking`) in `routes/api_bookings.py` to use `db.session.delete()` on the booking object.
- Updated the API endpoint from `/api/admin/bookings/<id>/cancel` to `/api/admin/bookings/<id>/delete` to accurately reflect the action.
- Ensured audit logs correctly record the deletion event as "ADMIN_DELETE_BOOKING".
- Removed the check that prevented deletion of bookings in a terminal state (e.g., 'completed', 'cancelled'), allowing admins to fully remove such records.
- Added `test_admin_hard_delete_booking_success` to specifically verify the hard-delete functionality.
- Updated related admin booking tests (`test_admin_delete_booking_not_found`, `test_admin_delete_booking_no_permission`, `test_admin_delete_completed_booking_success`, `test_admin_delete_booking_permission`) to use the new `/delete` endpoint and reflect the hard-delete behavior.

This ensures that when an admin deletes a booking, it is completely removed from the system and will no longer be visible to you or in general admin listings.