### PR TITLE
Fix: Add hover effect to user dropdown button

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -146,6 +146,10 @@ body {
     cursor: pointer;
     padding: 10px; /* Adjust as needed */
 }
+.app-header #user-dropdown-button:hover {
+    background-color: var(--secondary-color);
+    border-radius: 4px;
+}
 .app-header .user-icon { /* Copied from existing .user-icon */
     font-size: 1.2em;
     margin-right: 2px;


### PR DESCRIPTION
This commit adds a hover effect (background highlight) to the user dropdown button in the header. This addresses previous feedback where the icon and dropdown arrow were not highlighted after a fix that removed hover from the welcome message.

The change includes:
- A new CSS rule in static/style.css for .app-header #user-dropdown-button:hover.
- This rule applies --secondary-color as the background on hover and adds a border-radius for consistency.