### PR TITLE
Fix: Update header and profile menu alignment

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -27,7 +27,7 @@
                     <button id="user-dropdown-button" aria-haspopup="true" aria-expanded="false" style="background: none; border: none; color: white; font-size: 1em; cursor: pointer; padding: 10px; font-weight: bold; display:flex; align-items:center;">
                         <span class="user-icon" style="font-size:1.2em;">&#x1F464;</span><span class="dropdown-arrow"> &#9662;</span>
                     </button>
-                    <div class="dropdown-menu" id="user-dropdown-menu" style="display: none; position: absolute; top: 100%; left: 0; background-color: #333; border: 1px solid #555; min-width: 160px; z-index: 1000; list-style-type: none; padding: 0; margin: 0; box-shadow: 0 2px 5px rgba(0,0,0,0.2);">
+                    <div class="dropdown-menu" id="user-dropdown-menu" style="display: none; position: absolute; top: 100%; right: 0; background-color: #333; border: 1px solid #555; min-width: 160px; z-index: 1000; list-style-type: none; padding: 0; margin: 0; box-shadow: 0 2px 5px rgba(0,0,0,0.2);">
                         <a class="dropdown-item" href="{{ url_for('ui.serve_profile_page') }}" style="display: block; padding: 10px 15px; text-decoration: none; color: white; text-align: center;">{{ _('Profile') }}</a>
                         <a class="dropdown-item" href="{{ url_for('ui.logout_and_redirect') }}" id="logout-link-dropdown" style="display: block; padding: 10px 15px; text-decoration: none; color: white; text-align: center;">{{ _('Logout') }}</a>
                     </div>


### PR DESCRIPTION
- Removed the Login button from the header as it was redundant. The application automatically redirects to login if you are not authenticated.
- Center-aligned the text for 'Profile' and 'Logout' items within the user dropdown menu.
- Adjusted the profile dropdown menu to align to the right edge of its container, addressing an issue where it appeared off to the left.