### PR TITLE
I've completed the removal of Flask-Mail and resolved an ImportError.

### DIFF
--- a/routes/admin_api_bookings.py
+++ b/routes/admin_api_bookings.py
@@ -3,7 +3,7 @@ from flask_login import login_required, current_user
 from datetime import timezone # Added timezone
 
 # Assuming extensions.py contains db, socketio, mail
-from extensions import db, socketio, mail
+from extensions import db, socketio # Removed mail
 # Assuming models.py contains these model definitions
 from models import Booking, User, Resource # Added Resource
 # Assuming utils.py contains these helper functions


### PR DESCRIPTION
This update addresses an ImportError for 'mail' from 'extensions' in `routes/admin_api_bookings.py` by removing the unused import.

It also includes broader changes to fully remove Flask-Mail integration:
- I refined private key string handling in `utils.send_email` to better process newline characters from environment variables for Gmail API authentication. I also added debug logging for the processed private key.
- I removed the `Mail` object instantiation and `mail.init_app()` call from `extensions.py` and `app_factory.py`.
- I removed all Flask-Mail diagnostic logs from `app_factory.py`.
- I removed Flask-Mail related imports from `utils.py`, `app_factory.py`, and `routes/api_bookings.py`.
- I ensured email sending functionalities in `routes/admin_api_bookings.py` and `scheduler_tasks.py` correctly use `utils.send_email` (Gmail API) by verifying no direct `mail` object usage remained or by updating calls. The email notification in `routes/api_bookings.py` for user-updated bookings was commented out as its direct Flask-Mail usage was removed and a full refactor to the new system was out of scope for the immediate fix.

The application now exclusively uses the Gmail API via `utils.send_email` for all email sending operations.