### PR TITLE
Debug: Add extensive logging for area role checkbox UI

### DIFF
--- a/routes/api_resources.py
+++ b/routes/api_resources.py
@@ -189,7 +189,10 @@ def update_resource_details_admin(resource_id):
     for field in allowed_fields:
         if field in data:
             if field == 'map_coordinates' and data[field] is not None:
-                setattr(resource, field, json.dumps(data[field]))
+                current_app.logger.info(f"Received map_coordinates data from frontend: {data[field]}")
+                json_string_to_save = json.dumps(data[field])
+                current_app.logger.info(f"JSON string being saved to resource.map_coordinates: {json_string_to_save}")
+                setattr(resource, field, json_string_to_save)
             else:
                 setattr(resource, field, data[field])
 

--- a/templates/admin_maps.html
+++ b/templates/admin_maps.html
@@ -669,6 +669,7 @@
                 document.querySelectorAll('#define-area-roles-checkbox-container input[type="checkbox"]:checked').forEach(checkbox => {
                     selectedAreaRoleIds.push(parseInt(checkbox.value));
                 });
+                console.log('Selected Area Role IDs (from checkboxes):', selectedAreaRoleIds);
 
                 const areaData = {
                     floor_map_id: floorMapId,
@@ -684,6 +685,7 @@
                     name: resourceId === '--CREATE_NEW--' ? 'New Resource from Map Area' : undefined,
                     status: resourceId === '--CREATE_NEW--' ? 'draft' : undefined
                 };
+                console.log('Constructed areaData.coordinates:', areaData.coordinates);
 
                 Object.keys(areaData).forEach(key => areaData[key] === undefined && delete areaData[key]);
                 if (areaData.coordinates) {
@@ -712,6 +714,7 @@
                         map_coordinates: areaData.coordinates,
                         booking_restriction: areaData.booking_restriction,
                     };
+                    console.log('Final payloadForResourceUpdate being sent:', payloadForResourceUpdate);
 
                     const response = await fetch(`/api/admin/resources/${targetResourceId}`, {
                         method: 'PUT',
@@ -742,6 +745,23 @@
         // Modify window.populateAreaForm to handle `allowed_role_ids` (Moved into DOMContentLoaded)
         const originalPopulateAreaForm = window.populateAreaForm;
         window.populateAreaForm = function(area, resourceId) {
+            console.log('populateAreaForm CALLED. resourceId:', resourceId, 'Raw area data received:', area);
+            if (area && typeof area === 'object') {
+                console.log('populateAreaForm: area.allowed_role_ids IS:', area.allowed_role_ids);
+            } else if (area) {
+                console.log('populateAreaForm: area is NOT an object. Raw area:', area, 'Attempting to parse if string...');
+                try {
+                    const parsedArea = JSON.parse(area);
+                    console.log('populateAreaForm: Parsed area from string:', parsedArea);
+                    if (parsedArea && typeof parsedArea === 'object') {
+                        console.log('populateAreaForm: Parsed area.allowed_role_ids IS:', parsedArea.allowed_role_ids);
+                    }
+                } catch (e) {
+                    console.error('populateAreaForm: Error parsing area string:', e);
+                }
+            } else {
+                console.log('populateAreaForm: area is null or undefined.');
+            }
             if (originalPopulateAreaForm) {
                 originalPopulateAreaForm(area, resourceId);
             } else {


### PR DESCRIPTION
I've added comprehensive console logging on the frontend (admin_maps.html) and backend logging (api_resources.py) to trace the data flow for area-specific role assignments using the new checkbox interface.

This logging will help diagnose an issue where selected roles (checkboxes) may not be correctly re-selected when you edit an area.

Logging points:
- Frontend (on save):
    - Selected role IDs from checkboxes.
    - Constructed `areaData.coordinates` object.
    - Final `payloadForResourceUpdate` sent to the backend.
- Backend (on resource update):
    - Received `map_coordinates` data from the frontend.
    - The exact JSON string being saved to `resource.map_coordinates`.
- Frontend (on form population for editing an area):
    - Raw `area` data received by `populateAreaForm`.
    - Specifically `area.allowed_role_ids`.

This commit is for debugging purposes to gather more information from your testing.