### PR TITLE
Fix: Ensure past dates are bookable when setting is enabled

### DIFF
--- a/routes/api_resources.py
+++ b/routes/api_resources.py
@@ -213,13 +213,8 @@ def get_unavailable_dates():
                     logger.debug(f"Date {current_processing_date} is past and allow_past_bookings is false. Added to unavailable.")
                     current_iter_date += timedelta(days=1)
                     continue
-
-                effective_cutoff = datetime.combine(current_processing_date + timedelta(days=1), time.min, tzinfo=timezone.utc) - timedelta(hours=booking_settings.past_booking_time_adjustment_hours)
-                if now > effective_cutoff:
-                    unavailable_dates_set.add(current_processing_date.strftime('%Y-%m-%d'))
-                    logger.debug(f"Date {current_processing_date} is past. Now: {now}, Effective Cutoff: {effective_cutoff}. Added to unavailable.")
-                    current_iter_date += timedelta(days=1)
-                    continue
+                else: # This means date_is_past is true AND booking_settings.allow_past_bookings is true.
+                    logger.debug(f"Date {current_processing_date} is past and allow_past_bookings is true. Proceeding to check slot availability for this date.")
 
             # b. User's Existing Bookings for the Day (for conflict checking against other resources)
             user_bookings_on_this_date = Booking.query.filter(


### PR DESCRIPTION
I modified the `get_unavailable_dates` function in `routes/api_resources.py` to correctly handle the 'Allow booking creation in the past' setting.

Previously, even if `allow_past_bookings` was true, an `effective_cutoff` check based on `past_booking_time_adjustment_hours` could prematurely mark recent past dates as unavailable.

This change removes the `effective_cutoff` check when `allow_past_bookings` is true. Now, if this setting is enabled, a past date's availability is determined solely by actual slot availability (considering resource status, other bookings, and user conflicts), not by an arbitrary time cutoff related to that past date.