### PR TITLE
fix: Resolve duplicate variable declaration in admin_maps.html

### DIFF
--- a/templates/admin_maps.html
+++ b/templates/admin_maps.html
@@ -487,8 +487,7 @@
                 const mapId = targetButton.dataset.mapId;
                 const row = event.target.closest('tr');
                 const offsetXInput = row.querySelector('.map-offset-x-input');
-                const row = targetButton.closest('tr');
-                const offsetXInput = row.querySelector('.map-offset-x-input');
+                // Removed duplicate: const row = targetButton.closest('tr');
                 const offsetYInput = row.querySelector('.map-offset-y-input');
 
                 const offsetX = parseInt(offsetXInput.value);


### PR DESCRIPTION
Corrects a JavaScript `SyntaxError: Identifier 'row' has already been declared` that occurred in the admin maps interface.

The error was caused by a duplicate `const row` declaration within the event listener for map actions (specifically in the 'update-map-offsets-btn' logic). The redundant declaration has been removed.