### PR TITLE
Fix: Populate booking details in API response

### DIFF
--- a/routes/api_bookings.py
+++ b/routes/api_bookings.py
@@ -235,6 +235,7 @@ def create_booking():
                 recurrence_rule=recurrence_rule_str
             )
             db.session.add(new_booking)
+            created_bookings.append(new_booking)
             # Defer commit until all bookings in a recurring series are validated and added, or handle rollback for series
         db.session.commit() # Commit all bookings in the series at once
 


### PR DESCRIPTION
The create_booking API endpoint was returning a 201 Created status but with an empty list of bookings in the JSON response. This was because the `created_bookings` list variable was not being appended with the new booking objects after they were added to the database session.

This commit ensures that `new_booking` objects are appended to `created_bookings` within the creation loop. This provides the frontend with the necessary booking details, resolving an issue where the UI would incorrectly report "Booking failed. Unexpected response from server." despite a successful booking on the backend.