### PR TITLE
Fix: Ensure main content scrollbar is visually contained

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -315,11 +315,11 @@ body {
 /* Main Content Styling */
 #main-content {
     margin-left: var(--sidebar-width);
-    padding: 30px 20px calc(30px + var(--footer-height)) 20px;
+    padding: 30px 20px;
     overflow-y: auto;
     background-color: var(--background-color-light);
     box-sizing: border-box; /* Added this line */
-    height: calc(100vh - var(--header-height));
+    height: calc(100vh - var(--header-height) - var(--footer-height));
     flex-grow: 0;
 }
 


### PR DESCRIPTION
This commit adjusts the height and padding of the main content area (`#main-content`) to ensure its scrollbar is visually contained between the header and the fixed footer.

Changes include:
- Setting `height` of `#main-content` to `calc(100vh - var(--header-height) - var(--footer-height));`.
- Adjusting `padding` of `#main-content` to `30px 20px;`, as the previous extra bottom padding for the footer's height is no longer needed with the new height calculation for the `#main-content` box itself.
- Maintained `overflow-y: auto;` and `flex-grow: 0;` for `#main-content`.
- The header remains an in-flow flex item at the top, and the footer remains `position: fixed;` at the bottom.

This should provide the desired visual separation and scrollbar behavior where the scrollbar for the content area does not extend alongside or behind the fixed footer.