### PR TITLE
Feat: Redesign Analytics filters to be label-less and horizontal

### DIFF
--- a/templates/analytics.html
+++ b/templates/analytics.html
@@ -58,46 +58,40 @@
     <div class="filter-section card">
         <div class="card-body">
             <h2 class="card-title">{{ _('Filters') }}</h2>
-            <form id="analyticsFiltersForm"> {/* Removed form-inline flex-wrap */}
-                <div class="row align-items-end"> {/* Added row wrapper */}
-                    <div class="col-sm-6 col-md-4 col-lg-3 mb-3">
-                        <label for="filterResourceTag" class="d-block mb-1">{{ _('Resource Tag:') }}</label>
-                        <select id="filterResourceTag" class="form-control custom-select"><option value="">{{ _('All Tags') }}</option></select>
-                    </div>
-                    <div class="col-sm-6 col-md-4 col-lg-3 mb-3">
-                        <label for="filterResourceStatus" class="d-block mb-1">{{ _('Resource Status:') }}</label>
-                        <select id="filterResourceStatus" class="form-control custom-select"><option value="">{{ _('All Statuses') }}</option></select>
-                    </div>
-                    <div class="col-sm-6 col-md-4 col-lg-3 mb-3">
-                        <label for="filterUser" class="d-block mb-1">{{ _('User:') }}</label>
-                        <select id="filterUser" class="form-control custom-select"><option value="">{{ _('All Users') }}</option></select>
-                    </div>
-                    <div class="col-sm-6 col-md-4 col-lg-3 mb-3">
-                        <label for="filterLocation" class="d-block mb-1">{{ _('Location:') }}</label>
-                        <select id="filterLocation" class="form-control custom-select"><option value="">{{ _('All Locations') }}</option></select>
-                    </div>
-                    <div class="col-sm-6 col-md-4 col-lg-3 mb-3">
-                        <label for="filterFloor" class="d-block mb-1">{{ _('Floor:') }}</label>
-                        <select id="filterFloor" class="form-control custom-select"><option value="">{{ _('All Floors') }}</option></select>
-                    </div>
-                    <div class="col-sm-6 col-md-4 col-lg-3 mb-3">
-                        <label for="filterMonth" class="d-block mb-1">{{ _('Month:') }}</label>
-                        <select id="filterMonth" class="form-control custom-select"><option value="">{{ _('All Months') }}</option></select>
-                    </div>
-                    <div class="col-sm-6 col-md-4 col-lg-3 mb-3">
-                        <label for="filterDayOfWeek" class="d-block mb-1">{{ _('Day of Week:') }}</label>
-                        <select id="filterDayOfWeek" class="form-control custom-select"><option value="">{{ _('All Days') }}</option></select>
-                    </div>
-                    <div class="col-sm-6 col-md-4 col-lg-3 mb-3">
-                        <label for="filterHourOfDay" class="d-block mb-1">{{ _('Hour of Day:') }}</label>
-                        <select id="filterHourOfDay" class="form-control custom-select"><option value="">{{ _('All Hours') }}</option></select>
-                    </div>
-                    <div class="col-sm-12 col-md-auto mb-3"> {/* Button group column */}
-                        <button type="button" id="applyFiltersBtn" class="btn btn-primary">{{ _('Apply Filters') }}</button>
-                        <button type="button" id="resetFiltersBtn" class="btn btn-secondary ml-2">{{ _('Reset Filters') }}</button>
-                    </div>
-                </div>
-            </form>
+<form id="analyticsFiltersForm">
+    <div class="row gx-2 gy-2 align-items-center"> <!-- gx-2 for horizontal gutter, gy-2 for vertical gutter on wrap, align-items-center for vertical alignment -->
+        <div class="col-auto">
+            <select id="filterResourceTag" class="form-control custom-select" aria-label="{{ _('Resource Tag filter') }}"><option value="">{{ _('All Tags') }}</option></select>
+        </div>
+        <div class="col-auto">
+            <select id="filterResourceStatus" class="form-control custom-select" aria-label="{{ _('Resource Status filter') }}"><option value="">{{ _('All Statuses') }}</option></select>
+        </div>
+        <div class="col-auto">
+            <select id="filterUser" class="form-control custom-select" aria-label="{{ _('User filter') }}"><option value="">{{ _('All Users') }}</option></select>
+        </div>
+        <div class="col-auto">
+            <select id="filterLocation" class="form-control custom-select" aria-label="{{ _('Location filter') }}"><option value="">{{ _('All Locations') }}</option></select>
+        </div>
+        <div class="col-auto">
+            <select id="filterFloor" class="form-control custom-select" aria-label="{{ _('Floor filter') }}"><option value="">{{ _('All Floors') }}</option></select>
+        </div>
+        <div class="col-auto">
+            <select id="filterMonth" class="form-control custom-select" aria-label="{{ _('Month filter') }}"><option value="">{{ _('All Months') }}</option></select>
+        </div>
+        <div class="col-auto">
+            <select id="filterDayOfWeek" class="form-control custom-select" aria-label="{{ _('Day of Week filter') }}"><option value="">{{ _('All Days') }}</option></select>
+        </div>
+        <div class="col-auto">
+            <select id="filterHourOfDay" class="form-control custom-select" aria-label="{{ _('Hour of Day filter') }}"><option value="">{{ _('All Hours') }}</option></select>
+        </div>
+        <div class="col-auto">
+            <button type="button" id="applyFiltersBtn" class="btn btn-primary">{{ _('Apply Filters') }}</button>
+        </div>
+        <div class="col-auto">
+            <button type="button" id="resetFiltersBtn" class="btn btn-secondary">{{ _('Reset Filters') }}</button>
+        </div>
+    </div>
+</form>
         </div>
     </div>
 


### PR DESCRIPTION
- I modified templates/analytics.html to remove all text labels for filters.
- I arranged all filter <select> dropdowns and action buttons into a single horizontal, responsive group using Bootstrap's col-auto and gutter utilities.
- I added aria-label attributes to <select> elements for accessibility.
- I adjusted static/style.css to comment out CSS rules that might conflict with the new layout, ensuring Bootstrap utilities primarily control filter appearance and spacing.