### PR TITLE
Refactor: Arrange analytics filters horizontally

### DIFF
--- a/templates/analytics.html
+++ b/templates/analytics.html
@@ -28,7 +28,8 @@
     }
     .filter-section .form-group {
         margin-right: 15px;
-        margin-bottom: 10px; /* Add some bottom margin for wrapped elements */
+        /* margin-bottom: 10px; */ /* Add some bottom margin for wrapped elements */
+        display: inline-flex;
     }
     h1, h2 {
         color: #333;


### PR DESCRIPTION
I modified the inline CSS for the analytics page to display filters in a horizontal layout.

- I changed `.filter-section .form-group` to use `display: inline-flex`.
- I removed `margin-bottom` from this class to prevent premature wrapping.

The parent form's `flex-wrap: wrap` property will ensure responsiveness on smaller screens, allowing filters to wrap to the next line as needed.