### PR TITLE
Feat: Apply scrollable table/content styles to Admin Bookings and My …

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1539,16 +1539,19 @@ a.fc-daygrid-event.fc-event {
     display: inline-flex;
 }
 
-/* Scrollable Admin Table Containers */
-.admin-table-scroll-wrapper,
-div.responsive-table-container { /* Targeting the existing wrapper for the users table */
-    max-height: 500px; /* Adjust this value as needed for approx. 10-15 rows */
+/* Scrollable Admin Table Containers & My Bookings Sections */
+.admin-table-scroll-wrapper,       /* Resource Management */
+div.responsive-table-container,   /* User Management & Admin Bookings */
+#upcoming-bookings-container,      /* My Bookings */
+#past-bookings-container {          /* My Bookings */
+    max-height: 500px;
     overflow-y: auto;
-    margin-bottom: 1rem; /* Optional: space before pagination controls */
+    margin-bottom: 1rem;
 }
 
-/* Ensure tables within these wrappers behave correctly */
+/* Ensure tables within specific admin scrollable wrappers behave correctly */
 .admin-table-scroll-wrapper > table,
-div.responsive-table-container > table {
-    width: 100%; /* Ensure table takes full width of scrollable container */
+div.responsive-table-container > table#users-table, /* User Management */
+div.responsive-table-container > table#admin-bookings-table { /* Admin Bookings */
+    width: 100%;
 }


### PR DESCRIPTION
…Bookings

This commit extends the scrollable content area functionality to the Admin Booking Records page and the My Bookings page.

Changes:
- In `static/style.css`:
    - Added `div.responsive-table-container` (for Admin Bookings table), `#upcoming-bookings-container`, and `#past-bookings-container` (for My Bookings page) to the existing CSS rule that applies `max-height: 500px` and `overflow-y: auto`.
    - Ensured the rule for `table { width: 100%; }` within `div.responsive-table-container` specifically targets `table#admin-bookings-table` to avoid unintended side effects, similar to the specificity added for the users table.

This makes these pages more manageable when displaying a large number of items, consistent with the scrolling behavior recently added to Admin Resources and Admin Users pages.