### PR TITLE
Fix: Update style of header welcome message

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1196,3 +1196,9 @@ a.fc-daygrid-event.fc-event { /* Targeting the <a> tag specifically */
 /* Time part (text node) will inherit default text handling. */
 /* JavaScript truncation now manages its length. */
 ```
+
+#welcome-message-container {
+    color: black;
+    margin-left: auto;
+    margin-right: 10px;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -22,7 +22,7 @@
             <div id="my-bookings-nav-link" style="display: none;">
                  <a href="{{ url_for('ui.serve_my_bookings_page') }}"><span class="menu-icon" aria-hidden="true">📖</span><span class="menu-text">{{ _('My Bookings') }}</span></a>
             </div>
-            <div id="welcome-message-container" style="display: none; margin-right: 10px; color: white; align-self: center;"></div>
+            <div id="welcome-message-container" style="display: none;"></div>
             <div id="auth-link-container" style="display: none; margin-left:auto;">
                 <a href="{{ url_for('ui.serve_login') }}"><span class="menu-icon" aria-hidden="true">🔑</span><span class="menu-text">{{ _('Login') }}</span></a>
             </div>


### PR DESCRIPTION
The "Welcome, admin!" message in the header was previously styled with inline CSS, setting its color to white and using align-self: center.

This commit updates the styling as follows:
- Moves the styling for #welcome-message-container to static/style.css.
- Changes the text color to black.
- Aligns the message to the right using margin-left: auto and adds a margin-right of 10px for spacing.
- Removes the redundant/conflicting inline styles (color, margin-right, align-self) from templates/base.html.