### PR TITLE
Fix: Resolve JS function conflict for map area roles

### DIFF
--- a/static/js/script.js
+++ b/static/js/script.js
@@ -2048,11 +2048,11 @@ document.addEventListener('DOMContentLoaded', function() {
         fetchAndDisplayMaps();
         
         // Populate Roles for Checkbox List in Define Area Form
-        async function populateDefineAreaRolesCheckboxes() {
-            const authorizedRolesCheckboxContainer = document.getElementById('define-area-authorized-roles-checkbox-container');
+        async function initializeRolesForAreaDefinitionUI() {
+            const authorizedRolesCheckboxContainer = document.getElementById('define-area-roles-checkbox-container');
 
             if (!authorizedRolesCheckboxContainer) {
-                console.error("#define-area-authorized-roles-checkbox-container not found in DOM.");
+                console.error("#define-area-roles-checkbox-container not found in DOM.");
                 return;
             }
 

--- a/templates/admin_maps.html
+++ b/templates/admin_maps.html
@@ -377,7 +377,7 @@
                     rolesLoadingMsg.style.display = 'block';
                 }
             }
-            populateDefineAreaRolesCheckboxes(); // Populate/update messages after fetch attempt
+            initializeRolesForAreaDefinitionUI(); // Populate/update messages after fetch attempt
         }
 
         function populateDefineAreaRolesCheckboxes(selectedRoleIds = []) {


### PR DESCRIPTION
This commit addresses an issue where clicking a map area did not correctly update the role permission checkboxes. The previous fix inadvertently caused a JavaScript error due to a function naming collision.

1.  I renamed `populateDefineAreaRolesCheckboxes` in `static/js/script.js` to `initializeRolesForAreaDefinitionUI`. This function is responsible for initially populating the list of all available roles when the "Define Areas" interface is loaded.
2.  I corrected the target element ID within `initializeRolesForAreaDefinitionUI` to `define-area-roles-checkbox-container` (it was previously referencing a non-existent ID).
3.  I updated the call site in `templates/admin_maps.html`'s inline script: the `loadAllRolesForAreaDefinition` function now calls the renamed `initializeRolesForAreaDefinitionUI`.
4.  I ensured that the `drawingCanvas.onmousedown` event handler in `static/js/script.js`, when an existing area is clicked, correctly calls the global `populateDefineAreaRolesCheckboxes(selectedRoleIds)` function (defined in the inline script of `templates/admin_maps.html`). This global function is responsible for checking/unchecking specific roles based on the selected area's configuration.

These changes ensure that the initial display of roles and the dynamic update of role checkboxes upon area selection work as intended, using the correct functions and DOM elements.