### PR TITLE
Fix: Include CSRF token in profile update requests

### DIFF
--- a/templates/edit_profile.html
+++ b/templates/edit_profile.html
@@ -51,6 +51,7 @@
         if (form) {
             form.addEventListener('submit', async function(event) {
                 event.preventDefault();
+                const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
                 const email = document.getElementById('email').value.trim();
                 const first_name = document.getElementById('first_name').value.trim();
                 const last_name = document.getElementById('last_name').value.trim();
@@ -70,7 +71,7 @@
                 try {
                     const response = await fetch('/api/profile', {
                         method: 'PUT',
-                        headers: { 'Content-Type': 'application/json' },
+                        headers: { 'Content-Type': 'application/json', 'X-CSRFToken': csrfToken },
                         body: JSON.stringify({
                             email: email || null,
                             password: password || null,


### PR DESCRIPTION
The PUT request to /api/profile was failing due to a missing CSRF token. This was because the JavaScript making the request was not including the token, which is enforced by the application-wide CSRF protection.

This commit fixes the issue by:
1. Ensuring the CSRF token is available in the `edit_profile.html` page (verified it's already provided by `base.html`).
2. Modifying the JavaScript in `templates/edit_profile.html` to:
    - Retrieve the CSRF token from the `meta[name="csrf-token"]` tag.
    - Include the token in the `X-CSRFToken` header of the `fetch` request to `/api/profile`.

This ensures that profile update requests are properly authenticated against CSRF attacks.