### PR TITLE
Fix: Adjust header welcome message position

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1199,6 +1199,5 @@ a.fc-daygrid-event.fc-event { /* Targeting the <a> tag specifically */
 
 #welcome-message-container {
     color: black;
-    margin-left: auto;
     margin-right: 10px;
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -22,10 +22,10 @@
             <div id="my-bookings-nav-link" style="display: none;">
                  <a href="{{ url_for('ui.serve_my_bookings_page') }}"><span class="menu-icon" aria-hidden="true">📖</span><span class="menu-text">{{ _('My Bookings') }}</span></a>
             </div>
-            <div id="welcome-message-container" style="display: none;"></div>
             <div id="auth-link-container" style="display: none; margin-left:auto;">
                 <a href="{{ url_for('ui.serve_login') }}"><span class="menu-icon" aria-hidden="true">🔑</span><span class="menu-text">{{ _('Login') }}</span></a>
             </div>
+            <div id="welcome-message-container" style="display: none;"></div>
             <div id="user-dropdown-container" style="display: none; position: relative; margin-left:auto;">
                 <button id="user-dropdown-button" aria-haspopup="true" aria-expanded="false" style="background: none; border: none; color: white; font-size: 1em; cursor: pointer; padding: 10px; font-weight: bold; display:flex; align-items:center;">
                     <span class="user-icon" style="font-size:1.2em;">&#x1F464;</span><span class="dropdown-arrow"> &#9662;</span>


### PR DESCRIPTION
This commit updates the position of the "Welcome, admin!" message in the header to appear immediately before the user profile icon, as per your feedback.

Changes include:
- Reordered elements in `templates/base.html` to place `welcome-message-container` directly before `user-dropdown-container`.
- Adjusted CSS for `#welcome-message-container` in `static/style.css` by removing `margin-left: auto;`. The `user-dropdown-container` (which has `margin-left: auto`) now correctly aligns both elements to the right.