### PR TITLE
Refine: Update Admin Bookings pagination UI format

### DIFF
--- a/templates/admin_bookings.html
+++ b/templates/admin_bookings.html
@@ -127,6 +127,7 @@
             <li class="page-item {% if not bookings_page_obj.has_prev %}disabled{% endif %}">
                 <a class="page-link" href="{% if bookings_page_obj.has_prev %}{{ url_for('admin_ui.serve_admin_bookings_page', page=bookings_page_obj.prev_num, per_page=per_page, status_filter=current_status_filter if current_status_filter else None) }}{% else %}#__{% endif %}">&laquo;</a>
             </li>
+            <li class="page-item disabled"><span class="page-link">||</span></li>
 
             {# Page Numbers #}
             {% for page_num in bookings_page_obj.iter_pages(left_edge=1, left_current=2, right_current=3, right_edge=1) %}
@@ -139,13 +140,13 @@
                 {% endif %}
             {% endfor %}
 
+            <li class="page-item disabled"><span class="page-link">||</span></li>
             {# Next Page Link #}
             <li class="page-item {% if not bookings_page_obj.has_next %}disabled{% endif %}">
                 <a class="page-link" href="{% if bookings_page_obj.has_next %}{{ url_for('admin_ui.serve_admin_bookings_page', page=bookings_page_obj.next_num, per_page=per_page, status_filter=current_status_filter if current_status_filter else None) }}{% else %}#__{% endif %}">&raquo;</a>
             </li>
         </ul>
     </nav>
-    <p class="text-center">{{ _('Page %(page_num)s of %(total_pages)s.') % {'page_num': bookings_page_obj.page, 'total_pages': bookings_page_obj.pages} }}</p>
     {% endif %}
 
 </div>


### PR DESCRIPTION
This commit adjusts the pagination UI on the Admin Bookings page based on specific feedback from you:

1.  Removed the "Page X of Y" text indicator that was previously displayed below the pagination links.
2.  Added "||" separators within the pagination bar to frame the page numbers, achieving the visual format: « || pages || »
    - The "pages" section continues to use Bootstrap's standard pagination items for individual page numbers and ellipses, generated by `iter_pages()`.
    - The "||" separators are styled as disabled, non-interactive page items.

These changes provide a cleaner pagination interface according to the requested design.