### PR TITLE
Fix: Prevent content from overlapping fixed footer

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -318,6 +318,7 @@ body {
     height: calc(100vh - var(--header-height) - var(--footer-height));
     overflow-y: auto;
     background-color: var(--background-color-light);
+    box-sizing: border-box; /* Added this line */
     /* flex-grow: 1; REMOVED */
 }
 


### PR DESCRIPTION
I added `box-sizing: border-box;` to the `#main-content` CSS rule.

This ensures that the `padding` of the `#main-content` element is included within its calculated `height` (`calc(100vh - var(--header-height) - var(--footer-height))`). Previously, without `box-sizing: border-box;`, the padding would be added to the calculated height, causing the `#main-content` area to extend beyond its intended boundaries and overlap with the fixed footer, especially when content within it was scrolled.

With this change, the `#main-content` area correctly respects its allocated space, and any overflowing content will now be scrollable within this area without visually going behind the fixed footer.