### PR TITLE
fix: Remove args=[app] from APScheduler job definitions

### DIFF
--- a/app_factory.py
+++ b/app_factory.py
@@ -419,11 +419,11 @@ def create_app(config_object=config, testing=False): # Added testing parameter
 
             # Add jobs from scheduler_tasks.py
             if cancel_unchecked_bookings: # Check if function exists before adding
-                scheduler.add_job(cancel_unchecked_bookings, 'interval', minutes=app.config.get('AUTO_CANCEL_CHECK_INTERVAL_MINUTES', 5), args=[app])
+                scheduler.add_job(cancel_unchecked_bookings, 'interval', minutes=app.config.get('AUTO_CANCEL_CHECK_INTERVAL_MINUTES', 5)) # Removed args=[app]
             if apply_scheduled_resource_status_changes: # Check if function exists
-                scheduler.add_job(apply_scheduled_resource_status_changes, 'interval', minutes=1, args=[app])
+                scheduler.add_job(apply_scheduled_resource_status_changes, 'interval', minutes=1) # Removed args=[app]
             if run_scheduled_backup_job: # Check if function exists
-                scheduler.add_job(run_scheduled_backup_job, 'interval', minutes=app.config.get('SCHEDULER_BACKUP_JOB_INTERVAL_MINUTES', 60), args=[app]) # New config option
+                scheduler.add_job(run_scheduled_backup_job, 'interval', minutes=app.config.get('SCHEDULER_BACKUP_JOB_INTERVAL_MINUTES', 60)) # Removed args=[app]
 
             if run_scheduled_booking_csv_backup: # Check if the function exists
                 booking_schedule_settings = app.config['BOOKING_CSV_SCHEDULE_SETTINGS']
@@ -446,8 +446,8 @@ def create_app(config_object=config, testing=False): # Added testing parameter
                         run_scheduled_booking_csv_backup,
                         'interval',
                         id='scheduled_booking_csv_backup_job', # Add an ID for later modification/removal
-                        **job_kwargs,
-                        args=[app] # Pass the app instance itself
+                        **job_kwargs
+                        # Removed args=[app]
                     )
                     app.logger.info(f"Scheduled booking CSV backup job added: Interval {interval_value} {interval_unit}, Range: {booking_schedule_settings.get('range_type')}.")
                 else:
@@ -464,8 +464,8 @@ def create_app(config_object=config, testing=False): # Added testing parameter
                     func=auto_checkout_overdue_bookings,
                     trigger='interval',
                     minutes=checkout_interval,
-                    replace_existing=True, # Good practice
-                    args=[app] # Pass app context
+                    replace_existing=True # Good practice
+                    # Removed args=[app]
                 )
                 app.logger.info(f"Scheduled auto_checkout_overdue_bookings job: Interval {checkout_interval} minutes.")
             else:


### PR DESCRIPTION
Corrects a ValueError from APScheduler when adding jobs. The error "ValueError: The list of positional arguments is longer than the target callable can handle" occurred because `args=[app]` was specified for scheduler tasks that are designed to fetch the app context internally using `current_app`.

This commit removes `args=[app]` from the `scheduler.add_job` calls in `app_factory.py` for the following tasks in `scheduler_tasks.py`:
- `auto_checkout_overdue_bookings`
- `cancel_unchecked_bookings`
- `apply_scheduled_resource_status_changes`
- `run_scheduled_backup_job`
- `run_scheduled_booking_csv_backup`

These tasks will now correctly obtain the Flask app context on their own when executed by the scheduler.