### PR TITLE
Fix: Resolve JavaScript syntax error in QR code logic

### DIFF
--- a/static/js/resource_management.js
+++ b/static/js/resource_management.js
@@ -809,9 +809,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 const resourceId = target.dataset.resourceId;
                 const checkinUrl = `${window.location.origin}/api/r/${resourceId}/checkin?pin=${pinValue}`; // Correct URL
 
-                const pinValue = target.dataset.pinValue;
-                const resourceId = target.dataset.resourceId;
-                const checkinUrl = `${window.location.origin}/api/r/${resourceId}/checkin?pin=${pinValue}`;
+                // Duplicated declarations removed below
 
                 const qrCodeModal = document.getElementById('qr-code-modal');
                 const qrCodeDisplay = document.getElementById('qr-code-display');


### PR DESCRIPTION
This commit fixes a "SyntaxError: Identifier has already been declared" error that occurred in `static/js/resource_management.js` within the event handler for the "Show QR Code" button.

The error was caused by inadvertently re-declaring variables (`pinValue`, `resourceId`, `checkinUrl`) with `const` in a scope where they were already defined. This patch removes the duplicate declarations, ensuring the variables are declared only once.

The QR code display functionality, including the recently added retry mechanism, should now operate without this JavaScript error.