### PR TITLE
Fix: Add missing pagination HTML to My Bookings page

### DIFF
--- a/templates/my_bookings.html
+++ b/templates/my_bookings.html
@@ -64,6 +64,17 @@
                 <!-- Upcoming bookings will be loaded here by JavaScript -->
                 <p class="loading-message">{{ _('Loading upcoming bookings...') }}</p>
             </div>
+            <!-- Upcoming Bookings Pagination Controls -->
+            <div id="upcoming_bk_pg_pagination_controls_container" class="d-flex justify-content-between align-items-center mt-3" style="display: none;">
+                <div>
+                    <label for="upcoming_bk_pg_per_page_select" class="form-label me-2">{{ _('Items per page:') }}</label>
+                    <select id="upcoming_bk_pg_per_page_select" class="form-select form-select-sm d-inline-block" style="width: auto;"></select>
+                </div>
+                <ul id="upcoming_bk_pg_pagination_ul" class="pagination pagination-sm my-0">
+                    <!-- Pagination links will be added by JavaScript -->
+                </ul>
+                <span id="upcoming_bk_pg_total_results_display" class="total-results-display"></span>
+            </div>
         </div>
 
         <hr class="my-4"> <!-- Optional separator -->
@@ -77,6 +88,17 @@
             <div id="past-bookings-container">
                 <!-- Past bookings will be loaded here by JavaScript -->
                 <p class="loading-message">{{ _('Loading past bookings...') }}</p>
+            </div>
+            <!-- Past Bookings Pagination Controls -->
+            <div id="past_bk_pg_pagination_controls_container" class="d-flex justify-content-between align-items-center mt-3" style="display: none;">
+                <div>
+                    <label for="past_bk_pg_per_page_select" class="form-label me-2">{{ _('Items per page:') }}</label>
+                    <select id="past_bk_pg_per_page_select" class="form-select form-select-sm d-inline-block" style="width: auto;"></select>
+                </div>
+                <ul id="past_bk_pg_pagination_ul" class="pagination pagination-sm my-0">
+                    <!-- Pagination links will be added by JavaScript -->
+                </ul>
+                <span id="past_bk_pg_total_results_display" class="total-results-display"></span>
             </div>
         </div>
     </div>


### PR DESCRIPTION
This commit resolves JavaScript errors on the 'My Bookings' page that were caused by missing HTML elements for pagination controls.

The following issues were observed:
- `my_bookings.js` logged warnings like "Pagination elements for prefix upcoming_bk_pg_ not found."
- Subsequent JavaScript errors such as "Cannot read properties of null (reading 'classList')" occurred when trying to manipulate these non-existent elements.

The fix involves:
- Adding the necessary HTML structure (containers, select dropdowns for items per page, unordered lists for page numbers, and spans for total results) to `templates/my_bookings.html` for both the "Upcoming Bookings" and "Past Bookings" sections.
- The IDs of these new HTML elements (`upcoming_bk_pg_pagination_controls_container`, `upcoming_bk_pg_per_page_select`, etc., and their `past_bk_pg_` counterparts) exactly match those expected by the JavaScript in `static/js/my_bookings.js`.

With these changes, the JavaScript should now correctly find and operate the pagination controls, eliminating the console warnings and errors.