### PR TITLE
feat: Display resource name in bold on map view

### DIFF
--- a/static/js/new_booking_map.js
+++ b/static/js/new_booking_map.js
@@ -256,7 +256,7 @@ document.addEventListener('DOMContentLoaded', function () {
                         areaDiv.style.top = `${coords.y + offsetY}px`;
                         areaDiv.style.width = `${coords.width}px`;
                         areaDiv.style.height = `${coords.height}px`;
-                        areaDiv.textContent = resource.name;
+                        areaDiv.innerHTML = `<b>${resource.name}</b>`;
                         areaDiv.dataset.resourceId = resource.id;
 
                         const primarySlots = [


### PR DESCRIPTION
This change modifies `static/js/new_booking_map.js` to display the resource name in bold text on the map interface.

In the `loadMapDetails` function, the resource name is now wrapped in `<b>` tags when being assigned to the `areaDiv`'s innerHTML. This enhances the visibility and clarity of resource names on the map, aligning with the styling applied to the calendar view.