### PR TITLE
Fix: Prevent apiCall from overriding Content-Type for FormData

### DIFF
--- a/static/js/script.js
+++ b/static/js/script.js
@@ -88,7 +88,7 @@ async function apiCall(url, options = {}, messageElement = null) {
         let csrfToken = csrfTokenTag ? csrfTokenTag.content : null;
         if (csrfToken) {
             if (!options.headers) options.headers = {};
-            if (!options.headers['Content-Type'] && (method === 'POST' || method === 'PUT' || method === 'PATCH') && options.body) {
+            if (!(options.body instanceof FormData) && !options.headers['Content-Type'] && (method === 'POST' || method === 'PUT' || method === 'PATCH') && options.body) {
                 options.headers['Content-Type'] = 'application/json';
             }
             options.headers['X-CSRFToken'] = csrfToken;


### PR DESCRIPTION
The apiCall helper function was unconditionally setting the Content-Type to 'application/json' for POST/PUT/PATCH requests with a body if no Content-Type was already set. This breaks file uploads using FormData, as the browser should automatically set the Content-Type to 'multipart/form-data' with the correct boundary.

This commit modifies the condition to ensure that Content-Type is not set to 'application/json' if the request body is an instance of FormData.