### PR TITLE
Fix: Update Procfile to help Gunicorn find wsgi module

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: gunicorn --bind=0.0.0.0 --timeout 600 wsgi:app
+web: gunicorn --chdir /home/site/wwwroot --bind=0.0.0.0 --timeout 600 wsgi:app
 


### PR DESCRIPTION
Adds the --chdir /home/site/wwwroot parameter to the gunicorn command in the Procfile.

This change is intended to resolve the `ModuleNotFoundError: No module named 'wsgi'` error that occurs during application startup on Azure App Service. By explicitly setting the working directory for Gunicorn to /home/site/wwwroot (where the application files, including wsgi.py, are deployed), Gunicorn should be able to correctly locate and import the wsgi module.

This addresses a key part of the startup failures. Note that an earlier error in the logs regarding 'requirements.txt' not being found by the Oryx build system may indicate a separate issue related to Azure's build environment configuration, which might require further attention through Azure settings.