### PR TITLE
fix: Correct AttributeError in locations-availability API

### DIFF
--- a/routes/api_maps.py
+++ b/routes/api_maps.py
@@ -66,8 +66,8 @@ def get_locations_availability():
 
                 resources_on_map = Resource.query.filter(
                     Resource.floor_map_id == floor_map.id,
-                    Resource.status == 'published', # Only published resources
-                    Resource.deleted_at.is_(None) # Only non-deleted resources
+                    Resource.status == 'published' # Only published resources
+                    # Resource.deleted_at.is_(None) # This line is removed as per instruction interpretation
                 ).all()
 
                 for resource in resources_on_map:


### PR DESCRIPTION
This commit fixes an AttributeError in the `GET /api/locations-availability` endpoint located in `routes/api_maps.py`.

The error occurred because the `Resource` model was being queried for a non-existent `deleted_at` attribute. My investigation of `models.py` revealed that resource activity is determined by the `status` field, with `'published'` indicating an active resource.

The fix involves:
- Removing the incorrect filter `Resource.deleted_at.is_(None)`.
- Ensuring the query correctly uses `Resource.status == 'published'` to filter for active resources, which was the intended logic.

This change should resolve the 500 Internal Server Error previously encountered when accessing this endpoint and allow your frontend to correctly display location availability.