### PR TITLE
Switch to Gmail API for emails and remove Flask-Mail

### DIFF
--- a/app_factory.py
+++ b/app_factory.py
@@ -5,8 +5,8 @@ import logging
 
 # Import configurations, extensions, and initialization functions
 import config
-from extensions import db, login_manager, oauth, mail, csrf, socketio, migrate
-from flask_mail import Message # Added for test email
+from extensions import db, login_manager, oauth, csrf, socketio, migrate # Removed mail
+# from flask_mail import Message # Removed: Added for test email - no longer needed by factory
 from models import User # Needed for load_user, others loaded via db object
 
 from translations import init_translations # SimpleTranslator is used internally by init_translations now
@@ -140,8 +140,8 @@ def create_app(config_object=config, testing=False): # Added testing parameter
     # For immediate critical output if needed, standard print() or logging.warning() could be used
     # before app.logger is reliably configured. However, standard practice is to use app.logger.
     app.logger.error("ERROR_DIAG: APP_FACTORY - create_app function entered.")
-    # from extensions import mail # mail is already imported at the top level
-    app.logger.error(f"ERROR_DIAG: APP_FACTORY - Initial mail object ID in create_app: {id(mail)}")
+    # from extensions import mail # mail has been removed from imports
+    # app.logger.error(f"ERROR_DIAG: APP_FACTORY - Initial mail object ID in create_app: {id(mail)}") # mail removed
 
     # 1. Load Configuration
     app.config.from_object(config_object)
@@ -320,26 +320,13 @@ def create_app(config_object=config, testing=False): # Added testing parameter
 
     # 3. Initialize Extensions
     # db.init_app(app) has been moved to earlier in the factory function
-    app.logger.error(f"ERROR_DIAG: APP_FACTORY - Config MAIL_SERVER: {app.config.get('MAIL_SERVER')}")
-    app.logger.error(f"ERROR_DIAG: APP_FACTORY - Config MAIL_PORT: {app.config.get('MAIL_PORT')}")
-    app.logger.error(f"ERROR_DIAG: APP_FACTORY - Config MAIL_USE_TLS: {app.config.get('MAIL_USE_TLS')}")
-    app.logger.error(f"ERROR_DIAG: APP_FACTORY - Config MAIL_USE_SSL: {app.config.get('MAIL_USE_SSL')}")
-    app.logger.error(f"ERROR_DIAG: APP_FACTORY - Config MAIL_USERNAME: {'<present>' if app.config.get('MAIL_USERNAME') else '<not present>'}")
-    app.logger.error(f"ERROR_DIAG: APP_FACTORY - Config MAIL_PASSWORD: {'<present>' if app.config.get('MAIL_PASSWORD') else '<not present>'}") # Added password presence check
-    app.logger.error(f"ERROR_DIAG: APP_FACTORY - Config MAIL_DEFAULT_SENDER: {app.config.get('MAIL_DEFAULT_SENDER')}")
-    app.logger.error(f"ERROR_DIAG: APP_FACTORY - app.extensions before mail.init_app: {list(app.extensions.keys())}")
-    app.logger.error(f"ERROR_DIAG: APP_FACTORY - Attempting mail.init_app(app). App object: {app}")
-    app.logger.error(f"ERROR_DIAG: APP_FACTORY - Mail object ID before init: {id(mail)}")
-    mail.init_app(app)
-    app.logger.error(f"ERROR_DIAG: APP_FACTORY - Mail object ID after init: {id(mail)}")
-    app.logger.error(f"ERROR_DIAG: APP_FACTORY - app.extensions after mail.init_app: {list(app.extensions.keys())}")
-    app.logger.error(f"ERROR_DIAG: APP_FACTORY - app.extensions.get('mail') object after init: {app.extensions.get('mail')}")
-    app.logger.error(f"ERROR_DIAG: APP_FACTORY - mail.state.app after init: {mail.state.app if hasattr(mail, 'state') and mail.state and hasattr(mail.state, 'app') else 'mail.state.app is None or mail.state is None'}")
+    # Removed Flask-Mail related diagnostic logs and mail.init_app(app)
+    # mail.init_app(app) # Removed
 
-    # Test email sending block
-    mail_state_for_test = getattr(mail, 'state', None)
-    app_from_state_for_test = getattr(mail_state_for_test, 'app', None)
-    app.logger.error(f"ERROR_DIAG: APP_FACTORY - Test email check: mail.state: {mail_state_for_test}, mail.state.app: {app_from_state_for_test}") # New log
+    # Test email sending block - mail object and its state are no longer relevant here
+    # mail_state_for_test = getattr(mail, 'state', None) # mail removed
+    # app_from_state_for_test = getattr(mail_state_for_test, 'app', None) # mail removed
+    # app.logger.error(f"ERROR_DIAG: APP_FACTORY - Test email check: mail.state: {mail_state_for_test}, mail.state.app: {app_from_state_for_test}") # mail removed
 
     app.logger.info("Attempting to send test email from app_factory.py...")
     with app.app_context():

--- a/extensions.py
+++ b/extensions.py
@@ -1,7 +1,7 @@
 from flask_sqlalchemy import SQLAlchemy
 from flask_login import LoginManager
 from authlib.integrations.flask_client import OAuth
-from flask_mail import Mail
+# from flask_mail import Mail # Removed
 from flask_wtf.csrf import CSRFProtect
 from flask_socketio import SocketIO
 from flask_migrate import Migrate
@@ -9,7 +9,7 @@ from flask_migrate import Migrate
 db = SQLAlchemy()
 login_manager = LoginManager()
 oauth = OAuth()
-mail = Mail()
+# mail = Mail() # Removed
 csrf = CSRFProtect()
 socketio = SocketIO()
 migrate = Migrate()

--- a/routes/api_bookings.py
+++ b/routes/api_bookings.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta, timezone, time
 
 # Local imports
 # Assuming extensions.py contains db, socketio, mail
-from extensions import db, socketio, mail
+from extensions import db, socketio # Removed mail
 # Assuming models.py contains these model definitions
 from models import Booking, Resource, User, WaitlistEntry, BookingSettings, ResourcePIN, FloorMap # Added ResourcePIN & FloorMap
 # Assuming utils.py contains these helper functions
@@ -1012,25 +1012,25 @@ def update_booking_by_user(booking_id):
 
         resource_name = booking.resource_booked.name if booking.resource_booked else "Unknown Resource"
 
-        # Email sending logic
-        if mail and current_user.email and any("time from" in change for change in change_details_list):
-            try:
-                from flask_mail import Message # Ensure Message is available
-                msg = Message(
-                    subject="Booking Updated",
-                    recipients=[current_user.email],
-                    body=(
-                        f"Your booking for {resource_name} has been updated.\n"
-                        f"New Title: {booking.title}\n"
-                        f"New Start Time: {booking.start_time.strftime('%Y-%m-%d %H:%M')}\n"
-                        f"New End Time: {booking.end_time.strftime('%Y-%m-%d %H:%M')}\n"
-                    ),
-                    sender=current_app.config.get('MAIL_DEFAULT_SENDER')
-                )
-                mail.send(msg)
-                current_app.logger.info(f"Booking update email sent to {current_user.email} via Flask-Mail.")
-            except Exception as mail_e:
-                current_app.logger.exception(f"[API PUT /api/bookings/{booking_id}] Failed to send booking update email to {current_user.email} via Flask-Mail: {mail_e}")
+        # Email sending logic - REMOVED as per subtask instructions
+        # if mail and current_user.email and any("time from" in change for change in change_details_list):
+        #     try:
+        #         from flask_mail import Message # Ensure Message is available
+        #         msg = Message(
+        #             subject="Booking Updated",
+        #             recipients=[current_user.email],
+        #             body=(
+        #                 f"Your booking for {resource_name} has been updated.\n"
+        #                 f"New Title: {booking.title}\n"
+        #                 f"New Start Time: {booking.start_time.strftime('%Y-%m-%d %H:%M')}\n"
+        #                 f"New End Time: {booking.end_time.strftime('%Y-%m-%d %H:%M')}\n"
+        #             ),
+        #             sender=current_app.config.get('MAIL_DEFAULT_SENDER')
+        #         )
+        #         mail.send(msg)
+        #         current_app.logger.info(f"Booking update email sent to {current_user.email} via Flask-Mail.")
+        #     except Exception as mail_e:
+        #         current_app.logger.exception(f"[API PUT /api/bookings/{booking_id}] Failed to send booking update email to {current_user.email} via Flask-Mail: {mail_e}")
 
         change_summary_text = '; '.join(change_details_list)
         add_audit_log(


### PR DESCRIPTION
This commit finalizes the transition to using the Gmail API with a Service Account for all application email sending, and completely removes the old Flask-Mail SMTP setup.

Key changes:
- Modified `utils.py`:
    - Refined the handling of the `GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY` environment variable within the `send_email` function to better process newline characters, addressing potential `ValueError: Unable to load PEM file` errors. Added debug logging for the processed key.
    - Removed now-unused imports related to Flask-Mail (`flask_mail.Message`, `extensions.mail`).
- Modified `extensions.py`:
    - Removed the `flask_mail.Mail` import and the `mail = Mail()` instantiation.
- Modified `app_factory.py`:
    - Removed `mail` from `extensions` imports.
    - Removed the `mail.init_app(app)` call.
    - Removed all diagnostic logging related to Flask-Mail configuration and state.
    - Removed the unused `flask_mail.Message` import.
- Modified `routes/api_bookings.py`:
    - Removed the `mail` import from `extensions`.
    - Commented out the Flask-Mail based email notification block in `update_booking_by_user` as its direct replacement with the new `utils.send_email` was out of scope for this specific refactor, preventing errors from the missing `mail` object. Future work can re-implement this notification if desired using `utils.send_email`.
- Modified `tests/test_app.py`:
    - Added new unit tests for the Gmail API version of `utils.send_email`, covering plain text, HTML/attachments, and HttpError handling by mocking Google API client calls.
    - Updated the integration test `test_create_booking_sends_confirmation_email` to mock the new Gmail API call path via `utils.send_email`.
    - Commented out obsolete tests that were specific to the old Flask-Mail `send_email` implementation.

The application now exclusively uses the configured Google Service Account and the Gmail API for sending emails. The old SMTP configuration variables in `config.py` and related documentation in `README.md` were updated/removed in the immediately preceding commit ("feature/gmail-api-oauth-send").