### PR TITLE
fix: Correct relative imports in scheduler_tasks

### DIFF
--- a/scheduler_tasks.py
+++ b/scheduler_tasks.py
@@ -1,8 +1,8 @@
 from datetime import datetime, timedelta, timezone
 from flask import current_app, render_template
-from .extensions import db
-from .models import Booking, User, Resource, FloorMap, BookingSettings # Added BookingSettings
-from .utils import add_audit_log, send_email
+from extensions import db # Changed to absolute import
+from models import Booking, User, Resource, FloorMap, BookingSettings # Changed to absolute import
+from utils import add_audit_log, send_email # Changed to absolute import
 
 def auto_checkout_overdue_bookings():
     """


### PR DESCRIPTION
Changed relative imports in `scheduler_tasks.py` to absolute imports to resolve an `ImportError: attempted relative import with no known parent package`.

This occurs when the script is run in a context where Python doesn't recognize it as part of a package, making relative imports like `from .extensions import db` problematic.

The imports for `extensions`, `models`, and `utils` are now absolute, assuming these modules are in the project root or otherwise accessible via `sys.path`.