### PR TITLE
Debug: Add logging for map_coordinates serialization

### DIFF
--- a/routes/api_resources.py
+++ b/routes/api_resources.py
@@ -200,7 +200,15 @@ def update_resource_details_admin(resource_id):
     for field in allowed_fields:
         if field in data:
             if field == 'map_coordinates' and data[field] is not None:
-                setattr(resource, field, json.dumps(data[field]))
+                map_coords_data = data[field]
+                current_app.logger.debug(f"Before json.dumps, map_coordinates data: {map_coords_data}")
+                current_app.logger.debug(f"Type of map_coordinates data: {type(map_coords_data)}")
+                if isinstance(map_coords_data, dict):
+                    current_app.logger.debug(f"Type of allowed_role_ids before dumps: {type(map_coords_data.get('allowed_role_ids'))}")
+
+                json_string_coords = json.dumps(map_coords_data)
+                current_app.logger.debug(f"After json.dumps, map_coordinates string: {json_string_coords}")
+                setattr(resource, field, json_string_coords)
             else:
                 setattr(resource, field, data[field])
 


### PR DESCRIPTION
I've added debug log statements in the `update_resource_details_admin` function in `routes/api_resources.py`.

These logs will help diagnose an issue where `allowed_role_ids` within the `map_coordinates` field are reportedly not being saved to the database, despite being present in the incoming request data.

The logs will show:
- The content and type of `data['map_coordinates']` before `json.dumps()`.
- The type of `allowed_role_ids` within that data.
- The JSON string produced by `json.dumps()`.