### PR TITLE
Fix: Correct translation formatting in Admin Bookings

### DIFF
--- a/templates/admin_bookings.html
+++ b/templates/admin_bookings.html
@@ -145,7 +145,7 @@
             </li>
         </ul>
     </nav>
-    <p class="text-center">{{ _('Page %(page_num)s of %(total_pages)s.', page_num=bookings_page_obj.page, total_pages=bookings_page_obj.pages) }}</p>
+    <p class="text-center">{{ _('Page %(page_num)s of %(total_pages)s.', {'page_num': bookings_page_obj.page, 'total_pages': bookings_page_obj.pages}) }}</p>
     {% endif %}
 
 </div>


### PR DESCRIPTION
I resolved a TypeError in the admin bookings template (`templates/admin_bookings.html`). The error "_() got an unexpected keyword argument 'page_num'" occurred because keyword arguments were passed directly to the translation function for a string with named placeholders.

The fix involves changing the translation call for the pagination indicator from:
  `_('Page %(page_num)s of %(total_pages)s.', page_num=..., total_pages=...)`
to the correct format:
  `_('Page %(page_num)s of %(total_pages)s.', {'page_num': ..., 'total_pages': ...})`
This provides the placeholder values as a dictionary, which is the expected syntax for Flask-Babel/Jinja2 when using named placeholders.