### PR TITLE
Fix: Improve JPG image generation for email attachments

### DIFF
--- a/routes/api_bookings.py
+++ b/routes/api_bookings.py
@@ -465,16 +465,6 @@ def create_booking():
                 }
                 # current_app.logger.info(f"Email data for booking {new_booking.id}: {email_data}") # Old log line
 
-                # ADD DIAGNOSTIC LOGGING HERE:
-                current_app.logger.info(f"Booking {new_booking.id} - DIAGNOSTIC - Resource ID: {resource_for_email.id}")
-                current_app.logger.info(f"Booking {new_booking.id} - DIAGNOSTIC - Resource Name: {resource_for_email.name}")
-                current_app.logger.info(f"Booking {new_booking.id} - DIAGNOSTIC - Raw map_coordinates: '{resource_for_email.map_coordinates}'")
-                current_app.logger.info(f"Booking {new_booking.id} - DIAGNOSTIC - Type of map_coordinates: {type(resource_for_email.map_coordinates)}")
-                current_app.logger.info(f"Booking {new_booking.id} - DIAGNOSTIC - Raw floor_map_id: {resource_for_email.floor_map_id}")
-                current_app.logger.info(f"Booking {new_booking.id} - DIAGNOSTIC - Type of floor_map_id: {type(resource_for_email.floor_map_id)}")
-                current_app.logger.info(f"Booking {new_booking.id} - DIAGNOSTIC - bool(map_coordinates): {bool(resource_for_email.map_coordinates)}")
-                current_app.logger.info(f"Booking {new_booking.id} - DIAGNOSTIC - bool(floor_map_id): {bool(resource_for_email.floor_map_id)}")
-
                 # Generate image with resource area marked
                 processed_image_path = None # Initialize
                 if resource_for_email and resource_for_email.map_coordinates and resource_for_email.floor_map_id:

--- a/utils.py
+++ b/utils.py
@@ -323,8 +323,8 @@ def generate_booking_image(resource_id: int, map_coordinates_str: str, resource_
                         x0, y0 = float(x), float(y)
                         x1, y1 = float(x) + float(width), float(y) + float(height)
 
-                        outline_color = (255, 0, 0, 200)  # Red, mostly opaque
-                        fill_color = (255, 0, 0, 100)    # Red, more transparent
+                        outline_color = (255, 0, 0, 255)  # Opaque Red
+                        fill_color = (255, 0, 0, 180)    # More Opaque Red (approx 70% opacity)
                         stroke_width_pil = 3
 
                         draw.rectangle([(x0, y0), (x1, y1)], outline=outline_color, fill=fill_color, width=stroke_width_pil)
@@ -356,6 +356,13 @@ def generate_booking_image(resource_id: int, map_coordinates_str: str, resource_
             logger.debug(f"Image mode is {img.mode}, converting to RGB before saving as JPG for resource ID {resource_id}.")
             img = img.convert('RGB')
 
+        # Resize image if it's too large
+        MAX_DIMENSION = 1200 # Or get from app.config if desired for more flexibility
+        if img.width > MAX_DIMENSION or img.height > MAX_DIMENSION:
+            logger.info(f"Image for resource ID {resource_id} ('{resource_name}') was large ({img.width}x{img.height}), resizing to fit within {MAX_DIMENSION}px on its largest side.")
+            img.thumbnail((MAX_DIMENSION, MAX_DIMENSION)) # Resizes in place
+            logger.info(f"Image for resource ID {resource_id} ('{resource_name}') resized to {img.width}x{img.height}.")
+
         # Sanitize resource_name and construct output path
         # Basic sanitization: replace spaces with underscores, remove non-alphanumeric (except underscore, hyphen, dot)
         sanitized_name_base = re.sub(r'[^\w.-]', '', resource_name.replace(' ', '_'))
@@ -376,7 +383,7 @@ def generate_booking_image(resource_id: int, map_coordinates_str: str, resource_
             except OSError as e_remove:
                 logger.warning(f"Could not remove existing temp file {output_path} before saving: {e_remove}")
 
-        img.save(output_path, "JPEG", quality=80, optimize=True)
+        img.save(output_path, "JPEG", quality=70, optimize=True) # Adjusted quality to 70
 
         logger.info(f"Saved modified image for resource ID {resource_id} ('{resource_name}') to temporary JPG file at {output_path}")
         return output_path


### PR DESCRIPTION
This commit addresses issues with the generated JPG images attached to booking confirmation emails:
- Removes diagnostic logging previously added to routes/api_bookings.py.
- Modifies utils.generate_booking_image to:
  - Resize images if their width or height exceeds 1200px, using img.thumbnail to maintain aspect ratio. This helps control file size for very large base images.
  - Adjusts JPG save quality from 80 to 70 to further reduce file size, aiming for under 350KB.
  - Increases the opacity of the colors used to draw the resource area rectangle (outline is now fully opaque red, fill is ~70% opaque red) to ensure it's clearly visible on the final JPG image.