### PR TITLE
Fix: Correct NameError in get_my_bookings API endpoint

### DIFF
--- a/routes/api_bookings.py
+++ b/routes/api_bookings.py
@@ -359,10 +359,9 @@ def get_my_bookings():
             }
 
             if booking_start_time_aware >= now_utc:
-                upcoming_bookings_data.append(booking_dict)
                 all_upcoming_bookings_dicts.append(booking_dict)
             else:
-                past_bookings_data.append(booking_dict)
+                all_past_bookings_dicts.append(booking_dict)
 
         # Sort before pagination
         all_upcoming_bookings_dicts.sort(key=lambda b: b['start_time'])


### PR DESCRIPTION
- Resolved a `NameError` in `routes/api_bookings.py` within the `get_my_bookings` function.
- Changed `upcoming_bookings_data.append(booking_dict)` to `all_upcoming_bookings_dicts.append(booking_dict)`.
- Changed `past_bookings_data.append(booking_dict)` to `all_past_bookings_dicts.append(booking_dict)`.
- This fixes the 500 Internal Server Error that occurred when fetching your bookings.

Investigated the console message "Login form with id 'login-form' not found on this page" in `static/js/script.js`. Determined it to be an informational log and not a functional error, so no changes were made for it.