### PR TITLE
Temp: Add console logging to updateAuthLink for debugging login issue

### DIFF
--- a/static/js/script.js
+++ b/static/js/script.js
@@ -315,7 +315,8 @@ async function updateAuthLink() {
         }
     } catch (error) {
         // Also hide userActionsArea on error (already handled by setStateLoggedOut)
-        setStateLoggedOut();
+        console.error("Error in updateAuthLink, preventing immediate logout:", error);
+        // setStateLoggedOut();
     }
 }
 


### PR DESCRIPTION
This commit modifies the `updateAuthLink` function in `static/js/script.js`. In the `catch` block of this function, `setStateLoggedOut()` is temporarily commented out, and a `console.error` message is added to log any errors that occur during the execution of `updateAuthLink`.

This is a temporary measure to help diagnose a login issue reported after a previous change. The goal is to capture any errors related to the `/api/auth/status` call or other logic within `updateAuthLink` without immediately logging you out.