### PR TITLE
Fix: Ensure map area role checkboxes are correctly populated

### DIFF
--- a/static/js/script.js
+++ b/static/js/script.js
@@ -2382,11 +2382,17 @@ document.addEventListener('DOMContentLoaded', function() {
                             updateCoordinateInputs(coords);
                             if (resourceToMapSelect) resourceToMapSelect.value = area.resource_id;
                             if (bookingPermissionDropdown) bookingPermissionDropdown.value = area.booking_restriction || "";
-                            if (authorizedRolesCheckboxContainer) {
-                                const selectedRoleIds = (area.roles || []).map(r => String(r.id));
-                                authorizedRolesCheckboxContainer.querySelectorAll('input[type="checkbox"]').forEach(cb => {
-                                    cb.checked = selectedRoleIds.includes(cb.value);
-                                });
+                            // Replace existing role checkbox logic with a call to populateDefineAreaRolesCheckboxes
+                            if (typeof populateDefineAreaRolesCheckboxes === 'function') {
+                                const selectedRoleIds = (area.roles || []).map(r => r.id); // Ensure IDs are passed as expected
+                                populateDefineAreaRolesCheckboxes(selectedRoleIds);
+                            } else {
+                                console.error('populateDefineAreaRolesCheckboxes function is not defined globally. Check admin_maps.html inline script.');
+                                // Fallback or error handling if the global function isn't available
+                                // For example, clear existing checkboxes or show an error to the user in the UI
+                                if (authorizedRolesCheckboxContainer) {
+                                    authorizedRolesCheckboxContainer.innerHTML = '<p class="error">Error: Role selection unavailable.</p>';
+                                }
                             }
                             resourceToMapSelect.dispatchEvent(new Event('change'));
                             break;


### PR DESCRIPTION
When defining areas on a map, clicking an existing area did not correctly call the function responsible for populating the role permission checkboxes based on the area's configuration.

This commit modifies `static/js/script.js` in the `drawingCanvas.onmousedown` event handler. When an existing map area is clicked, it now correctly calls the global `populateDefineAreaRolesCheckboxes(selectedRoleIds)` function (defined in the inline script of `templates/admin_maps.html`).

The `selectedRoleIds` are extracted from the clicked area's data. The `populateDefineAreaRolesCheckboxes` function in `admin_maps.html` then iterates through the available roles and checks the appropriate checkboxes based on these selected IDs.

This ensures that your UI accurately reflects the configured role permissions for the selected map area.