### PR TITLE
Fix: Ensure map area role checkboxes reflect saved state

### DIFF
--- a/templates/admin_maps.html
+++ b/templates/admin_maps.html
@@ -381,7 +381,9 @@
         }
 
         function populateDefineAreaRolesCheckboxes(selectedRoleIds = []) {
+            console.log("selectedRoleIds:", selectedRoleIds);
             const numericSelectedRoleIds = (selectedRoleIds || []).map(id => parseInt(id, 10)).filter(id => !isNaN(id));
+            console.log("numericSelectedRoleIds:", numericSelectedRoleIds);
             const checkboxContainer = document.getElementById('define-area-roles-checkbox-container');
             const rolesLoadingMsg = document.getElementById('define-area-roles-loading-message');
             if (!checkboxContainer) return;
@@ -413,6 +415,7 @@
             }
 
             allRolesForAreaAssignment.forEach(role => {
+                console.log("role.id:", role.id);
                 const div = document.createElement('div');
                 div.className = 'checkbox-item'; // For styling if needed
 
@@ -422,7 +425,8 @@
                 checkbox.value = role.id;
                 checkbox.name = 'area_roles'; // Consistent name for grouping
 
-                if (numericSelectedRoleIds.includes(role.id)) {
+                checkbox.checked = false; // Explicitly set to false before checking
+                if (numericSelectedRoleIds.includes(Number(role.id))) {
                     checkbox.checked = true;
                 }
 


### PR DESCRIPTION
I'll modify the `populateDefineAreaRolesCheckboxes` JavaScript function in `templates/admin_maps.html` to:
- Explicitly set `checkbox.checked = false` before evaluating.
- Convert `role.id` to a `Number` during comparison for robustness.
- Add temporary `console.log` statements for debugging the values involved in role checkbox state determination.

This aims to resolve an issue where permission checkboxes for map areas were not correctly checked according to their configured state upon selection.