### PR TITLE
Fix: Add JS shim for populateDefineAreaRolesSelect to prevent Referen…

### DIFF
--- a/templates/admin_maps.html
+++ b/templates/admin_maps.html
@@ -383,6 +383,19 @@
             populateDefineAreaRolesCheckboxes(); // Populate/update messages after fetch attempt
         }
 
+        function populateDefineAreaRolesSelect(selectedRoleIds) {
+            console.warn('Deprecated call to populateDefineAreaRolesSelect, redirecting to populateDefineAreaRolesCheckboxes. Caller should be updated.');
+            // Ensure populateDefineAreaRolesCheckboxes is accessible in this scope.
+            // If it's defined on window, use window.populateDefineAreaRolesCheckboxes
+            if (typeof populateDefineAreaRolesCheckboxes === 'function') {
+                populateDefineAreaRolesCheckboxes(selectedRoleIds);
+            } else if (typeof window.populateDefineAreaRolesCheckboxes === 'function') {
+                window.populateDefineAreaRolesCheckboxes(selectedRoleIds);
+            } else {
+                console.error('populateDefineAreaRolesCheckboxes function not found for shim redirection.');
+            }
+        }
+
         function populateDefineAreaRolesCheckboxes(selectedRoleIds = []) {
             const checkboxContainer = document.getElementById('define-area-roles-checkbox-container');
             const rolesLoadingMsg = document.getElementById('define-area-roles-loading-message');


### PR DESCRIPTION
…ceError

Added a shim function for `populateDefineAreaRolesSelect` in the inline JavaScript of `templates/admin_maps.html`. This shim redirects any calls made to the old function name to the new
`populateDefineAreaRolesCheckboxes` function.

It also logs a console warning when the deprecated function is called, to help identify any remaining call sites that should be updated.

This is intended to definitively resolve the persistent `ReferenceError: populateDefineAreaRolesSelect is not defined` that occurred in the admin maps interface.