### PR TITLE
Fix: Resolve JavaScript error on booking cancellation in My Bookings

### DIFF
--- a/static/js/my_bookings.js
+++ b/static/js/my_bookings.js
@@ -1,4 +1,6 @@
 document.addEventListener('DOMContentLoaded', () => {
+    const upcomingBookingsContainer = document.getElementById('upcoming-bookings-container');
+    const pastBookingsContainer = document.getElementById('past-bookings-container');
     const bookingItemTemplate = document.getElementById('booking-item-template');
     const statusDiv = document.getElementById('my-bookings-status'); // Used by multiple functions in this scope
 
@@ -191,8 +193,8 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     async function fetchAndDisplayBookings() {
-        const upcomingBookingsContainer = document.getElementById('upcoming-bookings-container');
-        const pastBookingsContainer = document.getElementById('past-bookings-container');
+        // const upcomingBookingsContainer = document.getElementById('upcoming-bookings-container'); // Now global
+        // const pastBookingsContainer = document.getElementById('past-bookings-container'); // Now global
         const myBookingsStatusDiv = document.getElementById('my-bookings-status'); // Uses the global statusDiv
 
         if (!upcomingBookingsContainer || !pastBookingsContainer) {


### PR DESCRIPTION
Corrects a `ReferenceError: upcomingBookingsContainer is not defined` that occurred when you tried to cancel a booking from the 'My Bookings' page.

The error was due to `upcomingBookingsContainer` and `pastBookingsContainer` variables being defined locally within the `fetchAndDisplayBookings` function, making them inaccessible to a global click event listener that handled the cancellation UI update.

The fix involves moving the definitions of these container variables to the top level of the `DOMContentLoaded` event listener in `static/js/my_bookings.js`. This makes them accessible to all functions and event handlers within that scope, allowing the UI to update correctly after a booking is cancelled.