### PR TITLE
Fix: Resolve element not found error on calendar page load

### DIFF
--- a/templates/calendar.html
+++ b/templates/calendar.html
@@ -10,10 +10,9 @@
 <h2>{{ _('My Calendar') }}</h2>
 
 <div class="mb-3">
-    <label for="calendar-resource-select" class="form-label">{{ _('Filter by Resource:') }}</label> {# Changed label for clarity #}
-    <select id="calendar-resource-select" class="form-select">
-        <option value="all" selected>-- {{ _('All My Booked Resources') }} --</option>
-        {# Options for individual resources will be populated by JavaScript #}
+    <label for="calendar-status-filter" class="form-label">{{ _('Filter by Status:') }}</label>
+    <select id="calendar-status-filter" class="form-select">
+        {# Options will be populated by JavaScript #}
     </select>
 </div>
 


### PR DESCRIPTION
Corrects a JavaScript error "Required calendar elements or modal not found" that occurred when `static/js/calendar.js` initialized. The error was caused by a mismatch in the ID of the filter dropdown element between the JavaScript file and the `templates/calendar.html` template.

The `calendar.js` script expected the filter dropdown to have the ID `calendar-status-filter`, while the HTML template previously used `calendar-resource-select` for this element (a remnant from before the filter was changed from resource-based to status-based).

This commit updates `templates/calendar.html` to:
- Change the filter dropdown's `id` to `calendar-status-filter`.
- Update the associated label's `for` attribute accordingly.
- Change the label text to "Filter by Status:".
- Remove a static default option from the select element, as it's now dynamically populated by JavaScript.

This ensures the JavaScript can correctly find and interact with the filter dropdown, allowing the calendar page and its status filter functionality to load and operate as intended.