### PR TITLE
fix: Prevent double submission of map upload form

### DIFF
--- a/templates/admin_maps.html
+++ b/templates/admin_maps.html
@@ -479,6 +479,8 @@
         if (uploadMapForm) {
             uploadMapForm.addEventListener('submit', async function(event) {
                 event.preventDefault();
+                event.stopImmediatePropagation(); // Prevent other listeners on this form
+
                 showStatus(uploadStatusDiv, '{{ _("Uploading map...") }}');
                 const formData = new FormData(uploadMapForm);
                 try {


### PR DESCRIPTION
Addresses an issue where the 'Upload New Floor Map' form was being submitted twice, leading to an initial successful upload (201) followed by a failed attempt (500 - UNIQUE constraint error) for the same map data.

The root cause was identified as two JavaScript event listeners being active for the same form (`#upload-map-form`):
1. A newer handler in the inline script of `templates/admin_maps.html`.
2. An older handler in `static/js/script.js`.

This commit modifies the event listener within the inline script in `templates/admin_maps.html` by adding
`event.stopImmediatePropagation()` immediately after `event.preventDefault()`. This ensures that only this more specific and current handler executes, preventing the redundant handler in `static/js/script.js` from also processing the event and attempting a second form action.

The redundant handler in `static/js/script.js` has not been removed at this time to avoid potential disruption to other functionalities (like 'Define Areas') that share the same conditional block in that file. The `stopImmediatePropagation()` provides a targeted and safe fix for the reported double form action problem.