### PR TITLE
Fix: Ensure Define Areas canvas uses zero offsets

### DIFF
--- a/static/js/script.js
+++ b/static/js/script.js
@@ -2143,9 +2143,16 @@ document.addEventListener('DOMContentLoaded', function() {
             }
             canvasCtx.clearRect(0, 0, drawingCanvas.width, drawingCanvas.height);
 
-            // Apply global map offsets before drawing each area
-            const globalOffsetX = window.currentMapContext ? (window.currentMapContext.offsetX || 0) : 0;
-            const globalOffsetY = window.currentMapContext ? (window.currentMapContext.offsetY || 0) : 0;
+            // The IS_ADMIN_MAP_DEFINE_AREAS_PAGE flag differentiates the admin "Define Areas" context
+            // from other potential canvas drawing contexts. In the admin view, areas are drawn
+            // using raw coordinates (offsets are zeroed out).
+            // Other contexts might apply offsets (though new_booking_map.js handles its own offset logic).
+            const isAdminPage = typeof IS_ADMIN_MAP_DEFINE_AREAS_PAGE !== 'undefined' && IS_ADMIN_MAP_DEFINE_AREAS_PAGE;
+
+            // effectiveOffsetX and effectiveOffsetY ensure that drawing uses raw coordinates (0,0 offset)
+            // on the admin "Define Areas" page, and map-defined offsets otherwise.
+            const effectiveOffsetX = (window.currentMapContext && !isAdminPage) ? (window.currentMapContext.offsetX || 0) : 0;
+            const effectiveOffsetY = (window.currentMapContext && !isAdminPage) ? (window.currentMapContext.offsetY || 0) : 0;
 
             canvasCtx.font = "10px Arial";
             existingMapAreas.forEach(area => {
@@ -2154,8 +2161,8 @@ document.addEventListener('DOMContentLoaded', function() {
                 }
                 if (area.map_coordinates && area.map_coordinates.type === 'rect') {
                     const coords = area.map_coordinates;
-                    const drawX = coords.x + globalOffsetX;
-                    const drawY = coords.y + globalOffsetY;
+                    const drawX = coords.x + effectiveOffsetX;
+                    const drawY = coords.y + effectiveOffsetY;
 
                     canvasCtx.fillStyle = 'rgba(255, 0, 0, 0.1)';
                     canvasCtx.strokeStyle = 'rgba(255, 0, 0, 0.7)';
@@ -2175,8 +2182,8 @@ document.addEventListener('DOMContentLoaded', function() {
 
             if (selectedAreaForEditing && selectedAreaForEditing.map_coordinates && selectedAreaForEditing.map_coordinates.type === 'rect') {
                 const coords = selectedAreaForEditing.map_coordinates;
-                const drawX = coords.x + globalOffsetX;
-                const drawY = coords.y + globalOffsetY;
+                const drawX = coords.x + effectiveOffsetX;
+                const drawY = coords.y + effectiveOffsetY;
 
                 canvasCtx.fillStyle = 'rgba(0, 0, 255, 0.2)';
                 canvasCtx.strokeStyle = SELECTED_BORDER_COLOR;

--- a/templates/admin_maps.html
+++ b/templates/admin_maps.html
@@ -227,6 +227,11 @@
     <script src="{{ url_for('static', filename='js/admin_resource_edit.js') }}" defer></script>
     <script src="{{ url_for('static', filename='js/admin_resource_roles.js') }}" defer></script>
     <script>
+    // This flag signals to static/js/script.js (specifically window.redrawCanvas)
+    // that the current context is the admin page for defining map areas.
+    // In this context, canvas drawing for areas should use raw coordinates (no visual offsets applied),
+    // as the map image itself is displayed without offsets.
+    var IS_ADMIN_MAP_DEFINE_AREAS_PAGE = true;
     document.addEventListener('DOMContentLoaded', function() {
         const mapsTableBody = document.getElementById('maps-table-body');
         const adminMapsListStatus = document.getElementById('admin-maps-list-status');


### PR DESCRIPTION
Previously, in your admin 'Define Areas' section, while the map image was displayed without offsets, the resource areas drawn on the canvas were incorrectly shifted by the map's global X/Y offsets. This caused a visual misalignment between the areas and the map image.

This commit corrects the `redrawCanvas` function in `static/js/script.js`. It now checks for an `IS_ADMIN_MAP_DEFINE_AREAS_PAGE` flag (set to true in `templates/admin_maps.html`). If this flag is true, the function uses effective offsets of zero for drawing on the canvas.

This ensures that in your 'Define Areas' view, resource areas are drawn using their raw coordinates, aligning correctly with the un-offsetted map image. The map's X/Y offsets continue to be applied as intended on your public 'Resource Availability' page.

Clarifying comments have also been added to `static/js/script.js` and `templates/admin_maps.html`.