### PR TITLE
Debug: Add route listing to app_factory

### DIFF
--- a/app_factory.py
+++ b/app_factory.py
@@ -418,4 +418,13 @@ def create_app(config_object=config):
 
     app.logger.info("Flask app created and configured via factory.")
 
+    if not app.testing: # Avoid printing during tests
+        app.logger.info("--- Registered URL Rules ---")
+        output_lines = []
+        for rule in app.url_map.iter_rules():
+            output_lines.append(f"Endpoint: {rule.endpoint}, Methods: {','.join(rule.methods)}, Path: {str(rule)}")
+        # Log as a single multi-line entry if possible, or loop
+        app.logger.info("\n".join(output_lines))
+        app.logger.info("--- End of Registered URL Rules ---")
+
     return app


### PR DESCRIPTION
I've modified app_factory.py to log all registered URL rules during application startup. This will help me diagnose a persistent 404 error related to booking API routes.