### PR TITLE
Fix: Ensure 'Total Results' aligns to the right in pagination

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1675,3 +1675,8 @@ ul.pagination.align-items-baseline > li.page-item {
        For example, ensuring they all have a consistent top/bottom reference.
     */
 }
+
+/* Ensure ul.pagination spans full width for ms-auto to work on children */
+ul.pagination.d-flex {
+    width: 100%;
+}


### PR DESCRIPTION
Corrects the alignment of the 'Total Results' display within the pagination controls on your "My Bookings" page.

The issue was that the `ul.pagination` flex container was not spanning the full width of its parent, preventing `ms-auto` on the 'Total Results' list item from effectively pushing it to the far right.

This commit adds `width: 100%;` to the `ul.pagination.d-flex` CSS rule in `static/style.css` to resolve this.