### PR TITLE
fix: Address issues found after initial OAuth commit

### DIFF
--- a/app_factory.py
+++ b/app_factory.py
@@ -332,14 +332,18 @@ def create_app(config_object=config, testing=False): # Added testing parameter
     app.logger.info("Attempting to send test email from app_factory.py...")
     with app.app_context():
         try:
+            # utils.send_email now handles its own detailed success/failure logging.
+            # The factory's role is just to trigger the test email.
             send_email(
                 to_address="debug@example.com",
-                subject="Test Email from App Factory (via Gmail API)",
-                body="This is a test email sent from app_factory.py using the Gmail API."
+                subject="Test Email from App Factory (Startup Check)",
+                body="This is a test email sent from app_factory.py during application startup to check email functionality."
             )
-            app.logger.info("Test email from factory sent successfully.")
+            # Success message is now primarily handled within send_email or by observing logs from utils.py
+            app.logger.info("Test email dispatch attempt from factory completed. Check logs for success/failure details from utils.send_email.")
         except Exception as e_factory_mail:
-            app.logger.error(f"Test email from factory FAILED. Error: {e_factory_mail}", exc_info=True)
+            # This will catch unexpected errors if the send_email call itself fails catastrophically.
+            app.logger.error(f"Test email dispatch from factory FAILED due to an unexpected error: {e_factory_mail}", exc_info=True)
 
     csrf.init_app(app)
     socketio.init_app(app, message_queue=app.config.get('SOCKETIO_MESSAGE_QUEUE')) # Add message_queue from config

--- a/routes/gmail_auth.py
+++ b/routes/gmail_auth.py
@@ -63,11 +63,11 @@ def authorize_gmail_sending():
     except ValueError as ve:
         current_app.logger.error(f"Configuration error during Gmail auth initiation: {str(ve)}")
         flash(f"Configuration error: {str(ve)}. Please check server logs and config.", "danger")
-        return redirect(url_for('admin_ui.serve_system_settings_page')) # Redirect to a relevant admin page
+        return redirect(url_for('admin_ui.system_settings_page')) # Corrected route name
     except Exception as e:
         current_app.logger.exception(f"Error initiating Gmail sending authorization: {e}")
         flash("An unexpected error occurred while initiating Gmail authorization. Please try again.", "danger")
-        return redirect(url_for('admin_ui.serve_system_settings_page'))
+        return redirect(url_for('admin_ui.system_settings_page')) # Corrected route name
 
 
 @gmail_auth_bp.route('/authorize_callback')
@@ -83,7 +83,7 @@ def authorize_gmail_callback():
     if not state or state != request.args.get('state'):
         current_app.logger.error("OAuth state mismatch in Gmail authorization callback. Potential CSRF.")
         flash("Authorization failed due to a state mismatch. Please try again.", "error")
-        return redirect(url_for('admin_ui.serve_system_settings_page')) # Or a more specific error page
+        return redirect(url_for('admin_ui.system_settings_page')) # Corrected route name
 
     try:
         flow = get_gmail_oauth_flow()
@@ -126,12 +126,12 @@ def authorize_gmail_callback():
             )
             flash(flash_message, "warning")
             current_app.logger.warning(f"Gmail authorization for {current_user.username} did not yield a refresh token. Access token: {access_token}")
-            return redirect(url_for('admin_ui.serve_system_settings_page'))
+            return redirect(url_for('admin_ui.system_settings_page')) # Corrected route name
 
     except OAuthError as oe:
         current_app.logger.error(f"OAuthError during Gmail token exchange: {str(oe)}", exc_info=True)
         flash(f"OAuth error during token exchange: {str(oe)}. Please ensure your client ID/secret and redirect URI are correct.", "danger")
-        return redirect(url_for('admin_ui.serve_system_settings_page'))
+        return redirect(url_for('admin_ui.system_settings_page')) # Corrected route name
     except Exception as e:
         current_app.logger.exception(f"Error in Gmail authorization callback: {e}")
         flash("An unexpected error occurred during the Gmail authorization callback.", "danger")

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -1,0 +1,9 @@
+{% macro render_flash_messages(messages) %}
+    {% if messages %}
+        <ul class="flashes">
+        {% for category, message in messages %}
+            <li class="{{ category }}">{{ message }}</li>
+        {% endfor %}
+        </ul>
+    {% endif %}
+{% endmacro %}


### PR DESCRIPTION
This commit includes several fixes for issues identified during testing of the Gmail OAuth2 integration:

1.  **Correct `app_factory.py` Test Email Logging**:
    - The startup test email log message in `app_factory.py` now more accurately reflects that an attempt was made, and directs you to check `utils.send_email` logs for actual success/failure.
    - Updated subject/body of the factory test email for clarity.

2.  **Fix `BuildError` in `routes/gmail_auth.py`**:
    - Ensured all `url_for` calls redirecting to the system settings page (e.g., after an OAuth error or state mismatch) correctly use `admin_ui.system_settings_page` instead of the non-existent `admin_ui.serve_system_settings_page`.

3.  **Resolve `TemplateNotFound` for `macros.html`**:
    - Created `templates/macros.html` and added a `render_flash_messages` macro, adapted from `templates/base.html`. This resolves the error when `templates/admin/system_settings.html` tries to import this macro. The `system_settings.html` page was found to only use this specific macro, so others (render_field, render_submit_button) were not added at this time.