### PR TITLE
Refactor: Update pagination on My Bookings page to new template

### DIFF
--- a/templates/my_bookings.html
+++ b/templates/my_bookings.html
@@ -53,19 +53,6 @@
     </div>
 
     <div id="my-bookings-list">
-        <!-- Items Per Page Selector -->
-        <div class="row mb-3">
-            <div class="col-md-4">
-                <label for="items-per-page-select" class="form-label">{{ _('Show entries:') }}</label>
-                <select id="items-per-page-select" class="form-select form-select-sm" style="width: auto; display: inline-block;">
-                    <option value="5">5</option>
-                    <option value="10" selected>10</option>
-                    <option value="25">25</option>
-                    <option value="50">50</option>
-                </select>
-            </div>
-        </div>
-
         <div id="upcoming-bookings-section">
             <h2>{{ _('Upcoming Bookings') }}</h2>
 			<div class="form-check form-switch mb-2">


### PR DESCRIPTION
This commit updates the pagination component on the "My Bookings" page to match the new HTML template provided in the issue.

Key changes:
- I modified `static/js/my_bookings.js` to dynamically generate the new pagination HTML structure within the `renderPaginationControls` function. This includes:
    - Integrating the "Items Per Page" selector (with options 10, 25, 50, 100) directly into the pagination controls.
    - Styling pagination links (previous, next, page numbers) and static elements (brackets, separators) according to the new template.
    - Ensuring event listeners for page navigation and items per page selection correctly trigger data refresh.
- I removed the old, standalone "Items Per Page" selector from `templates/my_bookings.html` as it is now redundant.
- The new pagination style is applied to both "Upcoming Bookings" and "Past Bookings" sections.