### PR TITLE
fix: Correct HTML structure for filter columns in DB browser

### DIFF
--- a/templates/admin_troubleshooting.html
+++ b/templates/admin_troubleshooting.html
@@ -26,8 +26,9 @@
 
                         <div id="db-filter-area" class="mb-3" style="display: none;">
                             <h5>{{ _('Filters') }}</h5>
-                            <div id="db-filter-controls-container">
-                                 <p>{{ _('Select a table to see available filters.') }}</p>
+                            <div id="db-filter-controls-container" class="row">
+                                <div id="db-filter-col-1" class="col-md-6"></div>
+                                <div id="db-filter-col-2" class="col-md-6"></div>
                             </div>
                             <button id="db-apply-filters-btn" class="btn btn-primary mt-2">{{ _('Apply Filters') }}</button>
                             <button id="db-clear-filters-btn" class="btn btn-secondary mt-2">{{ _('Clear Filters') }}</button>
@@ -156,8 +157,10 @@ document.addEventListener('DOMContentLoaded', function () {
         const dbFilterCol2 = document.getElementById('db-filter-col-2');
 
         if (!dbFilterCol1 || !dbFilterCol2) {
-            console.error('Filter columns not found in DOM.');
-            updateDbViewStatus('{{ _("Internal UI error: Filter columns not found.") }}', true);
+            console.error('CRITICAL: Filter column elements (db-filter-col-1 or db-filter-col-2) are null/not found in DOM immediately after getElementById within loadTableInfoAndGenerateFilters.');
+            if (typeof updateDbViewStatus === 'function') {
+                updateDbViewStatus('Internal UI error: Filter layout components are missing. Please try refreshing.', true);
+            }
             return;
         }
 


### PR DESCRIPTION
This commit fixes the HTML structure in `templates/admin_troubleshooting.html` for the database browser's filter area.

The `db-filter-controls-container` div was missing the `class="row"` attribute, and its children divs, `db-filter-col-1` and `db-filter-col-2` (for the two-column layout), were not present in the HTML. This caused the "Filter columns not found in DOM" JavaScript error.

Changes:
- Added `class="row"` to `div#db-filter-controls-container`.
- Added `<div id="db-filter-col-1" class="col-md-6"></div>` and `<div id="db-filter-col-2" class="col-md-6"></div>` as children of `db-filter-controls-container`.
- Removed the old placeholder paragraph from within `db-filter-controls-container`.

A diagnostic log remains in `loadTableInfoAndGenerateFilters` to help confirm during testing that these column elements are now found.