### PR TITLE
Fix: Set header font to white on hover and update dark mode styles

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -101,7 +101,7 @@ body {
 .header-content > a:hover,
 .header-content > div:hover:not(#user-dropdown-container):not(#welcome-message-container):not(#user-actions-area) { /* Avoid hover on non-interactive divs unless they contain an <a> that handles it */
     background-color: var(--secondary-color);
-    /* color is already set to black and important, hover shouldn't change it unless specified */
+    color: #ffffff !important;
     text-decoration: none;
 }
 /* Specifically target <a> tags within the divs for hover, if the div itself shouldn't have hover */
@@ -109,7 +109,7 @@ body {
 .header-content #auth-link-container a:hover {
     background-color: var(--secondary-color); /* Apply hover to the link itself */
     border-radius: 4px; /* Ensure hover matches overall item shape */
-    /* color is already set to black and important */
+    color: #ffffff !important;
     text-decoration: none;
 }
 .header-content #my-bookings-nav-link a,
@@ -155,6 +155,7 @@ body {
 .app-header #user-dropdown-button:hover {
     background-color: var(--secondary-color);
     border-radius: 4px;
+    color: #ffffff !important;
 }
 .app-header .user-icon { /* Copied from existing .user-icon */
     font-size: 1.2em;


### PR DESCRIPTION
This commit introduces a new hover effect for header elements and includes previous fixes for dark mode styling:

1.  Header font color on hover:
    - Added `color: #ffffff !important;` to the hover states of interactive header elements (navigation links, user dropdown button, login/auth links).
    - This ensures that header text becomes white when hovered over in both light and dark modes, providing clear visual feedback.

2.  Header font color in dark mode (base state):
    - Modified CSS rules for header elements to use `inherit` for color, allowing them to correctly pick up the theme-dependent color from the parent `.app-header`.
    - This ensures header text is white in dark mode by default.

3.  Upcoming Bookings background in dark mode:
    - Added a CSS rule for the `#upcoming-bookings` section on the home page.
    - In dark mode, the background of this section is now set to black (#000000), with text color inheriting the light theme color for good contrast.

These changes enhance the visual consistency, readability, and user experience of both light and dark modes, particularly for header interactions.