### PR TITLE
Refactor: Separate storage for map area role permissions

### DIFF
--- a/models.py
+++ b/models.py
@@ -116,6 +116,7 @@ class Resource(db.Model):
     scheduled_status_at = db.Column(db.DateTime, nullable=True)
     floor_map_id = db.Column(db.Integer, db.ForeignKey('floor_map.id'), nullable=True)
     map_coordinates = db.Column(db.Text, nullable=True)
+    map_allowed_role_ids = db.Column(db.Text, nullable=True) # Stores JSON list of role IDs
 
     bookings = db.relationship('Booking', backref='resource_booked', lazy=True, cascade="all, delete-orphan")
     floor_map = db.relationship('FloorMap', backref=db.backref('resources', lazy='dynamic'))


### PR DESCRIPTION
I've refactored how area-specific role permissions (`allowed_role_ids`) are stored for resources associated with map areas.

Key changes:
1.  **Model (`models.py`):**
    - I added a new `map_allowed_role_ids` (Text type) column to the `Resource` model. This field will store a JSON string list of role IDs that are allowed to book a resource via a specific map area.

2.  **Data Saving (`routes/api_resources.py`):**
    - In `update_resource_details_admin`, when `map_coordinates` data is received: - `allowed_role_ids` are now extracted from the `map_coordinates` dictionary. - This list of role IDs is JSON serialized and saved to the new `resource.map_allowed_role_ids` field. - The `map_coordinates` dictionary (now containing only geometric data like x, y, width, height, type) is JSON serialized and saved to `resource.map_coordinates`.

3.  **Data Serialization (`utils.py`):**
    - In `resource_to_dict`, the `map_coordinates` object returned to the frontend is reconstructed: - Geometric coordinates are loaded from `resource.map_coordinates`. - The list of role IDs is loaded from `resource.map_allowed_role_ids`. - This list is then re-inserted into the `map_coordinates` dictionary under the `allowed_role_ids` key, ensuring the frontend receives data in the expected nested structure.

This refactoring aims to resolve issues where `allowed_role_ids` were not being reliably saved as part of the `map_coordinates` JSON blob, by giving them a dedicated storage field while maintaining the expected data structure for the client-side application.

A database migration (which you will need to handle manually by resetting migration history and creating a new initial migration) is required to add the new `map_allowed_role_ids` column to the `resource` table.