### PR TITLE
fix: Correct i18n import to use custom translations module

### DIFF
--- a/routes/api_bookings.py
+++ b/routes/api_bookings.py
@@ -2,7 +2,7 @@ from flask import Blueprint, jsonify, request, current_app, abort, render_templa
 from flask_login import login_required, current_user
 import json # Added json import
 from sqlalchemy import func
-from flask_babel import _ # For translations
+from translations import _ # For translations
 import secrets
 from datetime import datetime, timedelta, timezone, time
 


### PR DESCRIPTION
- Changed import in `routes/api_bookings.py` from `flask_babel` to the project's custom `translations` module.

This resolves a `ModuleNotFoundError` for `flask_babel` and ensures the application uses its own defined translation system. Other relevant files (`routes/admin_ui.py`, templates) were reviewed and found to be correctly using the custom translation setup.