### PR TITLE
Implement OAuth2 client flow for Gmail and update tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,19 +239,33 @@ The script will verify the schema of the existing `site.db` file. If it doesn't
 match the current models, the old database is deleted and rebuilt. Make sure you
 back up any important data before running the script in these situations.
 
-### Email Configuration
+### Email Configuration (Gmail API with OAuth 2.0)
 
-Flask-Mail is used to send email notifications when bookings are created, updated or cancelled. Configure your SMTP credentials through environment variables before running the application:
+The application sends email notifications (e.g., booking confirmations, alerts) using the Gmail API with OAuth 2.0. This method requires a one-time authorization by the owner of the Gmail account that will be used for sending emails.
 
-* `MAIL_SERVER` – SMTP server address
-* `MAIL_PORT` – SMTP port number
-* `MAIL_USERNAME` – SMTP username
-* `MAIL_PASSWORD` – SMTP password
-* `MAIL_USE_TLS` – set to `true` to enable TLS
-* `MAIL_USE_SSL` – set to `true` to enable SSL
-* `MAIL_DEFAULT_SENDER` – address used as the default sender
+**Required Environment Variables:**
 
-If these variables are not provided, placeholder values from `app.py` will be used.
+*   `GOOGLE_CLIENT_ID`: Your Google Cloud OAuth 2.0 Client ID (typically used for user login, and reused here).
+*   `GOOGLE_CLIENT_SECRET`: Your Google Cloud OAuth 2.0 Client Secret.
+*   `GMAIL_SENDER_ADDRESS`: The Gmail account the application will send emails *from* (e.g., `your-app-notifications@gmail.com`).
+*   `GMAIL_OAUTH_REDIRECT_URI`: The application's redirect URI for the Gmail authorization flow. Example: `http://localhost:5000/admin/gmail_auth/authorize_callback`.
+    *   **Important**: You MUST add this exact URI to the "Authorized redirect URIs" list for your OAuth 2.0 Client ID in the Google Cloud Console.
+*   `GMAIL_REFRESH_TOKEN`: The refresh token obtained after the one-time authorization process (see below). This token allows the application to continuously send emails without further manual intervention. Store this securely.
+*   `MAIL_DEFAULT_SENDER`: Fallback sender email address if `GMAIL_SENDER_ADDRESS` is not determined for some reason (e.g., `fallback@example.com`).
+
+**One-Time Authorization to Obtain Refresh Token:**
+
+To enable email sending, an administrator must perform a one-time authorization:
+1.  Ensure all the above environment variables (except `GMAIL_REFRESH_TOKEN` initially) are set.
+2.  Start the application.
+3.  In a web browser, log in to the Gmail account that will be used as the `GMAIL_SENDER_ADDRESS`.
+4.  Navigate to the `/admin/gmail_auth/authorize_sending` route in the application.
+5.  You will be redirected to a Google consent screen. Grant the requested permissions (to send emails).
+6.  Upon successful authorization, Google will redirect you back to the application's `GMAIL_OAUTH_REDIRECT_URI`, and the application will display the **Refresh Token**.
+7.  Copy this Refresh Token and set it as the `GMAIL_REFRESH_TOKEN` environment variable for your application.
+8.  Restart the application. It should now be able to send emails.
+
+The old SMTP `MAIL_*` variables (like `MAIL_SERVER`, `MAIL_PORT`, `MAIL_USERNAME`, `MAIL_PASSWORD`, etc.) are no longer used for the primary email sending mechanism when using the Gmail API with OAuth 2.0.
 
 ### Teams Notifications
 

--- a/app_factory.py
+++ b/app_factory.py
@@ -24,6 +24,7 @@ from routes.api_waitlist import init_api_waitlist_routes
 from routes.api_system import init_api_system_routes
 from routes.admin_api_bookings import init_admin_api_bookings_routes # New import
 from routes.admin_api_system_settings import init_admin_api_system_settings_routes # New import
+from routes.gmail_auth import init_gmail_auth_routes # Added for Gmail OAuth flow
 
 # For scheduler
 from apscheduler.schedulers.background import BackgroundScheduler
@@ -377,6 +378,7 @@ def create_app(config_object=config, testing=False): # Added testing parameter
     init_api_system_routes(app)
     init_admin_api_bookings_routes(app) # Register new blueprint
     init_admin_api_system_settings_routes(app) # Register new blueprint
+    init_gmail_auth_routes(app) # Added for Gmail OAuth flow
 
     # 8. Register Error Handlers - Skip if testing
     if not testing:

--- a/config.py
+++ b/config.py
@@ -63,35 +63,34 @@ SCOPES = ['openid', 'https://www.googleapis.com/auth/userinfo.email', 'https://w
 # Optional: Path to client_secret.json if that method is preferred over direct env vars for ID/Secret
 # CLIENT_SECRET_FILE = basedir / 'client_secret.json'
 
-# --- Email (Flask-Mail) Configuration ---
-MAIL_SERVER = os.environ.get('MAIL_SERVER', 'localhost') # Default SMTP server
-MAIL_PORT = int(os.environ.get('MAIL_PORT', 25)) # Default SMTP port
-MAIL_USE_TLS = os.environ.get('MAIL_USE_TLS', 'false').lower() in ['true', '1', 'yes']
-MAIL_USE_SSL = os.environ.get('MAIL_USE_SSL', 'false').lower() in ['true', '1', 'yes']
-MAIL_USERNAME = os.environ.get('MAIL_USERNAME', '')
-MAIL_PASSWORD = os.environ.get('MAIL_PASSWORD', '')
-# Default sender email, uses MAIL_USERNAME if MAIL_DEFAULT_SENDER is not set
-MAIL_DEFAULT_SENDER = os.environ.get('MAIL_DEFAULT_SENDER', MAIL_USERNAME or 'noreply@example.com')
+# --- Email Configuration ---
+# Old Flask-Mail variables (removed as Flask-Mail is no longer used)
+# MAIL_SERVER = os.environ.get('MAIL_SERVER', 'localhost')
+# MAIL_PORT = int(os.environ.get('MAIL_PORT', 25))
+# MAIL_USE_TLS = os.environ.get('MAIL_USE_TLS', 'false').lower() in ['true', '1', 'yes']
+# MAIL_USE_SSL = os.environ.get('MAIL_USE_SSL', 'false').lower() in ['true', '1', 'yes']
+# MAIL_USERNAME = os.environ.get('MAIL_USERNAME', '')
+# MAIL_PASSWORD = os.environ.get('MAIL_PASSWORD', '')
+MAIL_DEFAULT_SENDER = os.environ.get('MAIL_DEFAULT_SENDER', 'fallback_sender@example.com') # Keep a default sender for other purposes or direct use in utils
 
-# --- Gmail API Service Account Configuration (for sending email via OAuth2) ---
-# These are used if you prefer loading service account details from individual environment variables
-# instead of a JSON file path (GOOGLE_APPLICATION_CREDENTIALS).
-GOOGLE_SERVICE_ACCOUNT_TYPE = os.environ.get('GOOGLE_SERVICE_ACCOUNT_TYPE')
-GOOGLE_SERVICE_ACCOUNT_PROJECT_ID = os.environ.get('GOOGLE_SERVICE_ACCOUNT_PROJECT_ID')
-GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY_ID = os.environ.get('GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY_ID')
-# For the private key, ensure newlines are correctly handled if setting via env var
-# Example: export GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY="$(cat key.json | jq -r .private_key | awk '{printf "%s\n", $0}')"
-GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY = os.environ.get('GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY')
-GOOGLE_SERVICE_ACCOUNT_CLIENT_EMAIL = os.environ.get('GOOGLE_SERVICE_ACCOUNT_CLIENT_EMAIL')
-GOOGLE_SERVICE_ACCOUNT_CLIENT_ID = os.environ.get('GOOGLE_SERVICE_ACCOUNT_CLIENT_ID') # Also used for user OAuth, but distinct if service account is different
-GOOGLE_SERVICE_ACCOUNT_AUTH_URI = os.environ.get('GOOGLE_SERVICE_ACCOUNT_AUTH_URI')
-GOOGLE_SERVICE_ACCOUNT_TOKEN_URI = os.environ.get('GOOGLE_SERVICE_ACCOUNT_TOKEN_URI')
-GOOGLE_SERVICE_ACCOUNT_AUTH_PROVIDER_X509_CERT_URL = os.environ.get('GOOGLE_SERVICE_ACCOUNT_AUTH_PROVIDER_X509_CERT_URL')
-GOOGLE_SERVICE_ACCOUNT_CLIENT_X509_CERT_URL = os.environ.get('GOOGLE_SERVICE_ACCOUNT_CLIENT_X509_CERT_URL')
+# --- Gmail API OAuth 2.0 Client ID Configuration (for sending application emails) ---
+# GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET are already defined above for user OAuth.
+# They will be reused here for authorizing the application to send mail via a specific Gmail account.
 
-# Email address of the user the service account will impersonate for sending emails
-# This is required if using domain-wide delegation.
-GMAIL_API_IMPERSONATED_EMAIL = os.environ.get('GMAIL_API_IMPERSONATED_EMAIL') # e.g., rmsunicef@gmail.com
+# The GMAIL_SENDER_ADDRESS is the email account (e.g., rmsunicef@gmail.com)
+# that will be authorized to send emails.
+GMAIL_SENDER_ADDRESS = os.environ.get('GMAIL_SENDER_ADDRESS') # e.g., 'rmsunicef@gmail.com'
+
+# The Redirect URI for the Gmail authorization flow.
+# This MUST be added to your Google Cloud Console "Authorized redirect URIs" for the OAuth 2.0 Client ID.
+# Example: 'http://localhost:5000/authorize_gmail_callback' or 'https://yourdomain.com/authorize_gmail_callback'
+GMAIL_OAUTH_REDIRECT_URI = os.environ.get('GMAIL_OAUTH_REDIRECT_URI')
+
+# The Refresh Token obtained after the one-time authorization for GMAIL_SENDER_ADDRESS.
+# This should be stored securely, e.g., as an environment variable.
+GMAIL_REFRESH_TOKEN = os.environ.get('GMAIL_REFRESH_TOKEN')
+
+# Old Gmail API Service Account Configuration variables removed.
 
 # --- Booking and Check-in Behavior ---
 CHECK_IN_GRACE_MINUTES = int(os.environ.get('CHECK_IN_GRACE_MINUTES', 15)) # Grace period for check-in in minutes

--- a/routes/gmail_auth.py
+++ b/routes/gmail_auth.py
@@ -1,0 +1,135 @@
+import os
+from flask import Blueprint, request, session, redirect, url_for, current_app, flash, render_template
+from flask_login import login_required, current_user # Added current_user
+from google_auth_oauthlib.flow import Flow
+from google.oauth2.credentials import Credentials
+from google.auth.exceptions import OAuthError
+
+# Assuming User model might be needed for permission checks, or permission_required decorator
+from auth import permission_required
+
+gmail_auth_bp = Blueprint('gmail_auth', __name__, url_prefix='/admin/gmail_auth')
+
+def get_gmail_oauth_flow():
+    # Ensure GMAIL_OAUTH_REDIRECT_URI is correctly configured in config.py and Google Cloud Console
+    redirect_uri = current_app.config.get('GMAIL_OAUTH_REDIRECT_URI')
+    if not redirect_uri:
+        raise ValueError("GMAIL_OAUTH_REDIRECT_URI is not configured in the application.")
+
+    # Scopes for sending email
+    scopes = ['https://www.googleapis.com/auth/gmail.send']
+
+    # Client config details are loaded from current_app.config
+    # These should be the GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET for the web application
+    client_config = {
+        "web": {
+            "client_id": current_app.config.get('GOOGLE_CLIENT_ID'),
+            "client_secret": current_app.config.get('GOOGLE_CLIENT_SECRET'),
+            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+            "token_uri": "https://oauth2.googleapis.com/token",
+            "redirect_uris": [redirect_uri],
+            # "javascript_origins": [...] # Optional, if needed
+        }
+    }
+    # For development/testing with http, allow insecure transport
+    # In production, ensure HTTPS is used.
+    if current_app.debug:
+         os.environ['OAUTHLIB_INSECURE_TRANSPORT'] = '1'
+
+    flow = Flow.from_client_config(
+        client_config=client_config,
+        scopes=scopes,
+        redirect_uri=redirect_uri
+    )
+    return flow
+
+@gmail_auth_bp.route('/authorize_sending')
+@login_required
+@permission_required('manage_system') # Ensure only admins can initiate this
+def authorize_gmail_sending():
+    try:
+        flow = get_gmail_oauth_flow()
+        # Generate authorization URL & store state for CSRF protection
+        authorization_url, state = flow.authorization_url(
+            access_type='offline', # Request offline access to get a refresh token
+            prompt='consent'       # Force consent screen to ensure refresh token is issued
+        )
+        session['oauth_gmail_state'] = state
+        current_app.logger.info(f"Admin {current_user.username} initiating Gmail sending authorization. Redirecting to Google.")
+        return redirect(authorization_url)
+    except ValueError as ve:
+        current_app.logger.error(f"Configuration error during Gmail auth initiation: {str(ve)}")
+        flash(f"Configuration error: {str(ve)}. Please check server logs and config.", "danger")
+        return redirect(url_for('admin_ui.serve_system_settings_page')) # Redirect to a relevant admin page
+    except Exception as e:
+        current_app.logger.exception(f"Error initiating Gmail sending authorization: {e}")
+        flash("An unexpected error occurred while initiating Gmail authorization. Please try again.", "danger")
+        return redirect(url_for('admin_ui.serve_system_settings_page'))
+
+
+@gmail_auth_bp.route('/authorize_callback')
+# This route should match the GMAIL_OAUTH_REDIRECT_URI
+@login_required # Ensure an admin is still logged in, though state also protects
+@permission_required('manage_system')
+def authorize_gmail_callback():
+    state = session.pop('oauth_gmail_state', None)
+    # Verify state parameter to prevent CSRF
+    if not state or state != request.args.get('state'):
+        current_app.logger.error("OAuth state mismatch in Gmail authorization callback. Potential CSRF.")
+        flash("Authorization failed due to a state mismatch. Please try again.", "error")
+        return redirect(url_for('admin_ui.serve_system_settings_page')) # Or a more specific error page
+
+    try:
+        flow = get_gmail_oauth_flow()
+        # Exchange authorization code for tokens
+        flow.fetch_token(authorization_response=request.url)
+
+        credentials = flow.credentials
+        refresh_token = credentials.refresh_token
+        access_token = credentials.token # Current access token
+
+        # Log and display the refresh token to the admin
+        # IMPORTANT: This is sensitive. In a real app, consider more secure handling or direct storage.
+        log_message = (
+            f"Gmail sending authorization successful for admin {current_user.username}. "
+            f"Obtained refresh token (first 10 chars): {refresh_token[:10] if refresh_token else 'NONE'}... "
+            f"Access token (first 10 chars): {access_token[:10] if access_token else 'NONE'}..."
+        )
+        current_app.logger.info(log_message)
+
+        if refresh_token:
+            flash_message = (
+                "Gmail sending authorization successful! "
+                "Please copy the **Refresh Token** below and set it as the "
+                "`GMAIL_REFRESH_TOKEN` environment variable for your application. "
+                "Store this token securely. You will only see it once."
+            )
+            flash(flash_message, "success")
+            # Render a simple page to display the token
+            return render_template('admin/display_refresh_token.html',
+                                   refresh_token=refresh_token,
+                                   access_token=access_token,
+                                   target_email=current_app.config.get('GMAIL_SENDER_ADDRESS', 'Not Configured'))
+        else:
+            flash_message = (
+                "Gmail authorization was successful, but a **Refresh Token was NOT provided by Google**. "
+                "This might happen if consent was previously granted without 'offline' access, or if the "
+                "'prompt=consent' parameter was not effective. Please ensure your Google OAuth client is "
+                "configured correctly and try removing the app's access from the Google account settings "
+                "and re-authorizing with 'prompt=consent'."
+            )
+            flash(flash_message, "warning")
+            current_app.logger.warning(f"Gmail authorization for {current_user.username} did not yield a refresh token. Access token: {access_token}")
+            return redirect(url_for('admin_ui.serve_system_settings_page'))
+
+    except OAuthError as oe:
+        current_app.logger.error(f"OAuthError during Gmail token exchange: {str(oe)}", exc_info=True)
+        flash(f"OAuth error during token exchange: {str(oe)}. Please ensure your client ID/secret and redirect URI are correct.", "danger")
+        return redirect(url_for('admin_ui.serve_system_settings_page'))
+    except Exception as e:
+        current_app.logger.exception(f"Error in Gmail authorization callback: {e}")
+        flash("An unexpected error occurred during the Gmail authorization callback.", "danger")
+        return redirect(url_for('admin_ui.serve_system_settings_page'))
+
+def init_gmail_auth_routes(app):
+    app.register_blueprint(gmail_auth_bp)

--- a/templates/admin/display_refresh_token.html
+++ b/templates/admin/display_refresh_token.html
@@ -1,0 +1,50 @@
+{% extends "base.html" %}
+{% block title %}Gmail Refresh Token - Admin{% endblock %}
+{% block content %}
+<div class="container mt-4">
+    <h2>Gmail Sending Authorization - Refresh Token</h2>
+    {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+            {% for category, message in messages %}
+                <div class="alert alert-{{ category }}">{{ message }}</div>
+            {% endfor %}
+        {% endif %}
+    {% endwith %}
+
+    <p>The application has been authorized to send emails on behalf of <strong>{{ target_email }}</strong>.</p>
+
+    {% if refresh_token %}
+        <div class="alert alert-warning">
+            <p><strong>Important:</strong> Please copy the Refresh Token below. You will need to set this as the
+            <code>GMAIL_REFRESH_TOKEN</code> environment variable for your application.
+            <strong>This token will not be shown again.</strong> Store it securely.</p>
+        </div>
+        <div class="form-group">
+            <label for="refreshToken">Refresh Token:</label>
+            <textarea class="form-control" id="refreshToken" rows="3" readonly>{{ refresh_token }}</textarea>
+        </div>
+        <button class="btn btn-secondary mt-2" onclick="copyToken()">Copy Token</button>
+        <hr>
+        <p>Current Access Token (short-lived, for reference):</p>
+        <textarea class="form-control" id="accessToken" rows="2" readonly>{{ access_token }}</textarea>
+    {% else %}
+        <p>No refresh token was obtained. Please see flashed messages for details or check server logs.</p>
+    {% endif %}
+
+    <p class="mt-3"><a href="{{ url_for('admin_ui.serve_system_settings_page') }}" class="btn btn-primary">Back to System Settings</a></p>
+</div>
+
+<script>
+function copyToken() {
+    var tokenText = document.getElementById("refreshToken");
+    tokenText.select();
+    tokenText.setSelectionRange(0, 99999); /* For mobile devices */
+    try {
+        document.execCommand("copy");
+        alert("Refresh Token copied to clipboard!");
+    } catch (err) {
+        alert("Failed to copy token. Please copy it manually.");
+    }
+}
+</script>
+{% endblock %}


### PR DESCRIPTION
This commit introduces the OAuth 2.0 web application flow for authorizing the application to send emails via a specific Gmail account (e.g., a standard Gmail account like rmsunicef@gmail.com) using the Gmail API. This replaces the previous Service Account implementation attempt.

Key changes:

1.  **Configuration (`config.py`):**
    *   Removed all `GOOGLE_SERVICE_ACCOUNT_*` variables.
    *   Added new environment variables:
        *   `GMAIL_SENDER_ADDRESS`: The email address to send from.
        *   `GMAIL_OAUTH_REDIRECT_URI`: The callback URI for the authorization flow.
        *   `GMAIL_REFRESH_TOKEN`: To store the obtained refresh token.
    *   The existing `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` are now
        reused for this email sending authorization.
    *   Old SMTP `MAIL_*` variables were previously removed.

2.  **One-Time Authorization Flow (`routes/gmail_auth.py`):**
    *   Created a new blueprint `gmail_auth_bp`.
    *   Added route `/admin/gmail_auth/authorize_sending` to initiate
        the OAuth 2.0 flow, redirecting to Google's consent screen for
        the `gmail.send` scope.
    *   Added callback route `/admin/gmail_auth/authorize_callback` to
        handle Google's response, fetch the refresh token, and display
        it to the admin for manual configuration as an environment variable.
    *   Added a simple HTML template `templates/admin/display_refresh_token.html`
        to show the refresh token.
    *   Registered this new blueprint in `app_factory.py`.

3.  **Email Sending Utility (`utils.py`):**
    *   The `send_email` function was refactored to use `google.oauth2.credentials.Credentials`
        with the `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, and the stored
        `GMAIL_REFRESH_TOKEN`.
    *   It no longer uses Service Account credentials.
    *   The "from" address is taken from `GMAIL_SENDER_ADDRESS`.

4.  **Testing (`tests/test_app.py`):**
    *   Updated unit tests for `utils.send_email` to mock and verify the
        new OAuth 2.0 Client ID (refresh token) flow. This includes tests for
        successful sending, missing refresh token configuration, and handling
        Gmail API `HttpError`.
    *   Modified the integration test `test_create_booking_sends_confirmation_email`
        to align with this new authentication mechanism, ensuring it mocks
        the correct credential flow.

5.  **Documentation (`README.md`):**
    *   Updated the "Email Configuration" section to detail the new
        OAuth 2.0 Client ID flow, the one-time authorization process,
        and the required environment variables.

This set of changes allows the application to be authorized by a standard Gmail account owner to send emails on their behalf.