### PR TITLE
Fix: Remove blank space at bottom of pages by using min-height for ma…

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -315,7 +315,7 @@ body {
     margin-left: var(--sidebar-width);
     margin-bottom: var(--footer-height);
     padding: 20px;
-    height: calc(100vh - var(--header-height) - var(--footer-height));
+    min-height: calc(100vh - var(--header-height) - var(--footer-height));
     overflow-y: auto;
     background-color: var(--background-color-light);
     box-sizing: border-box; /* Added this line */


### PR DESCRIPTION
…in-content

Changed the `height` property to `min-height` for the `#main-content` CSS selector. This prevents the main content area from stretching to the full viewport height when the actual content is shorter, which was causing unnecessary blank space at the bottom of some pages like the Backup & Restore page.