### PR TITLE
Fix: Import login_required in auth.py

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -3,7 +3,7 @@ from functools import wraps
 from flask import (
     Blueprint, request, session, redirect, url_for, jsonify, current_app, abort
 )
-from flask_login import current_user, login_user, logout_user
+from flask_login import current_user, login_user, logout_user, login_required
 
 from google_auth_oauthlib.flow import Flow
 from google.oauth2 import id_token


### PR DESCRIPTION
The `login_required` decorator was used in `auth.py` without being imported, causing a `NameError`. This change imports `login_required` from `flask_login` to resolve the error.