### PR TITLE
Feat: Default 'My Bookings' filter to 'Approved'

### DIFF
--- a/static/js/my_bookings.js
+++ b/static/js/my_bookings.js
@@ -764,6 +764,11 @@ document.addEventListener('DOMContentLoaded', () => {
         console.warn("Flatpickr not available or datePickerInput not found. Date picker will not be initialized.");
     }
 
+    // Set default status filter before the initial fetch
+    if (statusFilterSelect) {
+        statusFilterSelect.value = 'approved';
+    }
+
     // Initial fetch of bookings - now uses default filter values
     fetchAndDisplayBookings();
 


### PR DESCRIPTION
I've set the default status filter on your 'My Bookings' page to 'Approved' when the page is initially loaded. This provides a more focused view for you, typically showing you your active, approved bookings first.

I modified `static/js/my_bookings.js` to set the status filter dropdown to 'approved' and trigger the initial booking fetch with this default filter applied. You can still manually change the filter to other statuses.