### PR TITLE
Fix: Correct IndentationError in send_email configuration check

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -482,10 +482,10 @@ def send_email(to_address: str, subject: str, body: str = None, html_body: str =
                 from_email = current_app.config.get('GMAIL_SENDER_ADDRESS')
 
                 if not all([client_id, client_secret, refresh_token, from_email]):
-                logger.error("Gmail API OAuth 2.0 Client ID credentials not fully configured.")
-                email_log_entry['status'] = 'failed_oauth_config_missing'
-                # Do not return immediately, allow cleanup logic to run
-                break # Break from retry loop as this is a config error
+                    logger.error("Gmail API OAuth 2.0 Client ID credentials not fully configured.")
+                    email_log_entry['status'] = 'failed_oauth_config_missing'
+                    # Do not return immediately, allow cleanup logic to run
+                    break # Break from retry loop as this is a config error
 
             try:
                 creds = UserCredentials(


### PR DESCRIPTION
This commit resolves an IndentationError in the `send_email` function within `utils.py`. The error occurred because the block of code following the `if not all([client_id, ...])` check for Gmail OAuth configurations was not properly indented.

The fix ensures that the `logger.error` call, the assignment to `email_log_entry['status']`, and the subsequent `return` statement are correctly indented under the `if` condition. This ensures these lines execute only when essential configurations are missing, as originally intended.

This correction restores the proper logical flow and resolves the IndentationError.