### PR TITLE
Fix: Correct NameError in SQLite pragma setup in app_factory.py

### DIFF
--- a/app_factory.py
+++ b/app_factory.py
@@ -316,8 +316,9 @@ def create_app(config_object=config, testing=False): # Added testing parameter
         @app.before_request
         def ensure_sqlite_configured_wrapper():
            # Also check if not testing here, and URI starts with sqlite
-           if not current_app.config.get('TESTING', False) and \
-              current_app.config['SQLALCHEMY_DATABASE_URI'].startswith('sqlite'):
+           # Use 'app.config' from the closure instead of 'current_app.config'
+           if not app.config.get('TESTING', False) and \
+              app.config['SQLALCHEMY_DATABASE_URI'].startswith('sqlite'):
                _ensure_sqlite_configured_factory_hook(app, db)
 
     # 5. Register i18n


### PR DESCRIPTION
This commit resolves a NameError (current_app not defined) within the `ensure_sqlite_configured_wrapper` function in `app_factory.py`. This function is used as a `before_request` hook to configure SQLite pragmas.

The `current_app` proxy was incorrectly used at function definition time. The fix replaces `current_app.config` with `app.config`, utilizing the `app` instance available from the enclosing `create_app` function's scope via closure. This ensures your application configuration is accessed correctly when the conditions for applying SQLite pragmas are checked within the `before_request` handler.