### PR TITLE
Fix: Remove unused db argument in _import_resource_configurations_dat…

### DIFF
--- a/routes/api_resources.py
+++ b/routes/api_resources.py
@@ -410,7 +410,7 @@ def import_resources_admin():
     if not isinstance(resources_data, list): return jsonify({'error': 'JSON must be a list.'}), 400
 
     # Pass db instance from extensions
-    created, updated, errors = _import_resource_configurations_data(resources_data, db)
+    created, updated, errors = _import_resource_configurations_data(resources_data)
 
     summary = f"Import completed. Created: {created}, Updated: {updated}, Errors: {len(errors)}."
     add_audit_log(action="IMPORT_RESOURCES", details=f"User {current_user.username} imported resources. {summary} Errors: {errors}")


### PR DESCRIPTION
…a call

This commit fixes a TypeError that occurred because _import_resource_configurations_data was called with two arguments (resources_data, db) but is defined to take only one (resources_data_list). The db argument was not used within the function, so it has been safely removed from the call site in the import_resources_admin function in routes/api_resources.py.