### PR TITLE
fix: Resolve "Define Areas" errors and integrate map offsets

### DIFF
--- a/templates/admin_maps.html
+++ b/templates/admin_maps.html
@@ -405,16 +405,41 @@
 
                 window.currentMapContext = { mapId, mapName, imageUrl, offsetX, offsetY };
 
+                // Populate resources dropdown (can happen before image load)
                 if (typeof window.populateResourcesForMapping === 'function') {
                     window.populateResourcesForMapping(mapId);
                 } else {
                     console.warn('populateResourcesForMapping function not found.');
                 }
-                if (typeof window.fetchAndDrawExistingMapAreas === 'function') {
-                    window.fetchAndDrawExistingMapAreas(mapId);
+
+                // Ensure canvas logic runs after image is loaded
+                const selectedMapImageElForLoad = document.getElementById('selected-map-image'); // Re-fetch to be sure
+                if (selectedMapImageElForLoad) { // Check if element exists
+                    selectedMapImageElForLoad.onload = function() {
+                        console.log("Map image loaded. Initializing canvas and drawing areas.");
+                        if (typeof window.initializeDefineAreasCanvasLogic === 'function') {
+                            window.initializeDefineAreasCanvasLogic();
+                        } else {
+                            console.warn('initializeDefineAreasCanvasLogic function not found.');
+                        }
+                        if (typeof window.fetchAndDrawExistingMapAreas === 'function') {
+                            window.fetchAndDrawExistingMapAreas(mapId);
+                        } else {
+                            console.warn('fetchAndDrawExistingMapAreas function not found.');
+                        }
+                    };
+                    // If the image is already loaded from cache, 'onload' might not fire.
+                    // Trigger it manually if complete and naturalWidth > 0.
+                    if (selectedMapImageElForLoad.complete && selectedMapImageElForLoad.naturalWidth && selectedMapImageElForLoad.naturalWidth > 0) {
+                        console.log("Map image already complete, manually triggering onload logic.");
+                        selectedMapImageElForLoad.onload(); // Call the handler directly
+                    } else if (!selectedMapImageElForLoad.src || selectedMapImageElForLoad.src === window.location.href + "#") { // If src is empty or just '#'
+                        console.log("Map image src is empty or '#', not attempting to trigger onload.");
+                    }
                 } else {
-                    console.warn('fetchAndDrawExistingMapAreas function not found.');
+                    console.error("selected-map-image element not found for onload binding.");
                 }
+
                 if(defineAreasSection) defineAreasSection.scrollIntoView({ behavior: 'smooth' });
             } // End of select-map-btn logic
 


### PR DESCRIPTION
This commit addresses issues preventing the "Define Areas" feature on the admin maps page from working correctly, particularly after recent changes to map offset handling and JavaScript structure.

Key changes:

1.  **Exposed Core "Define Areas" Functions (`static/js/script.js`)**:
    *   Functions essential for the "Define Areas" feature
      (`populateResourcesForMapping`, `fetchAndDrawExistingMapAreas`,
      `redrawCanvas`) were explicitly assigned to the `window` object
      to make them globally accessible from the inline script in
      `templates/admin_maps.html`.
    *   A new global function `window.initializeDefineAreasCanvasLogic`
      was created in `script.js` to encapsulate the setup of the
      drawing canvas (dimensions, context, mouse event listeners).

2.  **Integrated Map Offsets into Canvas Logic (`static/js/script.js`)**:
    *   The `redrawCanvas` function and the canvas mouse event handlers
      (`onmousedown`, `onmousemove`, `onmouseup`), now part of
      `initializeDefineAreasCanvasLogic`, were updated.
    *   These functions now read `window.currentMapContext.offsetX` and
      `window.currentMapContext.offsetY` (set by the inline script in
      `admin_maps.html` when a map is selected for area definition).
    *   Coordinate calculations for drawing, moving, and resizing areas
      on the canvas now correctly account for these per-map offsets,
      ensuring that visual representation matches the logical map coordinates.

3.  **Adjusted Initialization in `static/js/script.js`**:
    *   The old event listener in `script.js` that previously handled
      "Define Areas" button clicks (on the now-defunct `<ul>` map list)
      was commented out to prevent conflicts with the new event handling
      in `admin_maps.html`.

4.  **Refined Calls in `templates/admin_maps.html` Inline Script**:
    *   The "Define Areas" button click handler in the inline script
      now correctly calls the globally exposed functions.
    *   `window.initializeDefineAreasCanvasLogic()` and
      `window.fetchAndDrawExistingMapAreas()` are now called within
      the `onload` handler of the selected map image. This ensures the
      canvas is set up with correct dimensions after the image is
      loaded and ready.

These changes should resolve the "function not found" errors and allow the "Define Areas" functionality to operate correctly, respecting individual map offsets.