### PR TITLE
Enhc: Add line separators between booking records

### DIFF
--- a/static/js/my_bookings.js
+++ b/static/js/my_bookings.js
@@ -377,9 +377,14 @@ document.addEventListener('DOMContentLoaded', () => {
                 fetchUpcomingBookings, (val) => upcomingCurrentPage = val, (val) => upcomingItemsPerPage = val);
             upcomingBookingsContainer.innerHTML = '';
             if (data.bookings && data.bookings.length > 0) {
-                data.bookings.forEach(booking => {
+                data.bookings.forEach((booking, index) => {
                     const bookingCard = createBookingCardElement(booking, data.check_in_out_enabled, allowCheckInWithoutPinUpcoming);
                     upcomingBookingsContainer.appendChild(bookingCard);
+                    if (index < data.bookings.length - 1) {
+                        const separator = document.createElement('hr');
+                        separator.className = 'booking-separator'; // Optional class for styling
+                        upcomingBookingsContainer.appendChild(separator);
+                    }
                 });
             } else {
                 upcomingBookingsContainer.innerHTML = '<p>No upcoming bookings found matching your criteria.</p>';
@@ -430,9 +435,14 @@ document.addEventListener('DOMContentLoaded', () => {
                 fetchPastBookings, (val) => pastCurrentPage = val, (val) => pastItemsPerPage = val);
             pastBookingsContainer.innerHTML = '';
             if (data.bookings && data.bookings.length > 0) {
-                data.bookings.forEach(booking => {
+                data.bookings.forEach((booking, index) => {
                     const bookingCard = createBookingCardElement(booking, data.check_in_out_enabled, allowCheckInWithoutPinPast);
                     pastBookingsContainer.appendChild(bookingCard);
+                    if (index < data.bookings.length - 1) {
+                        const separator = document.createElement('hr');
+                        separator.className = 'booking-separator'; // Optional class for styling
+                        pastBookingsContainer.appendChild(separator);
+                    }
                 });
             } else {
                 pastBookingsContainer.innerHTML = '<p>No past bookings found matching your criteria.</p>';

--- a/static/style.css
+++ b/static/style.css
@@ -1736,4 +1736,12 @@ ul.pagination.align-items-baseline > li.page-item {
     text-align: center;
 }
 
+/* Separator for Booking Cards */
+.booking-separator {
+    margin-top: 0.5rem; /* Adjust as needed */
+    margin-bottom: 1rem; /* Default Bootstrap hr margin is often 1rem, this aligns bottom */
+    border: 0; /* Optional: Reset border if you want a lighter/custom one */
+    border-top: 1px solid rgba(0, 0, 0, 0.1); /* Default Bootstrap hr color/style */
+}
+
 [end of static/style.css]


### PR DESCRIPTION
This commit enhances the user interface of the 'My Bookings' page by adding horizontal line separators (<hr>) between individual booking cards in both the 'Upcoming Bookings' and 'Past Bookings' sections.

This visual separation improves readability and makes it easier for you to distinguish between multiple booking entries, especially when many bookings are listed.

Changes include:
- Modifying `static/js/my_bookings.js` to dynamically insert an `<hr class="booking-separator">` element after each booking card, except for the last card in each section list.
- Adding a corresponding CSS class `.booking-separator` to `static/style.css` to provide basic styling for these separators, ensuring visual consistency with the page design.