### PR TITLE
Here's a debugging update regarding the Flask-Mail initialization:

### DIFF
--- a/app_factory.py
+++ b/app_factory.py
@@ -137,8 +137,11 @@ def create_app(config_object=config, testing=False): # Added testing parameter
     # but messages sent to it should be buffered or handled once logging is set up.
     # For immediate critical output if needed, standard print() or logging.warning() could be used
     # before app.logger is reliably configured. However, standard practice is to use app.logger.
-    app.logger.warning("APP_FACTORY: create_app function entered.")
-    app.logger.warning(f"APP_FACTORY: Initial mail object ID in create_app: {id(mail)}")
+    # app.logger.warning("APP_FACTORY: create_app function entered.") # Removed
+    # app.logger.warning(f"APP_FACTORY: Initial mail object ID in create_app: {id(mail)}") # Removed
+    print("PRINT_DEBUG: APP_FACTORY - create_app function entered.", flush=True)
+    # from extensions import mail # mail is already imported at the top level
+    print(f"PRINT_DEBUG: APP_FACTORY - Initial mail object ID in create_app: {id(mail)}", flush=True)
 
     # 1. Load Configuration
     app.config.from_object(config_object)
@@ -317,11 +320,15 @@ def create_app(config_object=config, testing=False): # Added testing parameter
 
     # 3. Initialize Extensions
     # db.init_app(app) has been moved to earlier in the factory function
-    app.logger.warning("APP_FACTORY: Attempting mail.init_app(app)")
-    app.logger.warning(f"APP_FACTORY: Mail object ID before init: {id(mail)}")
+    # app.logger.warning("APP_FACTORY: Attempting mail.init_app(app)") # Removed
+    # app.logger.warning(f"APP_FACTORY: Mail object ID before init: {id(mail)}") # Removed
+    print(f"PRINT_DEBUG: APP_FACTORY - Attempting mail.init_app(app). App object: {app}", flush=True)
+    print(f"PRINT_DEBUG: APP_FACTORY - Mail object ID before init: {id(mail)}", flush=True)
     mail.init_app(app)
-    app.logger.warning(f"APP_FACTORY: Mail object ID after init: {id(mail)}")
-    app.logger.warning(f"APP_FACTORY: mail.app state after init: {mail.app}")
+    # app.logger.warning(f"APP_FACTORY: Mail object ID after init: {id(mail)}") # Removed
+    # app.logger.warning(f"APP_FACTORY: mail.app state after init: {mail.app}") # Removed
+    print(f"PRINT_DEBUG: APP_FACTORY - Mail object ID after init: {id(mail)}", flush=True)
+    print(f"PRINT_DEBUG: APP_FACTORY - mail.app state after init: {mail.app}", flush=True)
     csrf.init_app(app)
     socketio.init_app(app, message_queue=app.config.get('SOCKETIO_MESSAGE_QUEUE')) # Add message_queue from config
     migrate.init_app(app, db)


### PR DESCRIPTION
- I've replaced the `app.logger.warning` messages in `app_factory.py` concerning mail initialization with direct `print(..., flush=True)` statements.
- This change ensures that diagnostic messages will appear in your console, irrespective of the logger configuration. This should help you trace any issues if `mail.init_app()` isn't working as expected.
- The diagnostic log within `utils.send_email` will continue to use `logger.warning`.