### PR TITLE
fix: Ensure Flask app context is available in scheduled tasks

### DIFF
--- a/app_factory.py
+++ b/app_factory.py
@@ -419,11 +419,11 @@ def create_app(config_object=config, testing=False): # Added testing parameter
 
             # Add jobs from scheduler_tasks.py
             if cancel_unchecked_bookings: # Check if function exists before adding
-                scheduler.add_job(cancel_unchecked_bookings, 'interval', minutes=app.config.get('AUTO_CANCEL_CHECK_INTERVAL_MINUTES', 5)) # Removed args=[app]
+                scheduler.add_job(cancel_unchecked_bookings, 'interval', minutes=app.config.get('AUTO_CANCEL_CHECK_INTERVAL_MINUTES', 5), args=[app])
             if apply_scheduled_resource_status_changes: # Check if function exists
-                scheduler.add_job(apply_scheduled_resource_status_changes, 'interval', minutes=1) # Removed args=[app]
+                scheduler.add_job(apply_scheduled_resource_status_changes, 'interval', minutes=1, args=[app])
             if run_scheduled_backup_job: # Check if function exists
-                scheduler.add_job(run_scheduled_backup_job, 'interval', minutes=app.config.get('SCHEDULER_BACKUP_JOB_INTERVAL_MINUTES', 60)) # Removed args=[app]
+                scheduler.add_job(run_scheduled_backup_job, 'interval', minutes=app.config.get('SCHEDULER_BACKUP_JOB_INTERVAL_MINUTES', 60), args=[app])
 
             if run_scheduled_booking_csv_backup: # Check if the function exists
                 booking_schedule_settings = app.config['BOOKING_CSV_SCHEDULE_SETTINGS']
@@ -446,8 +446,8 @@ def create_app(config_object=config, testing=False): # Added testing parameter
                         run_scheduled_booking_csv_backup,
                         'interval',
                         id='scheduled_booking_csv_backup_job', # Add an ID for later modification/removal
-                        **job_kwargs
-                        # Removed args=[app]
+                        **job_kwargs,
+                        args=[app]
                     )
                     app.logger.info(f"Scheduled booking CSV backup job added: Interval {interval_value} {interval_unit}, Range: {booking_schedule_settings.get('range_type')}.")
                 else:
@@ -464,8 +464,8 @@ def create_app(config_object=config, testing=False): # Added testing parameter
                     func=auto_checkout_overdue_bookings,
                     trigger='interval',
                     minutes=checkout_interval,
-                    replace_existing=True # Good practice
-                    # Removed args=[app]
+                    replace_existing=True, # Good practice
+                    args=[app]
                 )
                 app.logger.info(f"Scheduled auto_checkout_overdue_bookings job: Interval {checkout_interval} minutes.")
             else:


### PR DESCRIPTION
This commit addresses `RuntimeError: Working outside of application context` for APScheduler tasks.

Changes:
1.  **`scheduler_tasks.py`**:
    *   Refactored `auto_checkout_overdue_bookings`,
      `cancel_unchecked_bookings`, `apply_scheduled_resource_status_changes`,
      `run_scheduled_backup_job`, and `run_scheduled_booking_csv_backup`
      functions.
    *   Their signatures now explicitly require an `app` argument
      (e.g., `def task_name(app):`).
    *   The body of each function is wrapped with `with app.app_context():`
      to ensure operations are performed within the Flask application context.
    *   Loggers are now derived from the passed `app` instance (`app.logger`).

2.  **`app_factory.py`**:
    *   Reinstated `args=[app]` in the `scheduler.add_job(...)` calls for
      the five tasks listed above. This ensures the Flask `app` instance
      is passed to these tasks when they are executed by the scheduler.

This approach resolves the previous conflict between APScheduler's argument passing and the tasks' need for an active application context.