### PR TITLE
Fix: Resolve AttributeError in booking API and remove debug code

### DIFF
--- a/app_factory.py
+++ b/app_factory.py
@@ -418,13 +418,4 @@ def create_app(config_object=config):
 
     app.logger.info("Flask app created and configured via factory.")
 
-    if not app.testing: # Avoid printing during tests
-        app.logger.info("--- Registered URL Rules ---")
-        output_lines = []
-        for rule in app.url_map.iter_rules():
-            output_lines.append(f"Endpoint: {rule.endpoint}, Methods: {','.join(rule.methods)}, Path: {str(rule)}")
-        # Log as a single multi-line entry if possible, or loop
-        app.logger.info("\n".join(output_lines))
-        app.logger.info("--- End of Registered URL Rules ---")
-
     return app

--- a/routes/api_bookings.py
+++ b/routes/api_bookings.py
@@ -87,7 +87,9 @@ def _fetch_user_bookings_data(user_name, booking_type, page, per_page, status_fi
                 if token_expires_at_aware and token_expires_at_aware > now_utc and booking_end_time_aware > now_utc:
                     display_check_in_token = booking.check_in_token
 
-            pin_required_for_resource = resource.pin_required_for_check_in if resource else False
+            pin_required_for_resource = False # Defaulting as the attribute doesn't exist on Resource model
+            # TODO: Revisit logic for determining if a resource generally requires a PIN for check-in,
+            # potentially by checking active ResourcePIN entries or a new field on Resource model.
             pin_set_for_booking = booking.pin is not None and booking.pin != ""
 
 


### PR DESCRIPTION
- I fixed an AttributeError in `routes/api_bookings.py` within the `_fetch_user_bookings_data` function. The code was attempting to access a non-existent attribute `pin_required_for_check_in` on the `Resource` model. I've changed this to default the associated variable (`pin_required_for_resource`) to `False` to prevent the 500 Internal Server Error. I also added a TODO comment to revisit this logic if more nuanced behavior is required.

- I removed the diagnostic code from `app_factory.py` that was previously added to log all registered URL rules. This is no longer needed as the primary error has been identified and addressed.