### PR TITLE
feat: Implement Gmail API email sending via OAuth2 Client ID

### DIFF
--- a/routes/gmail_auth.py
+++ b/routes/gmail_auth.py
@@ -47,6 +47,9 @@ def get_gmail_oauth_flow():
 @login_required
 @permission_required('manage_system') # Ensure only admins can initiate this
 def authorize_gmail_sending():
+    # For development/testing with http, allow insecure transport
+    if current_app.debug: # Check if app is in debug mode
+        os.environ['OAUTHLIB_INSECURE_TRANSPORT'] = '1'
     try:
         flow = get_gmail_oauth_flow()
         # Generate authorization URL & store state for CSRF protection
@@ -72,6 +75,9 @@ def authorize_gmail_sending():
 @login_required # Ensure an admin is still logged in, though state also protects
 @permission_required('manage_system')
 def authorize_gmail_callback():
+    # For development/testing with http, allow insecure transport
+    if current_app.debug: # Check if app is in debug mode
+        os.environ['OAUTHLIB_INSECURE_TRANSPORT'] = '1'
     state = session.pop('oauth_gmail_state', None)
     # Verify state parameter to prevent CSRF
     if not state or state != request.args.get('state'):
@@ -129,7 +135,7 @@ def authorize_gmail_callback():
     except Exception as e:
         current_app.logger.exception(f"Error in Gmail authorization callback: {e}")
         flash("An unexpected error occurred during the Gmail authorization callback.", "danger")
-        return redirect(url_for('admin_ui.serve_system_settings_page'))
+        return redirect(url_for('admin_ui.system_settings_page')) # Corrected route name
 
 def init_gmail_auth_routes(app):
     app.register_blueprint(gmail_auth_bp)


### PR DESCRIPTION
This commit refactors the email sending functionality to use the Gmail API with OAuth 2.0 Client ID credentials, replacing the previous Flask-Mail SMTP and Google Service Account approaches.

Key changes:
- Added OAuth2 configuration variables to `config.py` (GMAIL_CLIENT_ID, GMAIL_CLIENT_SECRET, GMAIL_REDIRECT_URI, GMAIL_REFRESH_TOKEN, GMAIL_SENDER_ADDRESS).
- Implemented a one-time authorization flow in `routes/gmail_auth.py` (/admin/gmail_auth/authorize_sending and callback) for administrators to obtain a GMAIL_REFRESH_TOKEN.
- Created a template to display the obtained refresh token.
- Modified `utils.send_email` to use `google.oauth2.credentials.Credentials` (built from the refresh token) and the Gmail API service to send emails.
- Updated `app_factory.py` to register the new `gmail_auth` blueprint and removed all Flask-Mail initialization and diagnostic code.
- Updated `requirements.txt` to include `google-auth-oauthlib`.
- Updated `README.md` with new environment variables and instructions for the OAuth2 authorization flow.
- Updated tests in `tests/test_app.py` to mock the Gmail API and OAuth2 credentials for testing `utils.send_email`.
- Removed unused Flask-Mail (`mail`) imports from other files (e.g., `routes/admin_api_bookings.py`).
- Programmatically sets `OAUTHLIB_INSECURE_TRANSPORT=1` in `routes/gmail_auth.py` when `app.debug` is true to facilitate local HTTP development for the OAuth callback.
- Fixed a `BuildError` in a redirect URL within `routes/gmail_auth.py`.

This approach allows the application to send emails from a designated Gmail account using a more secure and modern authentication method. The administrator needs to perform a one-time authorization to grant the application permission and store the resulting refresh token.