### PR TITLE
Fix: Ensure all calls to populateDefineAreaRolesCheckboxes are correct

### DIFF
--- a/templates/admin_maps.html
+++ b/templates/admin_maps.html
@@ -561,7 +561,7 @@
 
                 // Ensure roles are loaded when map is selected for area definition
                 loadAllRolesForAreaDefinition();
-                populateDefineAreaRolesSelect(); // Clear and populate, any selected roles will be set by populateAreaForm if an area is later selected for edit
+                populateDefineAreaRolesCheckboxes(); // Clear and populate, any selected roles will be set by populateAreaForm if an area is later selected for edit
             } // End of select-map-btn logic
 
             else if (targetButton.classList.contains('delete-map-btn')) {


### PR DESCRIPTION
I corrected all identified instances of the old function name `populateDefineAreaRolesSelect` to the new function name `populateDefineAreaRolesCheckboxes` within the inline JavaScript of `templates/admin_maps.html`.

This is a more thorough fix for the JavaScript ReferenceError that occurred during interactions with the maps table in the admin floor maps interface, ensuring that your UI logic for populating role selection (now checkboxes) is invoked correctly in all relevant paths within the inline script.