### PR TITLE
fix: Remove blank space next to inline calendar

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -468,9 +468,10 @@ input[type="button"]:focus {
 }
 
 #inline-calendar-container {
-    flex: 1;
-    min-width: 280px; /* Minimum width before wrapping */
-    max-width: 320px; /* Maximum width to keep it compact */
+    width: max-content; /* Fit the width of the calendar content */
+    /* flex: 1; */ /* Removed */
+    /* min-width: 280px; */ /* Removed */
+    /* max-width: 320px; */ /* Removed */
     /* Add border or subtle background if needed to visually contain it */
     /* padding: 5px; */
     /* border: 1px solid var(--border-color); */


### PR DESCRIPTION
This commit addresses a layout issue on the resource availability page where a blank space was appearing next to the inline calendar.

The container for the inline calendar (`#inline-calendar-container`) had styling (flex-grow, min-width) that could make it wider than the Flatpickr calendar element it contained.

The fix involves modifying `static/style.css`:
- Removed `flex: 1`, `min-width`, and `max-width` from `#inline-calendar-container`.
- Added `width: max-content;` to `#inline-calendar-container` to ensure it shrinks to fit the actual width of the calendar.

This should resolve the extraneous blank space and allow the map buttons container to utilize the available space more effectively.