### PR TITLE
Fix: Remove hover effect from welcome message

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -93,7 +93,7 @@ body {
 }
 
 .header-content > a:hover,
-.header-content > div:hover:not(#user-dropdown-container):not(#welcome-message-container) { /* Avoid hover on non-interactive divs unless they contain an <a> that handles it */
+.header-content > div:hover:not(#user-dropdown-container):not(#welcome-message-container):not(#user-actions-area) { /* Avoid hover on non-interactive divs unless they contain an <a> that handles it */
     background-color: var(--secondary-color);
     /* color is already set to black and important, hover shouldn't change it unless specified */
     text-decoration: none;


### PR DESCRIPTION
The 'Welcome, admin!' text in the header was incorrectly displaying a hover effect. This was due to its parent container, 'user-actions-area', receiving hover styles.

This commit modifies the CSS rule in static/style.css to exclude 'user-actions-area' from the hover effect, ensuring that only the intended elements (like the user profile icon and dropdown arrow) show hover highlights.