### PR TITLE
fix: Resolve SyntaxError caused by loginForm redeclaration

### DIFF
--- a/static/js/script.js
+++ b/static/js/script.js
@@ -667,10 +667,11 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }
 
-    const loginForm = document.getElementById('login-form');
-    const loginMessageDiv = document.getElementById('login-message'); // Ensure this is defined in the scope
+    // loginForm and loginMessageDiv are already declared in this scope from lines ~366-367
+    // const loginForm = document.getElementById('login-form'); // REMOVE DUPLICATE
+    // const loginMessageDiv = document.getElementById('login-message'); // REMOVE DUPLICATE
 
-    if (loginForm) {
+    if (loginForm) { // This loginForm refers to the one declared earlier in the DOMContentLoaded scope
         loginForm.addEventListener('submit', async function(event) {
             console.log('Login form submit event triggered.'); // LOG 1
             event.preventDefault();


### PR DESCRIPTION
This addresses a critical issue that was preventing you from logging in. A `SyntaxError: Identifier 'loginForm' has already been declared` was occurring in `static/js/script.js`. This error halted script execution, preventing the login form's JavaScript submit handler from being properly attached and executed. As a result, `event.preventDefault()` was not called, causing the form to submit via a default GET request with credentials in the URL.

This commit removes the duplicate declaration of `loginForm` (and the associated `loginMessageDiv`) from `static/js/script.js`. The login form event handler now correctly uses the `loginForm` variable that was declared earlier in the `DOMContentLoaded` scope.

With this syntax error resolved, the JavaScript for the login form is expected to run correctly, ensuring that:
- `event.preventDefault()` is called.
- An AJAX POST request is made to `/api/auth/login` with credentials in the request body.
- Login proceeds as intended.

Diagnostic console logs previously added to the login handler remain in place to help confirm the correct execution flow.