### PR TITLE
feat: Filter upcoming bookings to next 3 days and update title

### DIFF
--- a/routes/ui.py
+++ b/routes/ui.py
@@ -33,9 +33,12 @@ def serve_index():
         # Define valid statuses for upcoming bookings
         valid_statuses = ['approved', 'checked_in', 'confirmed']
         # Assuming Booking model has a query attribute from db.Model
+        now = datetime.now(timezone.utc)
+        three_days_from_now = now + timedelta(days=3)
         upcoming_bookings = Booking.query.filter(
             Booking.user_name == current_user.username,
-            Booking.start_time > datetime.now(timezone.utc),
+            Booking.start_time > now,
+            Booking.start_time <= three_days_from_now,
             Booking.status.in_(valid_statuses)  # Filter by valid statuses
         ).order_by(Booking.start_time.asc()).all()
         return render_template("index.html", upcoming_bookings=upcoming_bookings)

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,7 +6,7 @@
     <h1>{{ _('Welcome to Smart Resource Booking') }}</h1>
     <p>{{ _('Your smart solution for managing and booking resources efficiently.') }}</p>
     <section id="upcoming-bookings">
-        <h2>{{ _('Upcoming Bookings') }}</h2>
+        <h2>{{ _('Upcoming Bookings (Next 3 Days)') }}</h2>
         <div id="upcoming-bookings-list">
             {% if upcoming_bookings and upcoming_bookings|length > 0 %}
                 <ul>


### PR DESCRIPTION
I modified the home page to display only upcoming bookings within the next 3 days.
- I updated `routes/ui.py` to filter bookings based on a 3-day window from the current time.
- I changed the section title in `templates/index.html` to "Upcoming Bookings (Next 3 Days)" to reflect the change.

I've outlined manual testing steps so you can verify this functionality.