### PR TITLE
Fix: Add Edit button to Upcoming Bookings

### DIFF
--- a/static/js/my_bookings.js
+++ b/static/js/my_bookings.js
@@ -196,6 +196,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
         const terminalStatuses = ['completed', 'cancelled', 'rejected', 'cancelled_by_admin', 'cancelled_admin_acknowledged'];
         if (!terminalStatuses.includes(booking.status)) {
+            // Add Edit button
+            const editButton = document.createElement('button');
+            editButton.textContent = 'Edit';
+            editButton.className = 'btn btn-sm btn-primary edit-title-btn me-1';
+            editButton.dataset.bookingId = booking.id;
+            actionsContainer.appendChild(editButton);
+
             if (checkInOutEnabled) {
                 if (booking.can_check_in && !booking.checked_in_at) {
                     const checkInBtn = document.createElement('button');
@@ -219,9 +226,9 @@ document.addEventListener('DOMContentLoaded', () => {
             cancelBtn.dataset.bookingId = booking.id;
             actionsContainer.appendChild(cancelBtn);
         }
-         // Edit title button (already in template, just ensure it has dataset.bookingId)
-        const editTitleBtn = bookingCardDiv.querySelector('.edit-title-btn');
-        if(editTitleBtn) editTitleBtn.dataset.bookingId = booking.id;
+        // The following lines are removed as the edit button is now conditionally added above.
+        // const editTitleBtn = bookingCardDiv.querySelector('.edit-title-btn');
+        // if(editTitleBtn) editTitleBtn.dataset.bookingId = booking.id;
 
 
         return bookingCardDiv;

--- a/templates/my_bookings.html
+++ b/templates/my_bookings.html
@@ -114,7 +114,6 @@
 
                 <!-- Existing buttons and check-in controls -->
                 <div class="booking-actions mt-2">
-                    <button class="btn btn-sm btn-primary update-booking-btn" data-booking-id="">{{ _('Update Booking') }}</button>
                     <button class="btn btn-sm btn-danger cancel-booking-btn" data-booking-id="">{{ _('Cancel Booking') }}</button>
                     <span class="check-in-controls" style="display:none;">
                         <input type="text" class="form-control form-control-sm d-inline-block booking-pin-input" style="width: 100px; margin-right: 5px; vertical-align: middle;" placeholder="{{ _('PIN') }}" data-booking-id="">


### PR DESCRIPTION
This commit addresses the issue where the 'Edit' button was missing for upcoming bookings on the 'My Bookings' page.

The `static/js/my_bookings.js` script has been updated to:
- Dynamically create and append an 'Edit' button to the actions area of each booking card that is not in a terminal status.
- The new button is styled as 'btn btn-sm btn-primary edit-title-btn me-1' and labeled 'Edit'.
- It correctly uses the 'edit-title-btn' class to trigger the existing modal for updating the booking title.

The `templates/my_bookings.html` file has been updated to:
- Remove a redundant static 'Update Booking' button from the `booking-item-template` as its functionality is now fully handled by the JavaScript, which dynamically clears and populates action buttons.

These changes ensure that you can now edit your upcoming bookings as intended.