### PR TITLE
feat: Update backup settings clock to display offset server time

### DIFF
--- a/static/js/admin_backup_common.js
+++ b/static/js/admin_backup_common.js
@@ -68,23 +68,38 @@ function enablePageInteractions() {
     });
 }
 
-// --- UTC Clock ---
+// --- UTC Clock / Server Time Clock ---
 function updateUtcClock() {
     const clockElement = document.getElementById('utc-clock');
     if (clockElement) {
-        const now = new Date();
-        const year = now.getUTCFullYear();
-        const month = String(now.getUTCMonth() + 1).padStart(2, '0');
-        const day = String(now.getUTCDate()).padStart(2, '0');
-        const hours = String(now.getUTCHours()).padStart(2, '0');
-        const minutes = String(now.getUTCMinutes()).padStart(2, '0');
-        const seconds = String(now.getUTCSeconds()).padStart(2, '0');
-        const customUtcString = `${year}-${month}-${day} ${hours}:${minutes}:${seconds} UTC`;
-        clockElement.textContent = customUtcString;
+        const offsetHours = parseInt(clockElement.dataset.offset) || 0;
+
+        const nowUtc = new Date();
+        // Calculate server time by applying the offset to UTC time
+        const serverTime = new Date(nowUtc.getTime() + offsetHours * 60 * 60 * 1000);
+
+        // Format the serverTime using UTC methods to reflect the offset time correctly
+        const year = serverTime.getUTCFullYear();
+        const month = String(serverTime.getUTCMonth() + 1).padStart(2, '0'); // Months are 0-indexed
+        const day = String(serverTime.getUTCDate()).padStart(2, '0');
+        const hours = String(serverTime.getUTCHours()).padStart(2, '0');
+        const minutes = String(serverTime.getUTCMinutes()).padStart(2, '0');
+        const seconds = String(serverTime.getUTCSeconds()).padStart(2, '0');
+
+        const formattedTime = `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
+
+        let offsetString = "(UTC)"; // Default to UTC if offset is 0
+        if (offsetHours > 0) {
+            offsetString = `(UTC+${offsetHours})`;
+        } else if (offsetHours < 0) {
+            offsetString = `(UTC${offsetHours})`; // Negative sign is included by offsetHours
+        }
+
+        clockElement.textContent = `${formattedTime} ${offsetString}`;
     }
 }
 setInterval(updateUtcClock, 1000);
-// updateUtcClock(); // Call once immediately if not relying on DOMContentLoaded for initial call
+// updateUtcClock(); // Initial call is at the end of the script
 
 // --- Log Appending ---
 function appendLog(logAreaId, message, detail, type = 'info', specificStatusEl = null) {

--- a/templates/admin/backup_settings.html
+++ b/templates/admin/backup_settings.html
@@ -59,7 +59,7 @@
 <div class="container mt-4">
     <h1>{{ _('Backup & Restore - General Settings') }}</h1>
     <hr>
-    <p>{{ _('Current UTC Time:') }} <span id="utc-clock">Loading...</span></p>
+    <p>{{ _('Current Server Time:') }} <span id="utc-clock" data-offset="{{ global_time_offset_hours | default(0) }}">Loading...</span></p>
     <hr>
 
     <!-- Global Time Offset Configuration Card -->


### PR DESCRIPTION
This commit modifies the clock on the Admin > Backup & Restore > General Settings page to reflect the configured global time offset.

Changes:
- The label "Current UTC Time:" is changed to "Current Server Time:".
- The `global_time_offset_hours` value (from BookingSettings) is passed to the `admin/backup_settings.html` template and embedded as a `data-offset` attribute in the clock's `<span>` element.
- The JavaScript function `updateUtcClock` in `static/js/admin_backup_common.js` has been updated to:
    - Read the `data-offset` attribute.
    - Calculate the displayed time by adding the offset to the current UTC time.
    - Format the displayed time as `YYYY-MM-DD HH:MM:SS (UTC+X)` or `(UTC-X)` or `(UTC)` based on the offset value.

This aligns the clock display on this page with your feedback to show time adjusted by the global offset.