### PR TITLE
Fix: Refine map color logic for your conflicts on available resources

### DIFF
--- a/static/js/new_booking_map.js
+++ b/static/js/new_booking_map.js
@@ -234,14 +234,17 @@ document.addEventListener('DOMContentLoaded', function () {
                                 // REMOVED: console.log("DEBUG MAP: Path C2 for " + resource.name + ". Assigning map-area-light-blue (Fully Booked by Others).");
                                 finalClass = 'map-area-light-blue';
                                 finalTitle += ' (Fully Booked by Others)';
-                            } else if (numGenerallyBooked === 0) {
-                                // REMOVED: console.log("DEBUG MAP: Path C3 for " + resource.name + " (Generally fully available)");
-                                if (numBookableByCurrentUser === numPrimarySlots) {
-                                    // REMOVED: console.log("DEBUG MAP: Path C3a for " + resource.name + ". Assigning map-area-green.");
+                            } else if (numGenerallyBooked === 0) { // Generally FULLY available (no bookings by anyone on this resource)
+                                if (numBookableByCurrentUser === numPrimarySlots) { // And current user can book all of it (no conflicts from their *other* bookings)
+                                    // console.log("DEBUG MAP: Condition for " + resource.name + ": Generally fully available, all slots available to current user. Assigning map-area-green.");
                                     finalClass = 'map-area-green';
                                     finalTitle += ' (Available)';
-                                } else {
-                                    // REMOVED: console.log("DEBUG MAP: Path C3b for " + resource.name + ". Assigning map-area-light-blue (User schedule conflicts).");
+                                } else if (numBookableByCurrentUser > 0) { // Generally fully available, but user's other conflicts block SOME (but not all) slots
+                                    // console.log("DEBUG MAP: Condition for " + resource.name + ": Generally fully available, but user conflicts block SOME slots. User can still book " + numBookableByCurrentUser + " slots. Assigning map-area-yellow.");
+                                    finalClass = 'map-area-yellow';
+                                    finalTitle += ' (Partially Available to You - Schedule Conflicts)';
+                                } else { // Generally fully available, but user's other schedule conflicts block ALL slots (numBookableByCurrentUser === 0)
+                                    // console.log("DEBUG MAP: Condition for " + resource.name + ": Generally fully available, but user conflicts block ALL slots. Assigning map-area-light-blue.");
                                     finalClass = 'map-area-light-blue';
                                     finalTitle += ' (Unavailable - Your Schedule Conflicts)';
                                 }
@@ -642,4 +645,4 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
 });
-
+// console.log('new_booking_map.js script execution finished.'); // Keep general load confirmation


### PR DESCRIPTION
This commit adjusts the state determination in `new_booking_map.js` to correctly apply 'Yellow' or 'Light Blue' styles when a generally available resource has partial conflicts with your other bookings.

Previously, if a generally fully available (Green) resource had any slot conflicting with your external schedule, it might turn entirely Light Blue.

The updated logic in `loadMapDetails` is now:

- If a resource is generally fully available (no bookings by anyone):
    - It becomes `map-area-green` if all its slots are bookable by you (no external conflicts).
    - It becomes `map-area-yellow` if *some* (but not all) of its slots are bookable by you (i.e., external conflicts block only part of it). The title reflects this partial availability to you.
    - It becomes `map-area-light-blue` if *all* its slots are made unbookable by your external schedule conflicts.

- The logic for resources generally partially available (booked by others) remains: Yellow if you can book the remainder, Light Blue if your conflicts prevent booking the remainder.

This ensures that 'Yellow' is used to indicate that a resource still has portions bookable by you, even if your own schedule makes other parts of it unavailable. 'Light Blue' due to your conflict is reserved for when the resource becomes entirely unbookable for you.

Clickability (Green/Yellow are clickable) and CSS styles are confirmed to align with this refined logic. Debug logs remain for now.