### PR TITLE
Fix: Add CSRF token to CSV user import request

### DIFF
--- a/static/js/user_management.js
+++ b/static/js/user_management.js
@@ -184,11 +184,19 @@ document.addEventListener('DOMContentLoaded', function() {
                 // If using apiCall and it has a default 'Content-Type' header, it needs to be omitted for FormData.
 
                 // Using fetch directly for clarity with FormData
-                const response = await fetch('/api/admin/users/import/csv', {
+                const csrfTokenTag = document.querySelector('meta[name="csrf-token"]');
+                const csrfToken = csrfTokenTag ? csrfTokenTag.content : null;
+
+                const fetchOptions = {
                     method: 'POST',
-                    body: formData
-                    // No 'Content-Type' header here, browser will set it for FormData
-                });
+                    body: formData,
+                    headers: {} // Initialize headers
+                };
+                if (csrfToken) {
+                    fetchOptions.headers['X-CSRFToken'] = csrfToken;
+                }
+
+                const response = await fetch('/api/admin/users/import/csv', fetchOptions);
 
                 const result = await response.json();
 


### PR DESCRIPTION
The CSV import functionality in `user_management.js` was using a direct `fetch` call without including the CSRF token. This caused a 'CSRF token is missing' error because the backend expects the token for POST requests.

This commit updates the `fetch` call to retrieve the CSRF token from the `meta[name="csrf-token"]` tag and include it in the `X-CSRFToken` header, consistent with how the `apiCall` helper function handles CSRF protection.