### PR TITLE
Revert "Fix: Correct JavaScript syntax error and resolve apiCall reference issueThe main `DOMContentLoaded` event listener in `static/js/script.js` was incorrectly commented out, with its closing `});` falling outside the comment block. This caused a syntax error, preventing the execution of critical JavaScript initializations, including the definition of the global `apiCall` function.This commit uncomments the `DOMContentLoaded` listener in `static/js/script.js`.This change is expected to:- Resolve the `Uncaught SyntaxError: Unexpected token '}'` in `script.js`.- Make the `apiCall` function globally available.- Resolve the `ReferenceError: apiCall is not defined` in `static/js/admin_resource_roles.js`.- Restore the functionality of the 'Configuration/Maps -> Define Area' page, allowing areas to be displayed and managed correctly."

### DIFF
--- a/static/js/script.js
+++ b/static/js/script.js
@@ -454,6 +454,7 @@ function checkUserPermissionForResource(resource, currentUserId, currentUserIsAd
     return true; 
 }
 
+/*
 document.addEventListener('DOMContentLoaded', function() {
     document.body.dataset.loginUrl = document.getElementById('login-form') ? "#" : "/login";
     updateAuthLink();


### PR DESCRIPTION
Reverts panaresium/ResourceBookingSystem#418