### PR TITLE
Fix: Remove trailing dot after header welcome message

### DIFF
--- a/static/js/script.js
+++ b/static/js/script.js
@@ -223,7 +223,7 @@ async function updateAuthLink() {
                 welcomeMessageContainer.style.display = 'flex';
             }
 
-            if (userDropdownContainer) userDropdownContainer.style.display = 'list-item';
+            if (userDropdownContainer) userDropdownContainer.style.display = 'block';
             if (userDropdownButton) {
                 userDropdownButton.innerHTML = `<span class="user-icon">&#x1F464;</span><span class="dropdown-arrow"> &#9662;</span>`;
                 userDropdownButton.setAttribute('aria-expanded', 'false');


### PR DESCRIPTION
This commit resolves an issue where a dot was appearing after the "Welcome, admin!" message. The dot was identified as a list marker for the `user-dropdown-container` element.

The `user-dropdown-container`, which immediately follows the welcome message, was being set to `display: list-item;` in `static/js/script.js` when you are logged in.

The fix involves:
- Modifying `static/js/script.js` in the `updateAuthLink` function to set `userDropdownContainer.style.display = 'block';` instead of `list-item`. This prevents the rendering of the list marker.

This change, along with previous fixes for the welcome message container itself, should ensure no unwanted dots appear in the header.