### PR TITLE
fix: Disable unavailable location/floor buttons

### DIFF
--- a/static/js/new_booking_map.js
+++ b/static/js/new_booking_map.js
@@ -242,6 +242,12 @@ document.addEventListener('DOMContentLoaded', function () {
                     button.classList.add('selected-map-button'); // Or reuse 'selected-location-button'
                 }
 
+                // Disable button if it's marked as unavailable
+                // This check is after all class assignments and title settings.
+                if (button.classList.contains('location-button-unavailable')) {
+                    button.disabled = true;
+                }
+
                 button.addEventListener('click', function() {
                     selectedMapId = mapInfo.id;
                     currentMapId = mapInfo.id; // Sync currentMapId as well


### PR DESCRIPTION
This commit updates the Resource Availability page to disable location/floor selection buttons that are marked as unavailable (typically styled in red).

-   In `static/js/new_booking_map.js`, within the `updateLocationFloorButtons` function, buttons that receive the `location-button-unavailable` class (due to low availability or missing data) now also have their `disabled` property set to `true`.
-   This prevents you from clicking on locations/floors that cannot be selected, improving the user experience.
-   The informational tooltip (title attribute) on these buttons remains functional to explain the reason for unavailability.