### PR TITLE
Fix: Populate roles in Define Areas section on Maps page

### DIFF
--- a/static/js/script.js
+++ b/static/js/script.js
@@ -2233,6 +2233,18 @@ document.addEventListener('DOMContentLoaded', function() {
                     if (count === 0) showSuccess(defineAreasStatusDiv, "No new resources available for mapping to this map.");
                     else if (!defineAreasStatusDiv.classList.contains('error')) hideMessage(defineAreasStatusDiv);
                 }
+
+                // Populate roles checkboxes for the define area section
+                if (typeof window.populateRolesCheckboxesForResource === 'function') {
+                    window.populateRolesCheckboxesForResource('define-area-authorized-roles-checkbox-container');
+                } else {
+                    console.error('populateRolesCheckboxesForResource function not found. Roles for define area cannot be loaded.');
+                    // Optionally, display an error in a relevant status div for the user
+                    const defineAreasStatusDiv = document.getElementById('define-areas-status');
+                    if (defineAreasStatusDiv) {
+                        showError(defineAreasStatusDiv, 'Error: Could not load role selection options.');
+                    }
+                }
             } catch (error) {
                 resourceToMapSelect.innerHTML = '<option value="">Error loading resources</option>';
             }


### PR DESCRIPTION
The 'Define Areas on Selected Map' section was not displaying authorized roles because the JavaScript function responsible for populating the resource dropdown (`populateResourcesForMapping`) did not trigger the separate function (`populateRolesCheckboxesForResource`) to load roles into the designated checkbox container.

This commit modifies `populateResourcesForMapping` in `static/js/script.js` to include a call to `window.populateRolesCheckboxesForResource('define-area-authorized-roles-checkbox-container')`. This ensures that when an admin selects a map to define areas, the associated roles are fetched and displayed correctly, allowing for proper configuration of role-based booking permissions for map areas.