### PR TITLE
Feat: Implement custom pagination UI for Admin Bookings

### DIFF
--- a/templates/admin_bookings.html
+++ b/templates/admin_bookings.html
@@ -29,23 +29,6 @@
         {# <button type="submit" class="button" style="margin-left: 10px; padding: 5px 10px;">Filter</button> #}
     </form>
 
-    <!-- Items per page selector - TOP -->
-    <div class="row mb-3">
-        <div class="col-md-6">
-            <form method="GET" action="{{ url_for('admin_ui.serve_admin_bookings_page') }}" class="form-inline">
-                {% if current_status_filter %}
-                    <input type="hidden" name="status_filter" value="{{ current_status_filter }}">
-                {% endif %}
-                <label for="per_page_select_top" class="mr-2">{{ _('Items per page:') }}</label>
-                <select name="per_page" id="per_page_select_top" class="form-control form-control-sm mr-2" style="width: auto;" onchange="this.form.submit()">
-                    {% for val in [10, 25, 50, 100] %}
-                        <option value="{{ val }}" {% if val == per_page %}selected{% endif %}>{{ val }}</option>
-                    {% endfor %}
-                </select>
-            </form>
-        </div>
-    </div>
-
     {% if bookings %}
     <div class="table-responsive">
         <table id="admin-bookings-table" class="table bookings-table"> {# Added id #}
@@ -102,53 +85,66 @@
     <p>{{ _('No bookings found.') }}</p>
     {% endif %}
 
-    <!-- Items per page selector - BOTTOM -->
-    <div class="row mt-3">
-        <div class="col-md-6">
-            <form method="GET" action="{{ url_for('admin_ui.serve_admin_bookings_page') }}" class="form-inline">
-                {% if current_status_filter %}
-                    <input type="hidden" name="status_filter" value="{{ current_status_filter }}">
-                {% endif %}
-                <label for="per_page_select_bottom" class="mr-2">{{ _('Items per page:') }}</label>
-                <select name="per_page" id="per_page_select_bottom" class="form-control form-control-sm mr-2" style="width: auto;" onchange="this.form.submit()">
-                    {% for val in [10, 25, 50, 100] %}
-                        <option value="{{ val }}" {% if val == per_page %}selected{% endif %}>{{ val }}</option>
-                    {% endfor %}
-                </select>
-            </form>
-        </div>
-    </div>
-
-    <!-- Pagination Controls -->
-    {% if bookings_page_obj and (bookings_page_obj.has_prev or bookings_page_obj.has_next) %}
+    <!-- Pagination Controls - New Structure -->
+    {% if bookings_page_obj and bookings_page_obj.total > 0 %} {# Check total items instead of just has_prev/has_next for showing the bar #}
     <nav aria-label="Bookings pagination" class="mt-4">
         <ul class="pagination justify-content-center">
-            {# Previous Page Link #}
-            <li class="page-item {% if not bookings_page_obj.has_prev %}disabled{% endif %}">
-                <a class="page-link" href="{% if bookings_page_obj.has_prev %}{{ url_for('admin_ui.serve_admin_bookings_page', page=bookings_page_obj.prev_num, per_page=per_page, status_filter=current_status_filter if current_status_filter else None) }}{% else %}#__{% endif %}">&laquo;</a>
+            <!-- Items Per Page Selector -->
+            <li class="page-item disabled">
+                <form method="GET" action="{{ url_for('admin_ui.serve_admin_bookings_page') }}" class="d-flex align-items-center">
+                    {% if current_status_filter %}
+                        <input type="hidden" name="status_filter" value="{{ current_status_filter }}">
+                    {% endif %}
+                    <label for="per_page_select_pagination" class="visually-hidden me-2">{{ _('Items per page:') }}</label>
+                    <select name="per_page" id="per_page_select_pagination" class="form-select form-select-sm me-2" style="width: auto;" onchange="this.form.submit()">
+                        {% for val in [10, 25, 50, 100] %}
+                            <option value="{{ val }}" {% if val == per_page %}selected{% endif %}>{{ val }}</option>
+                        {% endfor %}
+                    </select>
+                </form>
             </li>
-            <li class="page-item disabled"><span class="page-link">||</span></li>
 
-            {# Page Numbers #}
-            {% for page_num in bookings_page_obj.iter_pages(left_edge=1, left_current=2, right_current=3, right_edge=1) %}
+            <!-- Blank Separator -->
+            <li class="page-item disabled"><span class="page-link" style="padding-left: 1em;"></span></li>
+
+            <!-- Previous Icon Link -->
+            <li class="page-item {% if not bookings_page_obj.has_prev %}disabled{% endif %}">
+                <a class="page-link" href="{{ url_for('admin_ui.serve_admin_bookings_page', page=bookings_page_obj.prev_num, per_page=per_page, status_filter=current_status_filter) if bookings_page_obj.has_prev else '#' }}">&laquo;</a>
+            </li>
+
+            <!-- Opening Bracket -->
+            <li class="page-item disabled"><span class="page-link">[</span></li>
+
+            <!-- Page Numbers and Commas Loop -->
+            {% set last_was_page_or_ellipsis = false %}
+            {% for page_num in bookings_page_obj.iter_pages(left_edge=1, left_current=1, right_current=1, right_edge=1) %}
+                {% if last_was_page_or_ellipsis and (page_num or not loop.last) %}
+                    <li class="page-item disabled"><span class="page-link">,</span></li>
+                {% endif %}
                 {% if page_num %}
                     <li class="page-item {% if page_num == bookings_page_obj.page %}active{% endif %}">
-                        <a class="page-link" href="{{ url_for('admin_ui.serve_admin_bookings_page', page=page_num, per_page=per_page, status_filter=current_status_filter if current_status_filter else None) }}">{{ page_num }}</a>
+                        <a class="page-link" href="{{ url_for('admin_ui.serve_admin_bookings_page', page=page_num, per_page=per_page, status_filter=current_status_filter) }}">{{ ' ' ~ page_num }}</a>
                     </li>
+                    {% set last_was_page_or_ellipsis = true %}
                 {% else %}
                     <li class="page-item disabled"><span class="page-link">...</span></li>
+                    {% set last_was_page_or_ellipsis = true %}
                 {% endif %}
             {% endfor %}
 
-            <li class="page-item disabled"><span class="page-link">||</span></li>
-            {# Next Page Link #}
+            <!-- Closing Bracket -->
+            <li class="page-item disabled"><span class="page-link">]</span></li>
+
+            <!-- Next Icon Link -->
             <li class="page-item {% if not bookings_page_obj.has_next %}disabled{% endif %}">
-                <a class="page-link" href="{% if bookings_page_obj.has_next %}{{ url_for('admin_ui.serve_admin_bookings_page', page=bookings_page_obj.next_num, per_page=per_page, status_filter=current_status_filter if current_status_filter else None) }}{% else %}#__{% endif %}">&raquo;</a>
+                <a class="page-link" href="{{ url_for('admin_ui.serve_admin_bookings_page', page=bookings_page_obj.next_num, per_page=per_page, status_filter=current_status_filter) if bookings_page_obj.has_next else '#' }}">&raquo;</a>
             </li>
+
+            <!-- Final Blank Separator -->
+            <li class="page-item disabled"><span class="page-link" style="padding-left: 1em;"></span></li>
         </ul>
     </nav>
     {% endif %}
-
 </div>
 
 <script>


### PR DESCRIPTION
This commit overhauls the pagination controls on the Admin Bookings page to match a very specific HTML structure and layout you provided.

Key changes to `templates/admin_bookings.html`:

1.  Integrated the "Items per page" selector directly into the pagination bar as the first element. Removed previous top/bottom selectors.
2.  Structured the pagination elements in the following order:
    - Items per page selector form.
    - A blank spacer list item.
    - "Previous" page icon link (`&laquo;`).
    - An opening bracket `[` as a disabled page item.
    - A loop that renders page numbers (e.g., ` 1`, ` 2`) and ellipses (`...`) using `iter_pages()`.
    - Comma separators (`,`) are inserted as disabled page items between the displayed page numbers/ellipses.
    - A closing bracket `]` as a disabled page item.
    - "Next" page icon link (`&raquo;`).
    - A final blank spacer list item.
3.  Removed the "Page X of Y" text indicator.
4.  The entire custom pagination bar is conditionally rendered only if there are bookings to display (`bookings_page_obj.total > 0`).

This provides a unique and specific pagination interface as you requested for the Admin Bookings page.