### PR TITLE
Fix: Correct Jinja template syntax error in admin_maps.html

### DIFF
--- a/templates/admin_maps.html
+++ b/templates/admin_maps.html
@@ -943,7 +943,10 @@
                     showStatus(defineAreasStatus, {{ _("No saved area selected to delete.")|tojson }}, true);
                     return;
                 }
-                if (!confirm({{ _("Are you sure you want to remove the area mapping for resource '%s'? The resource itself will not be deleted.")|format(selectedArea.name || selectedArea.resource_id)|tojson }})) {
+                const confirmMsgBase = {{ _("Are you sure you want to remove the area mapping for resource '%s'? The resource itself will not be deleted.")|tojson }};
+                const resourceNameOrId = selectedArea.name || selectedArea.resource_id || 'Unnamed Resource';
+                const confirmMsg = confirmMsgBase.replace('%s', resourceNameOrId);
+                if (!confirm(confirmMsg)) {
                     return;
                 }
 


### PR DESCRIPTION
I resolved a Jinja TemplateSyntaxError that occurred in the JavaScript for the 'Delete Selected Area Mapping' confirmation dialog. The error was caused by improperly using a JavaScript expression within a Jinja `format()` filter.

The fix involves:
- Retrieving the translated string template (with '%s') using `|tojson`.
- Using JavaScript to determine the dynamic value (resource name/ID).
- Employing JavaScript's string `replace()` method to construct the final confirmation message.

This ensures correct separation of server-side Jinja processing and client-side JavaScript execution, preventing the template error.