### PR TITLE
Fix: Implement robust sticky footer using Flexbox

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -26,6 +26,7 @@
 
 html {
     overflow: hidden;
+    height: 100%;
 }
 
 /* Dark theme color variables */
@@ -47,7 +48,7 @@ body {
     overflow: hidden;
     display: flex;
     flex-direction: column;
-    height: 100vh;
+    min-height: 100vh;
 }
 
 /* Header Styling */


### PR DESCRIPTION
This commit ensures the footer correctly stays at the bottom of the viewport when content is short, and appears after the content when it is long. This addresses an issue where the footer would move up with short content after a previous Flexbox layout refactor.

Changes include:
- Set `height: 100%;` on the `html` element.
- Changed the `body` element's `height: 100vh;` to `min-height: 100vh;`.
- Maintained the body's `display: flex; flex-direction: column;` and the flex properties of its children (`.app-header`, `#main-content`, `footer`).

This establishes a common and robust pattern for sticky footers in a full-height flex layout.