### PR TITLE
Fix: Align text baselines in My Bookings pagination controls

### DIFF
--- a/templates/my_bookings.html
+++ b/templates/my_bookings.html
@@ -65,7 +65,7 @@
                 <p class="loading-message">{{ _('Loading upcoming bookings...') }}</p>
             </div>
             <div class="pagination-controls-wrapper mt-3" id="upcoming_bk_pg_pagination_controls_container" style="display: none;">
-                <div class="d-flex justify-content-start align-items-center flex-wrap">
+                <div class="d-flex justify-content-start align-items-baseline flex-wrap">
                     <div>
                         <label for="upcoming_bk_pg_per_page_select" class="form-label me-2">{{ _('Per Page:') }}</label>
                         <select id="upcoming_bk_pg_per_page_select" class="form-select form-select-sm d-inline-block" style="width: auto;"></select>
@@ -94,7 +94,7 @@
                 <p class="loading-message">{{ _('Loading past bookings...') }}</p>
             </div>
             <div class="pagination-controls-wrapper mt-3" id="past_bk_pg_pagination_controls_container" style="display: none;">
-                <div class="d-flex justify-content-start align-items-center flex-wrap">
+                <div class="d-flex justify-content-start align-items-baseline flex-wrap">
                     <div>
                         <label for="past_bk_pg_per_page_select" class="form-label me-2">{{ _('Per Page:') }}</label>
                         <select id="past_bk_pg_per_page_select" class="form-select form-select-sm d-inline-block" style="width: auto;"></select>


### PR DESCRIPTION
Replaces 'align-items-center' with 'align-items-baseline' for the flex container of the pagination controls on the "My Bookings" page.

This change aims to ensure that the text content of the "Per Page" label, the dropdown, the "Previous" link, the bracketed page numbers "[1, ..., n]", the "Next" link, and the total results display are all visually aligned along the same horizontal text baseline.