### PR TITLE
Fix: Prevent booking in past on the same day

### DIFF
--- a/routes/api_bookings.py
+++ b/routes/api_bookings.py
@@ -121,8 +121,9 @@ def create_booking():
         # new_booking_start_time is naive, convert to aware UTC if necessary, or compare dates directly if appropriate
         # Assuming new_booking_start_time is effectively local to server, convert to UTC date or compare with local server date.
         # For simplicity with current naive new_booking_start_time, comparing with datetime.utcnow().date()
-        if new_booking_start_time.date() < datetime.utcnow().date():
-            current_app.logger.warning(f"Booking attempt by {current_user.username} for resource {resource_id} in the past ({new_booking_start_time.date()}), not allowed by settings.")
+        # Updated to compare datetime objects directly, not just dates.
+        if new_booking_start_time < datetime.utcnow():
+            current_app.logger.warning(f"Booking attempt by {current_user.username} for resource {resource_id} in the past ({new_booking_start_time}), not allowed by settings.")
             return jsonify({'error': 'Booking in the past is not allowed.'}), 400
 
     # Enforce max_booking_days_in_future


### PR DESCRIPTION
The previous logic for the 'Allow booking creation in the past' setting only compared the date part of the booking time, allowing you to book times that had already passed on the current day.

This commit updates the validation in `routes/api_bookings.py` to compare the full datetime object (date and time) for `new_booking_start_time` against `datetime.utcnow()`.

A new test case has been added to `tests/test_app.py` to verify:
- Bookings for past times on the current day are blocked when the setting is disabled.
- Bookings for past times (e.g., yesterday) are allowed when the setting is enabled.