### PR TITLE
Fix: Allow past date selection in new_booking_map.js Flatpickr

### DIFF
--- a/static/js/new_booking_map.js
+++ b/static/js/new_booking_map.js
@@ -99,7 +99,6 @@ document.addEventListener('DOMContentLoaded', function () {
                 inline: true,
                 static: true,
                 dateFormat: "Y-m-d",
-                minDate: "today",
                 disable: [
                     function(date) {
                         const dateStr = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;


### PR DESCRIPTION
Removes the `minDate: "today"` configuration from the Flatpickr instance in `static/js/new_booking_map.js`. This was preventing you from selecting past dates even when the backend logic (via `/api/resources/unavailable_dates`) determined that those past dates should be available (e.g., when "Allow booking creation in the past" is enabled and no other conflicts exist).

Date availability in this calendar will now be primarily controlled by the `disable` array populated from the backend and other specific client-side rules within the `disable` function, rather than a global `minDate` restriction.