### PR TITLE
Fix: Ensure horizontal layout for admin bookings pagination

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1534,4 +1534,7 @@ a.fc-daygrid-event.fc-event {
 }
 */
 
-[end of static/style.css]
+/* Ensure Bootstrap pagination items are displayed inline-flex */
+.pagination > .page-item {
+    display: inline-flex;
+}


### PR DESCRIPTION
I corrected a layout issue where pagination items on your Admin Bookings page were rendering vertically instead of horizontally.

I confirmed the HTML structure was using standard Bootstrap 5 pagination classes. To ensure the intended horizontal flex layout, I added a specific CSS rule to `static/style.css`:

.pagination > .page-item {
    display: inline-flex;
}

This rule targets the pagination list items directly to ensure they align horizontally as expected.