### PR TITLE
Fix factory test email context

### DIFF
--- a/app_factory.py
+++ b/app_factory.py
@@ -341,16 +341,17 @@ def create_app(config_object=config, testing=False): # Added testing parameter
     app.logger.error(f"ERROR_DIAG: APP_FACTORY - Test email check: mail.state: {mail_state_for_test}, mail.state.app: {app_from_state_for_test}") # New log
 
     app.logger.info("Attempting to send test email from app_factory.py...")
-    try:
-        # from flask_mail import Message # Ensure Message is imported (already added at top)
-        msg = Message("Test Email from App Factory",
-                      sender=app.config.get('MAIL_DEFAULT_SENDER', 'default_sender@example.com'), # Added a fallback for sender
-                      recipients=["debug@example.com"]) # Use a dummy recipient
-        msg.body = "This is a test email sent from app_factory.py after mail.init_app()."
-        mail.send(msg)
-        app.logger.info("Test email from factory sent successfully.")
-    except Exception as e_factory_mail:
-        app.logger.error(f"Test email from factory FAILED. Error: {e_factory_mail}", exc_info=True)
+    with app.app_context():
+        try:
+            # from flask_mail import Message # Ensure Message is imported (already added at top)
+            msg = Message("Test Email from App Factory",
+                          sender=app.config.get('MAIL_DEFAULT_SENDER', 'default_sender@example.com'), # Added a fallback for sender
+                          recipients=["debug@example.com"]) # Use a dummy recipient
+            msg.body = "This is a test email sent from app_factory.py after mail.init_app()."
+            mail.send(msg)
+            app.logger.info("Test email from factory sent successfully.")
+        except Exception as e_factory_mail:
+            app.logger.error(f"Test email from factory FAILED. Error: {e_factory_mail}", exc_info=True)
 
     csrf.init_app(app)
     socketio.init_app(app, message_queue=app.config.get('SOCKETIO_MESSAGE_QUEUE')) # Add message_queue from config


### PR DESCRIPTION
Ensures the test email sent from `app_factory.py` during startup operates within an explicit Flask application context. This resolves a `RuntimeError: Working outside of application context` that occurred when `mail.send()` was called.

The `try...except` block for sending the test email is now wrapped with `with app.app_context():`.