### PR TITLE
Refine: Map area styling and clickability for booked states

### DIFF
--- a/static/js/new_booking_map.js
+++ b/static/js/new_booking_map.js
@@ -309,17 +309,35 @@ document.addEventListener('DOMContentLoaded', function () {
 
                         areaDiv.classList.add(finalAvailabilityClass);
 
-                        // Make clickable if not fully booked, not unknown, not user conflict, and not restricted
+                        // Determine clickability based *only* on finalAvailabilityClass
+                        // Default to not clickable for restricted, fully-booked, user-conflict, partially-booked, and unknown states.
+                        isMapAreaClickable = false;
+                        if (finalAvailabilityClass === 'resource-area-available') {
+                            // Further check permissions if 'available' could be set despite restrictions (should not happen with current logic order)
+                            // For now, assume 'resource-area-available' implies it passed permission checks.
+                            isMapAreaClickable = true;
+                        }
+
                         if (isMapAreaClickable) {
                             areaDiv.classList.add('map-area-clickable');
+                            // Ensure to clone the node to remove previous listeners if any, before adding a new one.
+                            // However, since areaDiv is created new each time, cloning isn't strictly for listener removal here,
+                            // but good practice if the element were being reused.
+                            const newAreaDiv = areaDiv.cloneNode(true); // Clone to ensure fresh listeners
+                            areaDiv.parentNode.replaceChild(newAreaDiv, areaDiv);
+                            areaDiv = newAreaDiv;
+
                             areaDiv.addEventListener('click', function() {
                                 if (resourceSelectBooking) {
                                     resourceSelectBooking.value = resource.id;
                                     resourceSelectBooking.dispatchEvent(new Event('change'));
                                 }
-                                // Pass userBookingsForDate to openResourceDetailModal
                                 openResourceDetailModal(resource, dateString, userBookingsForDate);
                             });
+                        } else {
+                            areaDiv.classList.remove('map-area-clickable');
+                            // If there's a possibility of old listeners on a non-clickable div (e.g. if not cloned), remove them.
+                            // Since areaDiv is new, this is not an issue here.
                         }
                         // Highlight resource if it's the one selected in the main form
                         if (resourceSelectBooking && resourceSelectBooking.value === resource.id.toString()) {

--- a/static/style.css
+++ b/static/style.css
@@ -1195,4 +1195,85 @@ a.fc-daygrid-event.fc-event { /* Targeting the <a> tag specifically */
 
 /* Time part (text node) will inherit default text handling. */
 /* JavaScript truncation now manages its length. */
-```
+
+/* --------------- MAP RESOURCE AREA STYLES --------------- */
+.resource-area {
+    /* Existing styles from map_view.html: */
+    position: absolute;
+    /* border: 2px solid blue; */ /* Will be overridden by specific states */
+    /* background-color: rgba(0, 0, 255, 0.3); */ /* Will be overridden by specific states */
+    box-sizing: border-box;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    overflow: hidden;
+    /* color: #000; */ /* Will be overridden by specific states */
+    /* font-size: 12px; */ /* Will be overridden by new styles */
+
+    /* New/refined general styles: */
+    padding: 2px;
+    text-overflow: ellipsis;
+    white-space: nowrap; /* Prevent text wrapping that breaks small boxes */
+    font-size: 0.8em; /* Suitable small font size */
+    border-width: 2px; /* Consistent border width */
+    border-style: solid; /* Consistent border style */
+}
+
+/* Available State (Green) */
+.resource-area-available {
+    background-color: rgba(0, 255, 0, 0.15);
+    border-color: rgba(0, 200, 0, 0.6);
+    color: #333333; /* Darker text for light green background */
+}
+
+/* Partially Booked State (Dark Orange) */
+.resource-area-partially-booked {
+    background-color: rgba(255, 140, 0, 0.3); /* Dark Orange background */
+    border-color: rgba(204, 112, 0, 0.7); /* Darker Orange border */
+    color: #ffffff; /* White text for readability */
+}
+
+/* Fully Booked State (Red) */
+.resource-area-fully-booked {
+    background-color: rgba(255, 0, 0, 0.3); /* Red background */
+    border-color: rgba(200, 0, 0, 0.7); /* Darker Red border */
+    color: #ffffff; /* White text for readability */
+}
+
+/* User Conflict State (Red) - Same as Fully Booked */
+.resource-area-user-conflict {
+    background-color: rgba(255, 0, 0, 0.3); /* Red background */
+    border-color: rgba(200, 0, 0, 0.7); /* Darker Red border */
+    color: #ffffff; /* White text for readability */
+}
+
+/* Restricted State (Grey) */
+.resource-area-restricted {
+    background-color: rgba(128, 128, 128, 0.3); /* Grey background */
+    border-color: rgba(100, 100, 100, 0.7); /* Darker Grey border */
+    color: #ffffff; /* White text for readability */
+}
+
+/* Unknown State (Light Grey) */
+.resource-area-unknown {
+    background-color: rgba(200, 200, 200, 0.3); /* Light Grey background */
+    border-color: rgba(150, 150, 150, 0.7); /* Darker Grey border */
+    color: #333333; /* Darker text for light grey background */
+}
+
+/* Clickable Cue (already exists, ensure it's compatible) */
+.map-area-clickable:hover {
+    cursor: pointer;
+    filter: brightness(110%);
+}
+
+/* Selected on form (already exists, ensure it's compatible) */
+.resource-area-form-selected {
+    border-width: 3px; /* Keep slightly thicker for emphasis */
+    border-color: #007bff; /* A distinct highlight color, maybe make this a variable if used elsewhere */
+    box-shadow: 0 0 10px #007bff;
+    /* filter: drop-shadow(0 0 5px #007bff); Could be an alternative to box-shadow */
+}
+
+/* --------------- END MAP RESOURCE AREA STYLES --------------- */


### PR DESCRIPTION
This commit implements specific visual styling and clickability rules for resource areas on the map view (`new_booking_map.js`) based on your feedback.

Key changes:

1.  **Styling Logic (`new_booking_map.js`):**
    *   The `loadMapDetails` function ensures that the correct CSS classes
      are assigned to map areas (`areaDiv`) based on their booking status:
        *   `resource-area-fully-booked` (for red background)
        *   `resource-area-user-conflict` (for red background)
        *   `resource-area-partially-booked` (for dark orange background)
        *   `resource-area-available` (for green/default background)

2.  **Clickability Logic (`new_booking_map.js`):**
    *   Map resource areas are now made non-clickable if their state is
      `resource-area-fully-booked`, `resource-area-user-conflict`,
      OR `resource-area-partially-booked`.
    *   Only areas that are fully `resource-area-available` (and permitted)
      will have a click listener to open the booking modal.

3.  **CSS Styles (`static/style.css`):**
    *   Added CSS rules to provide the specified background colors:
        *   Red for `.resource-area-fully-booked` and
          `.resource-area-user-conflict`.
        *   Dark orange for `.resource-area-partially-booked`.
    *   Ensured appropriate text colors for contrast against these
      backgrounds.
    *   Added general padding and text handling styles for `.resource-area`.

These changes provide clearer visual cues on the map and restrict interaction to only those resources that are fully available to you, aligning with the requested user experience.