### PR TITLE
Fix: Set explicit height on main content area to ensure scrolling

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -319,7 +319,8 @@ body {
     overflow-y: auto;
     background-color: var(--background-color-light);
     box-sizing: border-box; /* Added this line */
-    flex-grow: 1;
+    height: calc(100vh - var(--header-height));
+    flex-grow: 0;
 }
 
 /* Adjust margin-left when sidebar is collapsed */


### PR DESCRIPTION
This commit addresses persistent issues where the main content area (`#main-content`) was not scrollable.

Changes include:
- Setting `height: calc(100vh - var(--header-height));` on `#main-content`.
- Changing `flex-grow: 1;` to `flex-grow: 0;` on `#main-content` as its height is now explicitly defined.
- Maintained `overflow-y: auto;` and appropriate padding on `#main-content` to prevent content from being obscured by the header and the `position: fixed` footer.
- The `body` remains a flex container (`display: flex; flex-direction: column; min-height: 100vh;`), with the header as a `flex-shrink: 0` item.

This approach provides a more direct calculation for the height of the scrollable content area, aiming to ensure that `overflow-y: auto` functions correctly.