### PR TITLE
Fix: Remove dots appearing around header welcome message

### DIFF
--- a/static/js/script.js
+++ b/static/js/script.js
@@ -220,7 +220,7 @@ async function updateAuthLink() {
 
             if (welcomeMessageContainer) {
                 welcomeMessageContainer.textContent = `Welcome, ${data.user.username}!`;
-                welcomeMessageContainer.style.display = 'list-item';
+                welcomeMessageContainer.style.display = 'flex';
             }
 
             if (userDropdownContainer) userDropdownContainer.style.display = 'list-item';

--- a/static/style.css
+++ b/static/style.css
@@ -1205,3 +1205,9 @@ a.fc-daygrid-event.fc-event { /* Targeting the <a> tag specifically */
     display: flex;         /* For internal alignment if its content needs it */
     align-items: center;   /* For internal alignment */
 }
+
+#welcome-message-container::before,
+#welcome-message-container::after {
+  content: none !important;
+  display: none !important;
+}


### PR DESCRIPTION
This commit resolves an issue where dots were appearing before and after the "Welcome, admin!" message in the header.

The root cause was identified in `static/js/script.js`, where the `welcome-message-container` was being set to
`style.display = 'list-item';`. This likely caused browsers to render list markers.

The fix involves:
- Modifying `static/js/script.js` to set `welcomeMessageContainer.style.display = 'flex';` which is consistent with its intended CSS styling and prevents the list marker rendering.

Previous attempts included adding CSS to explicitly hide ::before and ::after pseudo-elements on the container, which are retained as a safeguard but the primary fix is the JavaScript change.