### PR TITLE
feat: Implement combined Location-Floor buttons with availability

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -494,6 +494,9 @@ input.flatpickr-input {
     color: var(--text-color-dark);
     background-color: #f0f0f0; /* Default neutral background */
     transition: background-color 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
+    white-space: normal; /* Allow text wrapping */
+    word-break: break-word; /* Break words if necessary */
+    text-align: center; /* Center text if it wraps */
 }
 
 .location-button:hover {
@@ -519,7 +522,7 @@ input.flatpickr-input {
     background-color: #ea6a6a; /* Slightly darker red */
 }
 
-.selected-location-button {
+.selected-map-button { /* Renamed from .selected-location-button */
     border-color: var(--accent-color); /* Steel Blue for selected border */
     box-shadow: 0 0 0 0.2rem rgba(70, 130, 180, .25); /* Subtle glow matching accent */
     /* If the JS sets background color for availability, this ensures border/shadow are primary indicators */
@@ -528,8 +531,8 @@ input.flatpickr-input {
     /* color: var(--text-color-light) !important; */
 }
 /* Ensure selected style is prominent even if JS changes background */
-.selected-location-button.location-button-available,
-.selected-location-button.location-button-unavailable {
+.selected-map-button.location-button-available, /* Renamed */
+.selected-map-button.location-button-unavailable { /* Renamed */
     /* border-color: var(--accent-color); /* Already set */
     /* box-shadow: 0 0 0 0.2rem rgba(70, 130, 180, .25); /* Already set */
     /* Potentially make border thicker or add an inner shadow if needed for visibility over colored backgrounds */

--- a/templates/resources.html
+++ b/templates/resources.html
@@ -12,10 +12,9 @@
     <div style="margin-top: 10px; margin-bottom: 10px;">
         <label>{{ _('Location:') }}</label> <!-- Consider removing or updating this label -->
         <div id="new-booking-map-location-buttons-container" style="margin-bottom: 10px; display: flex; flex-wrap: wrap; gap: 5px;">
-            <!-- Location buttons will be populated here -->
+            <!-- Combined Location-Floor buttons will be populated here -->
         </div>
-        <label for="new-booking-map-floor-select">{{ _('Floor:') }}</label>
-        <select id="new-booking-map-floor-select"></select>
+        <!-- Floor select label and dropdown removed -->
     </div>
 
     <div id="new-booking-map-container" style="position: relative; width: 800px; height: 600px; background-size: contain; background-repeat: no-repeat; background-position: center center; border: 1px solid #ccc; margin-bottom: 20px;">


### PR DESCRIPTION
This commit introduces a significant change to the resource availability page, replacing the separate Location buttons and Floor dropdown with a unified list of buttons, each representing a specific map (Location-Floor combination).

Key changes:

1.  **New API Endpoint (`GET /api/maps-availability`):**
    *   Created in `routes/api_maps.py`.
    *   Accepts a date parameter.
    *   Returns a list of all configured maps, each with an
      `is_available_for_user` flag indicating if you can
      book any resource on that map for the given date.
    *   This involved careful checking of resources, their bookings,
      maintenance status, and your other conflicting bookings.
    *   Previous AttributeErrors related to `Resource.deleted_at` and
      `Booking.user_id` in similar logic were addressed in prior commits.

2.  **Frontend UI Update (`templates/resources.html`):**
    *   Removed the old floor selection dropdown.
    *   The existing button container now holds the new combined map buttons.

3.  **Frontend Logic (`static/js/new_booking_map.js`):**
    *   Refactored to fetch data from `/api/maps-availability`.
    *   Dynamically generates buttons for each map (e.g., "Map Name" or "Location Floor").
    *   Button background colors (via CSS classes `location-button-available`
      and `location-button-unavailable`) indicate map availability for the
      selected date.
    *   Clicking a map button directly loads its details using `loadMapDetails`.
    *   Removed old JavaScript logic related to separate location and floor selections
      (e.g., `updateFloorSelectOptions`, `selectedLocationName`).

4.  **Styling Adjustments (`static/style.css`):**
    *   Ensured map buttons can handle potentially longer text by allowing wrapping.
    *   Updated the CSS class for selected buttons to `selected-map-button`.

This feature provides a more direct way for you to see the availability of specific maps and select them.