### PR TITLE
Fix: Ensure JS functions for map roles are globally accessible

### DIFF
--- a/static/js/script.js
+++ b/static/js/script.js
@@ -2087,7 +2087,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 // This catch block is for errors not handled by apiCall (e.g., if apiCall itself fails or network issues not caught by it)
                 // or if an error occurs in the processing logic above (after apiCall returns successfully but before this catch).
                 // apiCall should have already displayed an error in authorizedRolesCheckboxContainer if the API call failed.
-                console.error("Error in populateDefineAreaRolesCheckboxes after apiCall:", error);
+                console.error("Error in initializeRolesForAreaDefinitionUI after apiCall:", error);
                 // Check if an error message is already displayed by apiCall
                 const hasExistingErrorMessage = authorizedRolesCheckboxContainer.classList.contains('error') && authorizedRolesCheckboxContainer.textContent.trim() !== '';
                 if (!hasExistingErrorMessage) {
@@ -2096,6 +2096,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 }
             }
         }
+        window.initializeRolesForAreaDefinitionUI = initializeRolesForAreaDefinitionUI;
         // populateDefineAreaRolesCheckboxes(); // This is likely called on DOMContentLoaded or when Define Areas is shown.
 
         // Expose fetchAndDrawExistingMapAreas

--- a/templates/admin_maps.html
+++ b/templates/admin_maps.html
@@ -439,6 +439,7 @@
                 checkboxContainer.appendChild(div);
             });
         }
+        window.populateDefineAreaRolesCheckboxes = populateDefineAreaRolesCheckboxes;
 
         // Event listener for map actions (using event delegation on mapsTableBody)
         mapsTableBody.addEventListener('click', async function(event) {


### PR DESCRIPTION
This commit resolves JavaScript ReferenceErrors that occurred because functions defined in `static/js/script.js` and the inline script of `templates/admin_maps.html` were not reliably accessible to each other.

1.  Modified `static/js/script.js`: The `initializeRolesForAreaDefinitionUI` function (responsible for populating the 'Define Areas' UI with all available roles) is now explicitly exposed to the global scope by attaching it to the `window` object (`window.initializeRolesForAreaDefinitionUI = initializeRolesForAreaDefinitionUI;`).

2.  Modified `templates/admin_maps.html`: The `populateDefineAreaRolesCheckboxes(selectedRoleIds = [])` function (defined in the inline script and responsible for checking specific roles based on a selected map area) is now explicitly exposed to the global scope (`window.populateDefineAreaRolesCheckboxes = populateDefineAreaRolesCheckboxes;`).

These changes ensure that:
- When the "Define Areas" section is loaded, `admin_maps.html` can successfully call `initializeRolesForAreaDefinitionUI` from `script.js`.
- When a map area is clicked, `script.js` can successfully call `populateDefineAreaRolesCheckboxes` from `admin_maps.html`.

This should fix the previously reported errors and ensure the role permission checkboxes are populated and updated correctly.