### PR TITLE
Fix: Ensure calendar refreshes after date/time updates via modal

### DIFF
--- a/static/js/calendar.js
+++ b/static/js/calendar.js
@@ -206,6 +206,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
             cebmStatusMessage.textContent = response.message || 'Booking updated successfully!';
             cebmStatusMessage.className = 'status-message success-message'; // Ensure you have .success-message CSS
+
+            allUserEvents = []; // Clear the cache to force a fresh fetch
             calendar.refetchEvents(); // Refresh calendar events
 
             // Close modal and clear message after a short delay
@@ -221,6 +223,8 @@ document.addEventListener('DOMContentLoaded', () => {
             if (error.message && error.message.includes("No changes supplied.")) {
                 cebmStatusMessage.textContent = 'No changes detected. Booking details are already up to date.';
                 cebmStatusMessage.className = 'status-message success-message'; // Treat as success
+
+                allUserEvents = []; // Clear the cache
                 calendar.refetchEvents(); // Refresh calendar events
 
                 setTimeout(() => {


### PR DESCRIPTION
Resolves an issue where the main calendar view (`/calendar`) did not update to reflect changes to a booking's date or time when those changes were made through the event's edit modal.

The problem was caused by an in-memory event cache (`allUserEvents`) in `static/js/calendar.js` that was not being cleared before `calendar.refetchEvents()` was called. This meant FullCalendar's event source function might return the cached data instead of fetching fresh data from the server.

The fix involves explicitly clearing this cache (`allUserEvents = [];`) immediately before the `calendar.refetchEvents()` call within the `saveBookingChanges` function (which handles modal updates). This ensures that the calendar always fetches and displays the latest booking information after an update.