### PR TITLE
Feat: Implement conditional scrollbars for paginated views

### DIFF
--- a/static/js/my_bookings.js
+++ b/static/js/my_bookings.js
@@ -256,6 +256,22 @@ document.addEventListener('DOMContentLoaded', () => {
             const pastBookingItems = apiResponse.past_bookings.items;
             const checkInOutEnabled = apiResponse.check_in_out_enabled;
 
+            // Conditionally apply scrollable class based on pagination data
+            if (upcomingBookingsContainer) {
+                if (apiResponse.upcoming_bookings && apiResponse.upcoming_bookings.total_pages > 1) {
+                    upcomingBookingsContainer.classList.add('scrollable-when-paginated');
+                } else {
+                    upcomingBookingsContainer.classList.remove('scrollable-when-paginated');
+                }
+            }
+            if (pastBookingsContainer) {
+                if (apiResponse.past_bookings && apiResponse.past_bookings.total_pages > 1) {
+                    pastBookingsContainer.classList.add('scrollable-when-paginated');
+                } else {
+                    pastBookingsContainer.classList.remove('scrollable-when-paginated');
+                }
+            }
+
             upcomingBookingsContainer.innerHTML = '';
             pastBookingsContainer.innerHTML = '';
 

--- a/static/js/resource_management.js
+++ b/static/js/resource_management.js
@@ -90,6 +90,15 @@ document.addEventListener('DOMContentLoaded', function() {
             const resourcesToShow = data.resources;
             const paginationData = data.pagination;
 
+            const tableWrapper = document.querySelector('.admin-table-scroll-wrapper');
+            if (tableWrapper) {
+                if (paginationData && paginationData.total_pages > 1) {
+                    tableWrapper.classList.add('scrollable-when-paginated');
+                } else {
+                    tableWrapper.classList.remove('scrollable-when-paginated');
+                }
+            }
+
             const mapsById = {}; // Populate this if needed for grouping, or fetch maps separately
             // If maps are needed for display and not fetched globally, fetch them here or pass from a global store.
             // For simplicity, assuming map name isn't displayed in the resource row directly or is part of resource_to_dict if needed.

--- a/static/js/user_management.js
+++ b/static/js/user_management.js
@@ -103,6 +103,16 @@ document.addEventListener('DOMContentLoaded', function() {
             const data = await apiCall(`/api/admin/users?${params.toString()}`);
 
             localUsersCache = data.users || []; // Update cache with current page's users
+
+            const usersTable = document.getElementById('users-table');
+            const tableWrapper = usersTable ? usersTable.closest('.responsive-table-container') : null;
+            if (tableWrapper) {
+                if (data.pagination && data.pagination.total_pages > 1) {
+                    tableWrapper.classList.add('scrollable-when-paginated');
+                } else {
+                    tableWrapper.classList.remove('scrollable-when-paginated');
+                }
+            }
             
             usersTableBody.innerHTML = ''; // Clear existing rows
             if (data.users && data.users.length > 0) {

--- a/static/style.css
+++ b/static/style.css
@@ -1539,14 +1539,21 @@ a.fc-daygrid-event.fc-event {
     display: inline-flex;
 }
 
-/* Scrollable Admin Table Containers & My Bookings Sections */
-.admin-table-scroll-wrapper,       /* Resource Management */
-div.responsive-table-container,   /* User Management & Admin Bookings */
-#upcoming-bookings-container,      /* My Bookings */
-#past-bookings-container {          /* My Bookings */
-    max-height: 500px;
+/* Styling for Admin Table Containers & My Bookings Sections Wrappers */
+.admin-table-scroll-wrapper,
+div.responsive-table-container,
+#upcoming-bookings-container,
+#past-bookings-container {
+    margin-bottom: 1rem; /* Retain if needed, or remove if scrollable class handles it */
+    /* Other general styles for these wrappers, if any, can remain */
+}
+
+/* Class to make content scrollable when pagination is active (more than 1 page) */
+.scrollable-when-paginated {
+    max-height: 500px; /* Standard height for scrollable content */
     overflow-y: auto;
-    margin-bottom: 1rem;
+    /* If margin-bottom was tied to scrollability, move it here */
+    /* margin-bottom: 1rem; */
 }
 
 /* Ensure tables within specific admin scrollable wrappers behave correctly */

--- a/templates/admin_bookings.html
+++ b/templates/admin_bookings.html
@@ -30,7 +30,7 @@
     </form>
 
     {% if bookings %}
-    <div class="table-responsive">
+    <div class="table-responsive {% if bookings_page_obj and bookings_page_obj.pages > 1 %}scrollable-when-paginated{% endif %}">
         <table id="admin-bookings-table" class="table bookings-table"> {# Added id #}
             <thead>
                 <tr>


### PR DESCRIPTION
This commit updates the styling for table and content containers on several admin and user-facing pages to only apply a vertical scrollbar when the content requires pagination (i.e., when there is more than one page of results).

Changes:

1.  **CSS (`static/style.css`):**
    *   I defined a new class `.scrollable-when-paginated` with
      `max-height: 500px;` and `overflow-y: auto;`.
    *   I removed these scroll-specific properties from the general
      wrapper classes/IDs (`.admin-table-scroll-wrapper`,
      `div.responsive-table-container`, `#upcoming-bookings-container`,
      `#past-bookings-container`). These wrappers now primarily handle
      layout aspects like `margin-bottom`.

2.  **Admin Booking Records (`templates/admin_bookings.html`):**
    *   The `div.table-responsive` wrapper now conditionally includes
      the `scrollable-when-paginated` class based on whether
      `bookings_page_obj.pages > 1` (server-side Jinja logic).

3.  **Admin Resources (`static/js/resource_management.js`):**
    *   The `fetchAndDisplayResources` function now dynamically adds or
      removes the `scrollable-when-paginated` class from the
      `.admin-table-scroll-wrapper` based on `paginationData.total_pages > 1`
      received from the API.

4.  **Admin Users (`static/js/user_management.js`):**
    *   The `fetchAndDisplayUsers` function now dynamically adds or
      removes the `scrollable-when-paginated` class from the
      `div.responsive-table-container` based on `paginationData.total_pages > 1`.

5.  **My Bookings (`static/js/my_bookings.js`):**
    *   The `fetchAndDisplayBookings` function now dynamically adds or
      removes the `scrollable-when-paginated` class independently
      to `#upcoming-bookings-container` and `#past-bookings-container`
      based on their respective `total_pages` count from the API response.

This ensures a consistent user experience where content areas become scrollable only when necessary due to pagination, rather than just their absolute height.