### PR TITLE
Refactor: Unify My Bookings pagination into a single UL structure

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1609,3 +1609,69 @@ div.responsive-table-container > table#admin-bookings-table { /* Admin Bookings 
     text-decoration: underline;
 }
 */
+
+/* --- New Pagination Styling Adjustments --- */
+
+/* 1. Disable Padding for Page Numbers Span per user request */
+/*    Overriding the previous .page-item .page-link.page-numbers-span-container rule's padding. */
+.page-link.page-numbers-span-container {
+    padding: 0 !important;
+    line-height: normal; /* Reset line-height if it was affected by .page-link defaults */
+    /* Note: Vertical alignment will primarily be handled by align-items-baseline on the parent UL.
+       If this causes issues, further targeted adjustments for this span might be needed. */
+}
+
+/* 2. Style for Non-Interactive li.page-item Elements */
+/* For the "Per Page" LI (assumed to be the first child LI in the pagination UL) */
+ul.pagination > li.page-item:first-child {
+    border: 1px solid transparent; /* Remove default page-item border if any from Bootstrap */
+    background-color: transparent !important;
+    cursor: default;
+    padding-top: 0.1rem; /* Minor adjustment for baseline if needed */
+    padding-bottom: 0.1rem; /* Minor adjustment for baseline if needed */
+}
+ul.pagination > li.page-item:first-child:hover {
+    background-color: transparent !important;
+    border-color: transparent !important;
+}
+/* The span wrapper inside the "Per Page" LI */
+ul.pagination > li.page-item:first-child > span {
+    padding: 0.375rem 0.25rem; /* Provide some padding for height, less horizontal than typical page-link */
+                               /* Adjust as needed for vertical alignment with other items */
+}
+
+
+/* For the "Total Results" LI (assumed to be the last child LI with ms-auto) */
+ul.pagination > li.page-item.ms-auto {
+    border: 1px solid transparent; /* Remove default page-item border if any */
+    background-color: transparent !important;
+    cursor: default;
+}
+ul.pagination > li.page-item.ms-auto:hover {
+    background-color: transparent !important;
+    border-color: transparent !important;
+}
+/* The div inside "Total Results" LI already has p-2 from JS, which provides padding.
+   If its baseline needs adjustment, it can be targeted: */
+ul.pagination > li.page-item.ms-auto > div[id$="_total_results_display"] {
+   /* Example: padding-bottom: 0.1rem; to slightly shift baseline */
+}
+
+/* 4. Overall Vertical Alignment:
+   ul.pagination already has align-items-baseline.
+   The form-select-sm inside the "Per Page" li might need slight adjustment
+   if its baseline doesn't match perfectly with surrounding text/links.
+*/
+ul.pagination select.form-select-sm {
+    /* Example of a potential adjustment if select baseline is off: */
+    /* vertical-align: baseline; /* Might not work directly on select, often needs wrapper */
+    /* margin-bottom: -2px; /* Small nudge, highly dependent on font/bootstrap version */
+}
+
+/* Ensure all direct children LIs of the pagination UL are baseline aligned correctly as flex items */
+ul.pagination.align-items-baseline > li.page-item {
+    /* No specific override needed here usually, as align-items-baseline on UL should handle it.
+       However, if some LIs have different internal box structures, this can be a place for tweaks.
+       For example, ensuring they all have a consistent top/bottom reference.
+    */
+}

--- a/templates/my_bookings.html
+++ b/templates/my_bookings.html
@@ -65,19 +65,9 @@
                 <p class="loading-message">{{ _('Loading upcoming bookings...') }}</p>
             </div>
             <div class="pagination-controls-wrapper mt-3" id="upcoming_bk_pg_pagination_controls_container" style="display: none;">
-                <div class="d-flex justify-content-start align-items-baseline flex-wrap">
-                    <div>
-                        <label for="upcoming_bk_pg_per_page_select" class="form-label me-2">{{ _('Per Page:') }}</label>
-                        <select id="upcoming_bk_pg_per_page_select" class="form-select form-select-sm d-inline-block" style="width: auto;"></select>
-                    </div>
-                    <span class="me-3 pagination-controls-spacer"></span>
-                    <ul class="pagination pagination-sm mb-0" id="upcoming_bk_pg_pagination_ul">
-                        <!-- Pagination links will be built by JavaScript -->
-                    </ul>
-                    <div id="upcoming_bk_pg_total_results_display" class="text-muted ms-auto">
-                        <!-- Total results will be shown by JavaScript -->
-                    </div>
-                </div>
+                <ul class="pagination pagination-sm mb-0" id="upcoming_bk_pg_pagination_ul">
+                    <!-- Pagination links will be built by JavaScript -->
+                </ul>
             </div>
         </div>
 
@@ -94,19 +84,9 @@
                 <p class="loading-message">{{ _('Loading past bookings...') }}</p>
             </div>
             <div class="pagination-controls-wrapper mt-3" id="past_bk_pg_pagination_controls_container" style="display: none;">
-                <div class="d-flex justify-content-start align-items-baseline flex-wrap">
-                    <div>
-                        <label for="past_bk_pg_per_page_select" class="form-label me-2">{{ _('Per Page:') }}</label>
-                        <select id="past_bk_pg_per_page_select" class="form-select form-select-sm d-inline-block" style="width: auto;"></select>
-                    </div>
-                    <span class="me-3 pagination-controls-spacer"></span>
-                    <ul class="pagination pagination-sm mb-0" id="past_bk_pg_pagination_ul">
-                        <!-- Pagination links will be built by JavaScript -->
-                    </ul>
-                    <div id="past_bk_pg_total_results_display" class="text-muted ms-auto">
-                        <!-- Total results will be shown by JavaScript -->
-                    </div>
-                </div>
+                <ul class="pagination pagination-sm mb-0" id="past_bk_pg_pagination_ul">
+                    <!-- Pagination links will be built by JavaScript -->
+                </ul>
             </div>
         </div>
     </div>


### PR DESCRIPTION
I've overhauled the HTML structure and JavaScript rendering for pagination controls on your "My Bookings" page to meet specific layout requirements. All pagination elements, including "Per Page" controls and "Total Results", are now generated as list items (<li>) within the main <ul>.pagination.

Key Changes:

1.  **HTML (`templates/my_bookings.html`):**
    -   I simplified the static HTML for pagination controls. The
        `pagination-controls-wrapper` div now only contains an empty `<ul>`
        (e.g., `#upcoming_bk_pg_pagination_ul`). All content is
        dynamically generated by JavaScript.

2.  **JavaScript (`static/js/my_bookings.js`):**
    -   I significantly rewrote the `renderMyBookingsPaginationControls` function:
        -   It now constructs all pagination components ("Per Page" label/select,
            spacer, "Previous" link, bracketed page numbers `[1,...,n]`, "Next"
            link, and "Total Results" display) as `<li>` elements parented
            by the main `ul.pagination`.
        -   The `ul.pagination` itself is configured as a flex container
            (`d-flex flex-wrap align-items-baseline`) to manage the layout
            of its `li` children.
        -   The "Per Page" `select` element is dynamically created and
            initialized using an updated `initializeMyBookingsPerPageSelect`
            helper function, now correctly receiving the items-per-page setter.
        -   The "Total Results" `<li>` is styled with `ms-auto` to align it
            to the far right.
        -   I updated the function signature of `renderMyBookingsPaginationControls`
            to accept the `itemsPerPageVarSetter`.
        -   I updated calls to this function in `fetchUpcomingBookings` and
            `fetchPastBookings` accordingly.

3.  **CSS (`static/style.css`):**
    -   I removed padding from `.page-link.page-numbers-span-container`
        (which wraps the `[1,...,n]` numbers) as per your request.
    -   I added styles for the new `<li>` elements that wrap "Per Page"
        controls and "Total Results" to ensure they are non-interactive
        (no hover effects, transparent background/border, default cursor)
        and align correctly with other pagination items. Positional CSS
        selectors (`:first-child`, `.ms-auto`) were used for targeting.

This set of changes aims to achieve a single-line layout for all pagination controls, with text baselines aligned, and "Total Results" positioned to the rightmost, as per your detailed feedback.