### PR TITLE
Fix: Correct Jinja2 TemplateSyntaxError in edit_profile.html

### DIFF
--- a/templates/edit_profile.html
+++ b/templates/edit_profile.html
@@ -150,10 +150,3 @@
     });
 </script>
 {% endblock %}
-                    msg.className = 'error';
-                }
-            });
-        }
-    });
-</script>
-{% endblock %}


### PR DESCRIPTION
- I removed duplicated JavaScript code and an erroneous `{% endblock %}` tag from the end of `templates/edit_profile.html`.
- This error was introduced during a previous refactoring and caused a 500 server error when rendering the page.