### PR TITLE
Remove offset fields from map upload form

### DIFF
--- a/templates/admin_maps.html
+++ b/templates/admin_maps.html
@@ -25,14 +25,6 @@
                 <label for="map-image">{{ _('Map Image File:') }}</label>
                 <input type="file" id="map-image" name="map_image" accept="image/png, image/jpeg" required>
             </div>
-            <div>
-                <label for="map_offset_x">{{ _('Offset X (px):') }}</label>
-                <input type="number" id="map_offset_x" name="offset_x" value="0" style="width: 80px;">
-            </div>
-            <div>
-                <label for="map_offset_y">{{ _('Offset Y (px):') }}</label>
-                <input type="number" id="map_offset_y" name="offset_y" value="0" style="width: 80px;">
-            </div>
             <button type="submit">{{ _('Upload Map') }}</button>
         </form>
         <div id="upload-status"></div>


### PR DESCRIPTION
This commit removes the Offset X and Offset Y input fields from the "Upload New Floor Map" form in the admin panel. These fields were deemed unnecessary for the initial map upload.

- Modified `templates/admin_maps.html` to remove the HTML for offset_x and offset_y inputs from the upload form.
- The backend (`routes/api_maps.py`) already defaults these values to 0 if not provided in the form submission.
- The `FloorMap` model (`models.py`) also defaults these fields to 0.

The functionality to view and update offsets for existing maps remains unchanged.