### PR TITLE
feat: Display resource name in bold on calendar view

### DIFF
--- a/static/js/calendar.js
+++ b/static/js/calendar.js
@@ -471,6 +471,12 @@ document.addEventListener('DOMContentLoaded', () => {
                         eventHtml += `<br>${displayTime}`;
                     }
                 }
+
+                const resourceName = arg.event.extendedProps.resource_name;
+                if (resourceName) {
+                    eventHtml += `<br><b>${resourceName}</b>`;
+                }
+
                 return { html: eventHtml };
             }
             // For other views, retain original behavior (bold title, FC handles time)


### PR DESCRIPTION
This change modifies the `eventContent` function in `static/js/calendar.js` to display the resource name associated with an event in bold text.

The resource name is now shown on a new line below the event title and time in the `dayGridMonth` view, improving its visibility and clarity as per your requirement.