### PR TITLE
Style: Make map area text bold and add text shadow

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1423,6 +1423,8 @@ a.fc-daygrid-event.fc-event {
     font-size: 0.8em;
     border-width: 2px;
     border-style: solid;
+    font-weight: bold;
+    text-shadow: 0 0 8px rgba(0, 0, 0, 0.5);
 }
 
 #new-booking-map-container .resource-area.map-area-green {


### PR DESCRIPTION
This change updates the .resource-area class in static/style.css:
- Sets font-weight to bold.
- Adds a text-shadow (0 0 8px rgba(0, 0, 0, 0.5)) to improve text legibility and make it stand out against various map area backgrounds.