### PR TITLE
fix: Correct AttributeError in View DB Records API

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -721,17 +721,15 @@ class TestAdminFunctionality(AppTests): # Renamed from AppTests to avoid confusi
         for table_name in all_db_table_names:
             self.assertIn(table_name, response_table_keys, f"Table '{table_name}' not found in API response.")
 
-            table_content = data['data'][table_name]
-            # The content should be a list (of records, or an empty list, or a list with an info dict for skipped)
-            self.assertIsInstance(table_content, list, f"Content for table '{table_name}' should be a list.")
+            table_value = data['data'][table_name]
 
-            if table_content: # If the list is not empty
-                # If it's an info message for a skipped table, it's a list with one dict: e.g. [{"info": "Skipped..."}]
-                if "info" in table_content[0]:
-                    self.assertTrue(isinstance(table_content[0]["info"], str))
-                else: # Otherwise, it's a list of records (dictionaries)
-                    for record in table_content:
-                        self.assertIsInstance(record, dict)
+            if isinstance(table_value, list):
+                # If it's a list, it should be a list of records (dictionaries) or an empty list.
+                for record in table_value: # This loop is skipped if table_value is an empty list.
+                    self.assertIsInstance(record, dict, f"Record in table '{table_name}' should be a dict.")
+            else:
+                # If not a list, it must be a string (informational message for skipped/problematic table).
+                self.assertIsInstance(table_value, str, f"Skipped/problematic table '{table_name}' entry should be a string message. Got: {type(table_value)}")
 
         # Verify that all keys in response data are actual table names (no extra keys)
         for response_key in response_table_keys:


### PR DESCRIPTION
This commit fixes an AttributeError in the `/api/admin/view_db_raw_top100` endpoint that occurred when trying to access `db.Model._decl_class_registry`.

The fix involves:
- Modifying `routes/api_system.py` to use public SQLAlchemy APIs for introspection:
    - Table names are retrieved using `db.metadata.tables.keys()`.
    - Mapped model classes are looked up using `db.Model.registry.mappers`.
    - For tables without an explicit Python model class (e.g., association tables), the code now falls back to querying the table directly using the SQLAlchemy `Table` object (`db.session.query(table_obj)`).
- Records obtained from direct table queries are serialized correctly, including handling for `datetime` and `uuid` types.
- If processing a specific table fails, an informational string message is returned for that table in the API response.
- Updated the corresponding test `test_view_db_raw_top100_all_tables` in `tests/test_app.py` to align with the new API response format where skipped/problematic tables are represented by a direct string message instead of a list containing an object.