### PR TITLE
Refactor: Improve email sending logs for clarity

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -323,6 +323,7 @@ def send_email(to_address: str, subject: str, body: str = None, html_body: str =
 
     if not mail.app:
         logger.warning("Flask-Mail not available or not initialized with app. Email not sent via external server.")
+        logger.info(f"Email intent: To='{to_address}', Subject='{subject}'. This email was NOT sent via SMTP due to missing Flask-Mail configuration.")
         if attachment_path and tempfile.gettempdir() in os.path.normpath(os.path.abspath(attachment_path)):
             try:
                 os.remove(attachment_path)


### PR DESCRIPTION
- I enhanced the `send_email` utility function in `utils.py`.
- When Flask-Mail is not configured, I now add a specific informational log, detailing the recipient and subject of the email that was intended to be sent but could not be dispatched via SMTP.
- This provides clearer console feedback on email sending status, complementing the existing warning about Flask-Mail unavailability and the success/failure logs for actual SMTP dispatch.