### PR TITLE
Fix: Correct string formatting for translations in Admin Bookings

### DIFF
--- a/templates/admin_bookings.html
+++ b/templates/admin_bookings.html
@@ -145,7 +145,7 @@
             </li>
         </ul>
     </nav>
-    <p class="text-center">{{ _('Page %(page_num)s of %(total_pages)s.', {'page_num': bookings_page_obj.page, 'total_pages': bookings_page_obj.pages}) }}</p>
+    <p class="text-center">{{ _('Page %(page_num)s of %(total_pages)s.') % {'page_num': bookings_page_obj.page, 'total_pages': bookings_page_obj.pages} }}</p>
     {% endif %}
 
 </div>


### PR DESCRIPTION
Resolved a TypeError ("_() takes 1 positional argument but 2 were given") that occurred in the `templates/admin_bookings.html` template when displaying pagination information.

The error was due to incorrectly passing a dictionary of variables as a second argument to the `_()` translation function within the Jinja expression.

The fix ensures that the `_()` function is called with only the translatable string, and then Python's string formatting operator `%` is used on the result of `_()` with the dictionary of variables.

The corrected line is now:
  `{{ _('Page %(page_num)s of %(total_pages)s.') % {'page_num': ..., 'total_pages': ...} }}`
This is the standard way to handle named placeholders with translations in Jinja using Flask-Babel.