### PR TITLE
Fix: Correct JavaScript function call in admin maps

### DIFF
--- a/templates/admin_maps.html
+++ b/templates/admin_maps.html
@@ -561,7 +561,7 @@
 
                 // Ensure roles are loaded when map is selected for area definition
                 loadAllRolesForAreaDefinition();
-                populateDefineAreaRolesSelect(); // Clear and populate, any selected roles will be set by populateAreaForm if an area is later selected for edit
+                populateDefineAreaRolesCheckboxes(); // Clear and populate, any selected roles will be set by populateAreaForm if an area is later selected for edit
             } // End of select-map-btn logic
 
             else if (targetButton.classList.contains('delete-map-btn')) {


### PR DESCRIPTION
I corrected a JavaScript function call in templates/admin_maps.html from populateDefineAreaRolesSelect() to populateDefineAreaRolesCheckboxes().

This resolves a ReferenceError that occurred when you clicked the "Define Areas" button on the Configuration/Maps page, caused by an incorrect function name after a previous refactoring.