### PR TITLE
Okay, I've made a change to ensure the dynamic map opacity correctly …

### DIFF
--- a/static/js/new_booking_map.js
+++ b/static/js/new_booking_map.js
@@ -395,7 +395,7 @@ document.addEventListener('DOMContentLoaded', function () {
                         // Apply translucent background color
                         const rgbString = colorMap[finalClass];
                         if (rgbString) {
-                            areaDiv.style.backgroundColor = `rgba(${rgbString}, ${mapResourceOpacity})`;
+                            areaDiv.style.setProperty('background-color', `rgba(${rgbString}, ${mapResourceOpacity})`, 'important');
                         }
 
                         areaDiv.title = finalTitle;


### PR DESCRIPTION
…overrides the stylesheet.

I modified `static/js/new_booking_map.js` to use `element.style.setProperty('background-color', ..., 'important')` when applying the RGBA background color to resource areas on the map.

This ensures that the dynamically calculated translucent background color, which includes the opacity set by the `MAP_RESOURCE_OPACITY` environment variable (or its default), correctly overrides any `background-color` rules from the stylesheets, even if those rules use `!important`. This addresses the issue where opacity was set in the inline style but not visually rendering due to CSS override.