### PR TITLE
Fix: Ensure hover effect on user dropdown button

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -138,7 +138,7 @@ body {
 .app-header #user-dropdown-button { /* Copied from existing #user-dropdown-button and adapted */
     display: flex;
     align-items: center;
-    background: none;
+    background-color: transparent; /* Changed from background: none; */
     border: none;
     color: #000000 !important; /* Ensure color from header */
     font-weight: bold !important;


### PR DESCRIPTION
This commit resolves an issue where the user dropdown button in the header was not displaying its hover effect (background highlight).

The problem was caused by the button's base style using 'background: none;', which interfered with the 'background-color' property applied on hover.

The fix involves changing the base style of '.app-header #user-dropdown-button' in static/style.css to use 'background-color: transparent;' instead. This allows the existing hover rule, which sets
'background-color: var(--secondary-color);', to apply correctly and highlight the entire button area (including the icon and arrow) as intended.