### PR TITLE
Here's a proposed change to the code:

### DIFF
--- a/static/js/resource_management.js
+++ b/static/js/resource_management.js
@@ -709,6 +709,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 const qrCodeModal = document.getElementById('qr-code-modal');
                 const qrCodeDisplay = document.getElementById('qr-code-display');
                 const qrCodeUrlText = document.getElementById('qr-code-url-text');
+                console.log('[DEBUG QR MODAL ELEMENTS] qrCodeModal:', qrCodeModal, 'qrCodeDisplay:', qrCodeDisplay, 'qrCodeUrlText:', qrCodeUrlText);
 
                 if (qrCodeModal && qrCodeDisplay && qrCodeUrlText) {
                     qrCodeDisplay.innerHTML = ''; // Clear previous QR code


### PR DESCRIPTION
debug: Add console log for QR modal elements

This adds a console.log statement in `static/js/resource_management.js` within the '.show-qr-code-btn' click handler. This log will output the results of `getElementById` for `qr-code-modal`, `qr-code-display`, and `qr-code-url-text` to help diagnose an issue where these elements are reportedly not found.