### PR TITLE
I've made a fix to ensure the `MAP_RESOURCE_OPACITY` environment vari…

### DIFF
--- a/templates/map_view.html
+++ b/templates/map_view.html
@@ -109,12 +109,12 @@
         font-weight: bold;
     }
 </style>
+<script>
+  window.MAP_RESOURCE_OPACITY = {{ config.MAP_RESOURCE_OPACITY|tojson }};
+</script>
 {% endblock %}
 
 {% block content %}
-<script>
-  window.MAP_RESOURCE_OPACITY = {{ map_resource_opacity|tojson|safe }};
-</script>
     <h1 id="map-view-title">{{ _('Map View') }}</h1>
     <div>
         <label for="map-availability-date">{{ _('View Availability for Date:') }}</label>


### PR DESCRIPTION
…able correctly controls map resource opacity.

Previously, the `MAP_RESOURCE_OPACITY` environment variable wasn't being properly passed to the frontend JavaScript code. This meant the map resource opacity defaulted to 0.7, no matter what value you set for the environment variable.

Here's how I addressed the issue:

1.  I added a script tag in `templates/map_view.html`. This tag defines `window.MAP_RESOURCE_OPACITY` using the `config.MAP_RESOURCE_OPACITY` value from the backend configuration.
2.  I removed a redundant script tag that was also trying to set `window.MAP_RESOURCE_OPACITY`, which could have caused conflicts.

Now, the opacity value you set in the environment variable will be correctly used by the map view.