### PR TITLE
feat: Retrieve all tables in View DB Records

### DIFF
--- a/templates/admin_troubleshooting.html
+++ b/templates/admin_troubleshooting.html
@@ -87,20 +87,27 @@ document.addEventListener('DOMContentLoaded', function () {
 
                         const tableButton = document.createElement('button');
                         tableButton.className = 'btn btn-outline-primary btn-sm mb-1 w-100 text-start';
-                        tableButton.textContent = `${tableName} (${records.length} records)`;
+                        // Adjust button text based on whether records is an array or a message string
+                        tableButton.textContent = `${tableName} (${Array.isArray(records) ? records.length + ' ' + (records.length === 1 ? "{{ _('record') }}" : "{{ _('records') }}") : "{{ _('info') }}"})`;
 
                         const recordsDiv = document.createElement('div');
                         recordsDiv.className = 'db-records-content';
                         recordsDiv.style.display = 'none';
 
-                        if (records.length > 0) {
-                            const preFormattedRecords = document.createElement('pre');
-                            preFormattedRecords.style.whiteSpace = 'pre-wrap';
-                            preFormattedRecords.style.wordBreak = 'break-all';
-                            preFormattedRecords.textContent = JSON.stringify(records, null, 2);
-                            recordsDiv.appendChild(preFormattedRecords);
-                        } else {
-                            recordsDiv.textContent = "{{ _('No records found for this table.') }}";
+                        if (Array.isArray(records)) {
+                            if (records.length > 0) {
+                                const preFormattedRecords = document.createElement('pre');
+                                preFormattedRecords.style.whiteSpace = 'pre-wrap';
+                                preFormattedRecords.style.wordBreak = 'break-all';
+                                preFormattedRecords.textContent = JSON.stringify(records, null, 2);
+                                recordsDiv.appendChild(preFormattedRecords);
+                            } else {
+                                recordsDiv.textContent = "{{ _('No records found for this table.') }}";
+                            }
+                        } else if (typeof records === 'string') { // It's an informational message (e.g. for skipped tables)
+                            recordsDiv.textContent = records;
+                        } else { // Fallback for unexpected data type
+                            recordsDiv.textContent = "{{ _('Unexpected data format for this table.') }}";
                         }
 
                         tableButton.addEventListener('click', function() {


### PR DESCRIPTION
This commit modifies the 'View DB Records' functionality in the admin troubleshooting section to display all tables from the database instead of a fixed set.

Changes include:
- Updated the `/api/admin/view_db_raw_top100` endpoint in `routes/api_system.py` to dynamically fetch all table names from `db.metadata.tables.keys()` and retrieve the top 100 records for each. For tables that do not have a direct model mapping (e.g., association tables), an informational message is provided.
- Modified the JavaScript in `templates/admin_troubleshooting.html` to correctly render the data for all tables, including handling the informational messages for skipped tables.
- Added a new test case in `tests/test_app.py` to ensure the API endpoint returns data for all tables as expected and the response structure is correct.