### PR TITLE
feat: Display HTML page for resource URL check-in responses

### DIFF
--- a/templates/check_in_status_public.html
+++ b/templates/check_in_status_public.html
@@ -1,0 +1,46 @@
+{% extends "base.html" %}
+
+{% block title %}
+    {{ _('Check-in Status') }} - {% if super %}{{ super() }}{% else %}{{ _('Smart Resource Booking') }}{% endif %}
+{% endblock %}
+
+{% block content %}
+<div class="container" style="margin-top: 20px; text-align: center; padding: 15px;">
+    <h1>{{ _('Resource Check-in Status') }}</h1>
+
+    {% if status == 'success' %}
+        <div class="alert alert-success" role="alert" style="padding: 20px; border: 1px solid #28a745; border-radius: 5px; background-color: #d4edda; color: #155724; margin-bottom: 20px;">
+            <h4 class="alert-heading" style="margin-top: 0; margin-bottom: 10px; font-size: 1.5em;">{{ _('Success!') }}</h4>
+            <p style="font-size: 1.1em;">{{ message }}</p>
+            {% if booking_details %}
+                <hr style="border-top: 1px solid #155724;">
+                <div style="text-align: left; display: inline-block; margin-top: 15px;">
+                    <p style="margin-bottom: 5px;"><strong>{{ _('Booking Title:') }}</strong> {{ booking_details.title }}</p>
+                    <p style="margin-bottom: 5px;"><strong>{{ _('Resource:') }}</strong> {{ booking_details.resource_name }}</p>
+                    <p style="margin-bottom: 5px;"><strong>{{ _('User:') }}</strong> {{ booking_details.user_name }}</p>
+                    <p style="margin-bottom: 5px;"><strong>{{ _('Checked-in at:') }}</strong> {{ booking_details.checked_in_at_formatted }}</p>
+                </div>
+            {% endif %}
+        </div>
+    {% elif status == 'error' %}
+        <div class="alert alert-danger" role="alert" style="padding: 20px; border: 1px solid #dc3545; border-radius: 5px; background-color: #f8d7da; color: #721c24; margin-bottom: 20px;">
+            <h4 class="alert-heading" style="margin-top: 0; margin-bottom: 10px; font-size: 1.5em;">{{ _('Error') }}</h4>
+            <p style="font-size: 1.1em;">{{ message }}</p>
+        </div>
+    {% else %}
+        {# Fallback for unknown status or if status is not provided #}
+        <div class="alert alert-info" role="alert" style="padding: 20px; border: 1px solid #17a2b8; border-radius: 5px; background-color: #d1ecf1; color: #0c5460; margin-bottom: 20px;">
+            <h4 class="alert-heading" style="margin-top: 0; margin-bottom: 10px; font-size: 1.5em;">{{ _('Status') }}</h4>
+            <p style="font-size: 1.1em;">{{ message }}</p>
+        </div>
+    {% endif %}
+
+    <div style="margin-top: 30px;">
+        <a href="{{ url_for('ui.serve_index') }}" class="button primary-button">{{ _('Go to Homepage') }}</a>
+        {# Example for a conditional login link - logic for 'show_login_link' would be in the route #}
+        {% if show_login_link %}
+            <a href="{{ login_url }}" class="button" style="margin-left: 10px;">{{ _('Login') }}</a>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
This commit changes the behavior of the GET /api/r/<resource_id>/checkin endpoint. Instead of returning JSON responses, it now renders an HTML page to provide user-friendly feedback for check-in attempts.

Changes include:
- Created a new template `templates/check_in_status_public.html` which displays success or error messages, and booking details upon successful check-in. It includes styling based on status and uses i18n for messages.
- Modified the `resource_pin_check_in` function in `routes/api_bookings.py` to use `render_template` with the new HTML template for all user-facing success and error scenarios (e.g., invalid PIN, outside window, login required, success).
- Updated the audit log action name for successful check-ins via this URL to "CHECK_IN_VIA_RESOURCE_URL".
- Enabled a conditional login link in `check_in_status_public.html` for cases where login is required.