### PR TITLE
Fix: Correct manifest path logging in verify_backup_set

### DIFF
--- a/azure_backup.py
+++ b/azure_backup.py
@@ -1531,13 +1531,13 @@ def verify_backup_set(timestamp_str, socketio_instance=None, task_id=None):
         remote_manifest_path = f"{DB_BACKUPS_DIR}/{manifest_filename}"
         manifest_file_client = db_share_client.get_file_client(remote_manifest_path)
 
-        logger.info(f"VERIFY_BACKUP_SET: Attempting to check existence of manifest via _client_exists for: '{manifest_file_client.share_name}/{manifest_file_client.file_path}'")
+        logger.info(f"VERIFY_BACKUP_SET: Attempting to check existence of manifest via _client_exists for: '{db_share_name}/{remote_manifest_path}'")
         if not _client_exists(manifest_file_client):
             msg = f"Manifest file '{remote_manifest_path}' not found on share '{db_share_name}'."
             verification_results['errors'].append(msg)
             verification_results['status'] = 'manifest_missing'
-            # ADD THIS:
-            logger.warning(f"VERIFY_BACKUP_SET: _client_exists returned False for manifest: '{manifest_file_client.share_name}/{manifest_file_client.file_path}'. Detailed message: {msg}")
+            # Corrected log:
+            logger.warning(f"VERIFY_BACKUP_SET: _client_exists returned False for manifest: '{db_share_name}/{remote_manifest_path}'. Detailed message: {msg}")
             _emit_verify_progress(msg, level="ERROR")
             return verification_results
 


### PR DESCRIPTION
Updates logging statements in the `verify_backup_set` function within `azure_backup.py` to use the `remote_manifest_path` variable for logging the manifest file path.

This ensures the logged path is the clear, correctly formatted string used to access the file, rather than relying on potentially ambiguous string representations of client object attributes (e.g., `file_client.file_path`). This change improves log clarity for diagnosing manifest issues.