### PR TITLE
Fix: Refresh map selection button colors after booking

### DIFF
--- a/static/js/new_booking_map.js
+++ b/static/js/new_booking_map.js
@@ -742,6 +742,7 @@ document.addEventListener('DOMContentLoaded', function () {
                     }, 2000);
                     if (currentMapId && currentSelectedDateStr) { // Use global date string
                         loadMapDetails(currentMapId, currentSelectedDateStr);
+                        updateLocationFloorButtons(); // Update map selection buttons
                     }
                 } else {
                     if (!modalStatusMessageP.classList.contains('error') && !modalStatusMessageP.classList.contains('success')) {


### PR DESCRIPTION
Ensures that the location/floor selection buttons on the 'View Resources' page update their availability status (colors) immediately after you successfully book a resource.

Previously, only the individual resource area on the map would update. This change calls the `updateLocationFloorButtons()` function in `static/js/new_booking_map.js` after a successful booking, triggering a refresh of the button states to reflect the latest availability.