### PR TITLE
Fix: Correct URL path for verify_full_backup_route

### DIFF
--- a/routes/admin_ui.py
+++ b/routes/admin_ui.py
@@ -391,7 +391,7 @@ def verify_booking_csv_backup_route(timestamp_str):
     return redirect(url_for('admin_ui.serve_backup_restore_page'))
 
 
-@admin_ui_bp.route('/admin/verify_full_backup/<timestamp_str>', methods=['POST'])
+@admin_ui_bp.route('/verify_full_backup/<timestamp_str>', methods=['POST'])
 @login_required
 @permission_required('manage_system')
 def verify_full_backup_route(timestamp_str):


### PR DESCRIPTION
The route for `verify_full_backup_route` in `routes/admin_ui.py` was incorrectly defined as '/admin/verify_full_backup/<timestamp_str>'. Given that the blueprint `admin_ui_bp` already has a `url_prefix='/admin'`, this resulted in the actual URL being registered as '/admin/admin/verify_full_backup/<timestamp_str>'.

This commit corrects the route decorator to
'/verify_full_backup/<timestamp_str>', which, when combined with the blueprint prefix, correctly forms the URL
'/admin/verify_full_backup/<timestamp_str>'.

This resolves the 404 error you encountered when trying to access the backup verification functionality via the intended URL.