### PR TITLE
Fix: Remove trailing comma causing email subject to be a tuple

### DIFF
--- a/routes/api_bookings.py
+++ b/routes/api_bookings.py
@@ -1219,7 +1219,7 @@ def delete_booking_by_user(booking_id):
                 )
 
                 translated_subject_format = _("Booking Cancelled: %(resource_name)s - %(booking_title)s")
-                subject=translated_subject_format % {'resource_name': email_data['resource_name'], 'booking_title': email_data['booking_title']},
+                subject=translated_subject_format % {'resource_name': email_data['resource_name'], 'booking_title': email_data['booking_title']}
 
                 send_email(
                     to_address=user_email_for_cancellation,


### PR DESCRIPTION
Corrects a typo in `routes/api_bookings.py` within the `delete_booking_by_user` function where a trailing comma caused the email subject to be a single-element tuple instead of a string. This led to an `AttributeError: 'tuple' object has no attribute 'encode'` during email processing.

The comma has been removed to ensure the subject is correctly assigned as a string. The `update_booking_by_user` function was also checked and did not have this issue.