### PR TITLE
Fix: Correct Flatpickr inline calendar layout

### DIFF
--- a/static/js/new_booking_map.js
+++ b/static/js/new_booking_map.js
@@ -71,6 +71,7 @@ document.addEventListener('DOMContentLoaded', function () {
     if (calendarContainer) {
         flatpickr(calendarContainer, {
             inline: true, // Render the calendar inline
+            static: true, // Added this line
             dateFormat: "Y-m-d",
             defaultDate: currentSelectedDateStr, // Use the global variable
             onChange: function(selectedDates, dateStr, instance) {


### PR DESCRIPTION
Added `static: true` to the Flatpickr initialization options in `static/js/new_booking_map.js`.

Previously, the inline Flatpickr calendar was rendering as a sibling to its target `div#inline-calendar-container` instead of as a child. This caused the parent flex container (`#selection-controls-container`) to display three items (the container div, the calendar itself, and then the location buttons div) instead of the intended two.

By setting `static: true` along with `inline: true`, Flatpickr is encouraged to render the calendar directly within its target container. This corrects the DOM structure, allowing the flexbox layout to properly display the calendar container and the location buttons container as two distinct sections.