### PR TITLE
feat: Disable unavailable dates in calendar

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -24,6 +24,24 @@
     font-size: 16px;
 }
 
+/* Calendar specific styles */
+.fc-unavailable-date {
+    background-color: #eeeeee !important; /* Light grey background */
+    color: #aaaaaa !important; /* Darker grey text */
+    pointer-events: none; /* Make it non-interactive */
+}
+
+/* Make unavailable date cells appear more "disabled" */
+.fc-unavailable-date .fc-daygrid-day-number {
+    color: #aaaaaa !important;
+}
+
+/* Ensure events on unavailable dates also look disabled or are less prominent if they can exist */
+/* This might be too aggressive if events *should* be visible but just the day is not selectable for new bookings */
+/* .fc-unavailable-date .fc-event {
+    opacity: 0.5;
+} */
+
 html {
     overflow: hidden;
     height: 100%;

--- a/templates/calendar.html
+++ b/templates/calendar.html
@@ -16,7 +16,7 @@
     </select>
 </div>
 
-<div id="calendar"></div>
+<div id="calendar" {% if current_user.is_authenticated %}data-user-id="{{ current_user.id }}"{% endif %}></div>
 
 <div id="calendar-edit-booking-modal" class="modal" style="display:none;" role="dialog" aria-modal="true" aria-labelledby="cebm-title">
     <div class="modal-content">


### PR DESCRIPTION
Implements functionality to disable dates on the booking calendar that are not available to you.

Key changes:

- Added a new API endpoint `/api/resources/unavailable_dates` which returns a list of 'YYYY-MM-DD' formatted dates that are unavailable for a given user. This considers:
    - Past dates based on `BookingSettings.allow_past_bookings` and `BookingSettings.past_booking_time_adjustment_hours`.
    - Dates where all published resources are fully booked (any booking on that day) or under maintenance.
    - Dates where the querying user already has bookings.
- Modified `static/js/calendar.js`:
    - Fetches unavailable dates from the new endpoint using your ID.
    - Uses FullCalendar's `selectAllow` option to prevent selection of these unavailable dates.
    - Uses FullCalendar's `dayCellDidMount` option to add a CSS class (`fc-unavailable-date`) to visually mark these dates.
- Added CSS styles in `static/style.css` for `.fc-unavailable-date` to make them appear grayed out and non-interactive.
- Updated `templates/calendar.html` to pass your `id` to the JavaScript via a `data-user-id` attribute on the calendar element.
- Added a comprehensive suite of backend unit tests for the new API endpoint, covering various scenarios including authentication, past date logic, resource availability, and user-specific bookings.

This addresses the issue of allowing you to only select dates where resources are available and your own time is not already utilized.