### PR TITLE
feat: Add UI for global time offset on backup settings

### DIFF
--- a/templates/admin/backup_settings.html
+++ b/templates/admin/backup_settings.html
@@ -62,6 +62,24 @@
     <p>{{ _('Current UTC Time:') }} <span id="utc-clock">Loading...</span></p>
     <hr>
 
+    <!-- Global Time Offset Configuration Card -->
+    <div class="card mb-4">
+        <div class="card-header">
+            <h2 class="card-title h5">{{ _('Global Time Offset Configuration') }}</h2>
+        </div>
+        <div class="card-body">
+            <p class="card-text"><small>{{ _('This setting adjusts how times are displayed and processed across the application, relative to UTC. For example, if your local time is UTC+2, enter 2. If UTC-5, enter -5.') }}</small></p>
+            <form method="POST" action="{{ url_for('admin_ui.save_backup_time_offset') }}" id="time-offset-form">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+                <div class="form-group mb-3">
+                    <label for="global_time_offset_hours" class="form-label">{{ _('Global Time Offset (hours):') }}</label>
+                    <input type="number" class="form-control" id="global_time_offset_hours" name="global_time_offset_hours" value="{{ global_time_offset_hours | default(0) }}" min="-23" max="23" step="1">
+                </div>
+                <button type="submit" class="btn btn-primary"><i class="fas fa-save"></i> {{ _('Save Time Offset') }}</button>
+            </form>
+        </div>
+    </div>
+
     <!-- Startup Behavior Settings Card -->
     <div class="card mb-4">
         <div class="card-header">


### PR DESCRIPTION
Adds a configuration section to the Admin > Backup & Restore > General Settings page (templates/admin/backup_settings.html) to manage the 'global_time_offset_hours' stored in the BookingSettings model.

Key changes:
- Modified `routes/admin_ui.py` in `serve_backup_settings_page` to fetch and pass the current `global_time_offset_hours` to the template.
- Updated `templates/admin/backup_settings.html` to include a new form card allowing administrators to view and update this offset. The input field includes client-side validation for the range (-23 to +23 hours).
- Added a new route `save_backup_time_offset_route` in `routes/admin_ui.py` to handle the form submission. This route includes:
    - Permission checks (`manage_system`).
    - Robust server-side validation for the offset value (presence, integer type, range).
    - Saving the validated offset to `BookingSettings.global_time_offset_hours`.
    - Creation of an audit log entry upon successful update.
    - User feedback via flashed messages for success or failure.

This feature provides a dedicated UI on the backup settings page for this specific offset, which was previously only configurable via the general system settings page. Both UIs now modify the same underlying database field.