### PR TITLE
Refactor: Lower log level for missing user ID in calendar

### DIFF
--- a/static/js/calendar.js
+++ b/static/js/calendar.js
@@ -547,7 +547,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 initializeCalendar(); // Initialize calendar after API call attempt
             });
     } else {
-        console.warn('User ID not found for this calendar instance. Skipping fetching unavailable dates. This is normal for "My Calendar" view.');
+        console.info('User ID not found for this calendar instance. Skipping fetching unavailable dates. This is normal for "My Calendar" view.');
         initializeCalendar(); // Initialize calendar immediately if no user ID
     }
 


### PR DESCRIPTION
I changed console.warn to console.info for the message indicating that a user ID was not found for a calendar instance.

This specific scenario is considered normal and expected for the "My Calendar" view. Lowering the log level to "info" reduces unnecessary noise in the warning logs while still providing visibility for debugging purposes if needed.