### PR TITLE
Feat: Enhance Edit Resource page with PIN deletion and icon buttons

### DIFF
--- a/templates/resource_management.html
+++ b/templates/resource_management.html
@@ -132,14 +132,14 @@
                             <label for="pin_notes">{{ _('Notes:') }}</label>
                             <input type="text" id="pin_notes" class="form-control" style="width: auto; display: inline-block; margin-right: 10px;">
                         </div>
-                        <button type="button" id="btn-add-manual-pin" class="button">{{ _('Add/Set Manual PIN') }}</button>
-                        <button type="button" id="btn-auto-generate-pin" class="button">{{ _('Auto-generate New PIN') }}</button>
+                        <button type="button" id="btn-add-manual-pin" class="button" title="{{ _('Add/Set Manual PIN') }}"><span aria-hidden="true">➕</span></button>
+                        <button type="button" id="btn-auto-generate-pin" class="button" title="{{ _('Auto-generate New PIN') }}"><span aria-hidden="true">✨</span></button>
                     </div>
                      <div id="resource-pin-form-status" class="status-message" style="margin-top: 10px;"></div>
                 </div>
                 <!-- End Resource PINs Management Area -->
 
-                <button type="submit" class="button" style="margin-top: 10px;">{{ _('Save Resource') }}</button>
+                <button type="submit" class="button" style="margin-top: 10px;" title="{{ _('Save Resource') }}"><span aria-hidden="true">💾</span></button>
                 <div id="resource-form-modal-status" class="status-message" style="margin-top: 10px;"></div>
             </form>
         </div>


### PR DESCRIPTION
- I've added a "Delete" button for each PIN in the PIN management section of the Edit Resource modal.
- I've implemented the backend API endpoint (`DELETE /api/resources/<resource_id>/pins/<pin_id>`) to support PIN deletion, including logic to update the resource's current_pin.
- I've added frontend JavaScript to handle the delete PIN functionality, including user confirmation and UI updates.
- I've included comprehensive unit tests for the new delete PIN API endpoint, covering success cases, current_pin updates, error handling, and permissions.
- I've refactored buttons within the Edit Resource modal (Save Resource, Add/Set Manual PIN, Auto-generate New PIN) and the dynamically generated PIN action buttons (Copy URL, Show QR, Delete PIN) to use Unicode icons instead of text.
- I've added `title` attributes to the new icon buttons for improved accessibility.