### PR TITLE
Fix: Address JS modal button errors and Python email i18n TypeError

### DIFF
--- a/routes/api_bookings.py
+++ b/routes/api_bookings.py
@@ -1084,9 +1084,12 @@ def update_booking_by_user(booking_id):
                     f"Thank you!"
                 )
 
+                translated_update_subject_format = _("Booking Updated: %(resource_name)s - %(booking_title)s")
+                update_subject = translated_update_subject_format % {'resource_name': email_data['resource_name'], 'booking_title': email_data['booking_title']}
+
                 send_email(
                     to_address=current_user.email,
-                    subject=_("Booking Updated: %(resource_name)s - %(booking_title)s", resource_name=email_data['resource_name'], booking_title=email_data['booking_title']),
+                    subject=update_subject,
                     body=plain_text_body,
                     html_body=html_email_body,
                     attachment_path=processed_image_path
@@ -1215,9 +1218,12 @@ def delete_booking_by_user(booking_id):
                     f"Thank you."
                 )
 
+                translated_subject_format = _("Booking Cancelled: %(resource_name)s - %(booking_title)s")
+                subject=translated_subject_format % {'resource_name': email_data['resource_name'], 'booking_title': email_data['booking_title']},
+
                 send_email(
                     to_address=user_email_for_cancellation,
-                    subject=_("Booking Cancelled: %(resource_name)s - %(booking_title)s", resource_name=email_data['resource_name'], booking_title=email_data['booking_title']),
+                    subject=subject,
                     body=plain_text_body,
                     html_body=html_email_body
                     # No attachment for cancellation

--- a/static/js/calendar.js
+++ b/static/js/calendar.js
@@ -320,16 +320,20 @@ document.addEventListener('DOMContentLoaded', () => {
                 calendarEditBookingModal.style.display = 'block';
 
                 // Re-assign to the new button for the current scope
-                let currentSaveBtn = cebmSaveChangesBtn; // Initialize with the original button
+                // let currentSaveBtn = cebmSaveChangesBtn; // Initialize with the original button // Will be assigned after cloning
+
+                const currentSaveBtnElement = document.getElementById('cebm-save-changes-btn');
+                const currentDeleteBtnElement = document.getElementById('cebm-delete-booking-btn');
+                let currentSaveBtn; // Will hold the (potentially new) save button
 
                 // Remove previous event listener to avoid multiple bindings if any
-                if (cebmSaveChangesBtn && cebmSaveChangesBtn.parentNode) {
-                    const newSaveBtn = cebmSaveChangesBtn.cloneNode(true);
-                    cebmSaveChangesBtn.parentNode.replaceChild(newSaveBtn, cebmSaveChangesBtn);
+                if (currentSaveBtnElement && currentSaveBtnElement.parentNode) {
+                    const newSaveBtn = currentSaveBtnElement.cloneNode(true);
+                    currentSaveBtnElement.parentNode.replaceChild(newSaveBtn, currentSaveBtnElement);
                     currentSaveBtn = newSaveBtn; // Assign the new button to currentSaveBtn
                 } else {
-                    console.error("Error: Could not find 'cebm-save-changes-btn' or its parent node. Cannot re-attach event listener for save button.");
-                    // Optionally, disable the button or show a user-facing error if this state is critical
+                    console.error("Error: Could not find 'currentSaveBtnElement' (ID: cebm-save-changes-btn) or its parent node. Cannot re-attach event listener for save button.");
+                    currentSaveBtn = currentSaveBtnElement; // Fallback to original if not found or no parent, though problematic
                 }
 
                 // Ensure currentSaveBtn is valid before attaching onclick
@@ -345,13 +349,13 @@ document.addEventListener('DOMContentLoaded', () => {
                 } else {
                     // This case should ideally not be reached if cebmSaveChangesBtn was initially found.
                     // If it is reached, it means the original button was also null.
-                    console.error("Error: Save changes button ('cebm-save-changes-btn') not found. Save functionality will be unavailable.");
+                    console.error("Error: Save changes button ('currentSaveBtnElement', ID: cebm-save-changes-btn) not found. Save functionality will be unavailable.");
                 }
 
                 // Logic for delete button
-                if (cebmDeleteBookingBtn && cebmDeleteBookingBtn.parentNode) {
-                    const newDeleteBtn = cebmDeleteBookingBtn.cloneNode(true);
-                    cebmDeleteBookingBtn.parentNode.replaceChild(newDeleteBtn, cebmDeleteBookingBtn);
+                if (currentDeleteBtnElement && currentDeleteBtnElement.parentNode) {
+                    const newDeleteBtn = currentDeleteBtnElement.cloneNode(true);
+                    currentDeleteBtnElement.parentNode.replaceChild(newDeleteBtn, currentDeleteBtnElement);
 
                     newDeleteBtn.onclick = () => {
                         if (confirm("Are you sure you want to delete this booking?")) {
@@ -399,7 +403,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         }
                     };
                 } else {
-                    console.error("Error: Could not find 'cebm-delete-booking-btn' or its parent node.");
+                    console.error("Error: Could not find 'currentDeleteBtnElement' (ID: cebm-delete-booking-btn) or its parent node.");
                 }
             },
             eventSources: [


### PR DESCRIPTION
This commit includes two main fixes:

1. JavaScript (`static/js/calendar.js`):
   - Refactors the `eventClick` handler to re-query modal buttons ('cebm-save-changes-btn', 'cebm-delete-booking-btn') by ID each time an event is clicked before cloning and replacing them. This ensures that event listeners are attached to the correct, freshly obtained DOM elements, preventing errors if the modal content is manipulated.

2. Python (`routes/api_bookings.py`):
   - Corrects a TypeError in email sending functions (`delete_booking_by_user` and `update_booking_by_user`) where the translation function `_()` was incorrectly passed keyword arguments for string formatting.
   - The fix ensures that `_()` is called first to get the translated format string, and then Python's `%` operator is used for placeholder substitution.