### PR TITLE
Fix: Use datetime.time.min/max in get_detailed_map_availability_for_user

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -1591,8 +1591,8 @@ def get_detailed_map_availability_for_user(resources_list: list[Resource], targe
             # from sqlalchemy import func
             # func.date(Booking.start_time) == target_date
             # For now, let's assume direct comparison works or adjust if needed
-            Booking.start_time >= datetime.combine(target_date, time.min),
-            Booking.start_time <= datetime.combine(target_date, time.max),
+            Booking.start_time >= datetime.combine(target_date, datetime.time.min),
+            Booking.start_time <= datetime.combine(target_date, datetime.time.max),
             sqlfunc.trim(sqlfunc.lower(Booking.status)).in_(active_booking_statuses_for_conflict)
         ).all()
     except Exception as e:


### PR DESCRIPTION
Corrects an AttributeError that occurred when `time.min` and `time.max` were incorrectly attempting to access attributes on the `time` module instead of using `datetime.time.min` and `datetime.time.max`.

The function `get_detailed_map_availability_for_user` in `utils.py` was updated to explicitly use `datetime.time.min` and `datetime.time.max` to prevent ambiguity with the imported `time` module, thus resolving the "module 'time' has no attribute 'min'" error.