### PR TITLE
Refactor: Update PIN management buttons in Edit Resource modal

### DIFF
--- a/static/js/resource_management.js
+++ b/static/js/resource_management.js
@@ -643,28 +643,15 @@ document.addEventListener('DOMContentLoaded', function() {
             row.insertCell().textContent = pin.created_at ? new Date(pin.created_at).toLocaleString() : 'N/A';
 
             const actionsCell = row.insertCell();
-            const copyUrlBtn = document.createElement('button');
-            copyUrlBtn.textContent = 'Copy Check-in URL';
-            copyUrlBtn.classList.add('button', 'button-small', 'copy-pin-url-btn');
-            copyUrlBtn.dataset.pinValue = pin.pin_value;
-            copyUrlBtn.dataset.resourceId = resourceId;
-            actionsCell.appendChild(copyUrlBtn);
+            actionsCell.style.whiteSpace = "nowrap"; // Keep buttons on one line
 
-            const showQrBtn = document.createElement('button');
-            showQrBtn.textContent = 'Show QR Code';
-            showQrBtn.classList.add('button', 'button-small', 'show-qr-code-btn');
-            showQrBtn.dataset.pinValue = pin.pin_value;
-            showQrBtn.dataset.resourceId = resourceId;
-            showQrBtn.style.marginLeft = '5px';
-            actionsCell.appendChild(showQrBtn);
-
-            const deleteBtn = document.createElement('button');
-            deleteBtn.textContent = 'Delete';
-            deleteBtn.classList.add('button', 'button-small', 'danger', 'delete-pin-btn');
-            deleteBtn.dataset.pinId = pin.id;
-            deleteBtn.dataset.resourceId = resourceId;
-            deleteBtn.style.marginLeft = '5px'; // Maintain spacing
-            actionsCell.appendChild(deleteBtn);
+            // Action buttons for each PIN
+            actionsCell.innerHTML = `
+                <button class="button btn-pin-action btn-edit-pin" data-pin-id="${pin.id}" data-resource-id="${resourceId}" title="Edit PIN"><span aria-hidden="true">✏️</span></button>
+                <button class="button btn-pin-action btn-delete-pin danger" data-pin-id="${pin.id}" data-resource-id="${resourceId}" title="Delete PIN"><span aria-hidden="true">🗑️</span></button>
+                <button class="button button-small copy-pin-url-btn" data-pin-value="${pin.pin_value}" data-resource-id="${resourceId}" title="Copy Check-in URL" style="margin-left:5px;">Copy URL</button>
+                <button class="button button-small show-qr-code-btn" data-pin-value="${pin.pin_value}" data-resource-id="${resourceId}" title="Show QR Code" style="margin-left:5px;">Show QR</button>
+            `;
         });
     }
 

--- a/static/style.css
+++ b/static/style.css
@@ -1497,4 +1497,34 @@ a.fc-daygrid-event.fc-event {
 
 /* --------------- END MAP RESOURCE AREA STYLES --------------- */
 
+/* PIN action icon buttons in table */
+.btn-pin-action {
+    padding: 5px 8px; /* Smaller padding */
+    font-size: 1.2em; /* Slightly larger for better icon visibility, can be adjusted */
+    line-height: 1; /* Ensure consistent height */
+    margin: 2px; /* Adjust spacing between buttons */
+    vertical-align: middle; /* Align icons nicely if they vary in height */
+}
+
+/* Ensure icon buttons don't have excessive default button height if text is removed */
+.btn-pin-action span[aria-hidden="true"] {
+    display: inline-block; /* Helps with sizing and alignment */
+}
+
+/* Add New PIN buttons (text-based and smaller) */
+#btn-add-manual-pin,
+#btn-auto-generate-pin {
+    padding: 6px 10px; /* Smaller padding */
+    font-size: 0.9em; /* Smaller text */
+    /* The following lines are to ensure text is displayed if icons were previously used via JS/HTML structure */
+    /* However, the primary change to text content should be in HTML/JS */
+}
+/* If #btn-add-manual-pin and #btn-auto-generate-pin use <span> for icons, this would hide them: */
+/*
+#btn-add-manual-pin span[aria-hidden="true"],
+#btn-auto-generate-pin span[aria-hidden="true"] {
+    display: none;
+}
+*/
+
 [end of static/style.css]

--- a/templates/resource_management.html
+++ b/templates/resource_management.html
@@ -132,8 +132,8 @@
                             <label for="pin_notes">{{ _('Notes:') }}</label>
                             <input type="text" id="pin_notes" class="form-control" style="width: auto; display: inline-block; margin-right: 10px;">
                         </div>
-                        <button type="button" id="btn-add-manual-pin" class="button" title="{{ _('Add/Set Manual PIN') }}"><span aria-hidden="true">➕</span></button>
-                        <button type="button" id="btn-auto-generate-pin" class="button" title="{{ _('Auto-generate New PIN') }}"><span aria-hidden="true">✨</span></button>
+                        <button type="button" id="btn-add-manual-pin" class="button" title="{{ _('Add/Set Manual PIN') }}">{{ _('Add PIN') }}</button>
+                        <button type="button" id="btn-auto-generate-pin" class="button" title="{{ _('Auto-generate New PIN') }}">{{ _('Generate PIN') }}</button>
                     </div>
                      <div id="resource-pin-form-status" class="status-message" style="margin-top: 10px;"></div>
                 </div>


### PR DESCRIPTION
This commit addresses UI issues in the PIN management section of the Edit Resource modal on the admin/resources_manage page.

Changes include:
- Icon buttons (Edit, Delete, Copy URL, Show QR) for individual PINs are now located in an "Actions" column.
- The size of these icon buttons has been reduced.
- The "Add New PIN" and "Auto-generate New PIN" buttons are now text-based ("Add PIN", "Generate PIN") and their size has been reduced.

These changes improve the layout and visual consistency of the PIN management interface.