### PR TITLE
Fix: Ensure map area role checkboxes correctly reflect config

### DIFF
--- a/templates/admin_maps.html
+++ b/templates/admin_maps.html
@@ -384,6 +384,7 @@
         }
 
         function populateDefineAreaRolesCheckboxes(selectedRoleIds = []) {
+            const numericSelectedRoleIds = (selectedRoleIds || []).map(id => parseInt(id, 10)).filter(id => !isNaN(id));
             const checkboxContainer = document.getElementById('define-area-roles-checkbox-container');
             const rolesLoadingMsg = document.getElementById('define-area-roles-loading-message');
             if (!checkboxContainer) return;
@@ -424,7 +425,7 @@
                 checkbox.value = role.id;
                 checkbox.name = 'area_roles'; // Consistent name for grouping
 
-                if (selectedRoleIds.includes(role.id)) {
+                if (numericSelectedRoleIds.includes(role.id)) {
                     checkbox.checked = true;
                 }
 


### PR DESCRIPTION
The role permission checkboxes in the 'Define Areas' section of Floor Map Management were not always correctly checked based on the `map_allowed_role_ids` configuration.

This was likely due to a potential type mismatch during JavaScript comparison, where role IDs fetched for the area (potentially as strings if the JSON parsing was too lenient on heterogeneous arrays from other sources, or if data was stringified unexpectedly) were compared against numeric role IDs from the general roles list.

The `populateDefineAreaRolesCheckboxes` function in `templates/admin_maps.html` has been updated. It now explicitly parses the `selectedRoleIds` array to ensure all its elements are treated as numbers before comparing them with the numeric `role.id` values. This makes the checkbox selection robust against such type discrepancies.