### PR TITLE
I've updated the calendar booking details display format.

### DIFF
--- a/static/js/calendar.js
+++ b/static/js/calendar.js
@@ -487,7 +487,7 @@ document.addEventListener('DOMContentLoaded', () => {
                             if (endTimeUTC && endTimeUTC !== startTimeUTC) {
                                 fullTimeString += ` - ${endTimeUTC}`;
                             }
-                            fullTimeString += ' UTC';
+                            // fullTimeString += ' UTC'; // Removed ' UTC'
                         }
 
                         if (fullTimeString) {
@@ -497,6 +497,10 @@ document.addEventListener('DOMContentLoaded', () => {
                             }
                             eventHtml += `<br>${displayTime}`;
                         }
+                    }
+                    // Add resource name
+                    if (arg.event.extendedProps && arg.event.extendedProps.resource_name) {
+                        eventHtml += `<br><b>${arg.event.extendedProps.resource_name}</b>`;
                     }
                     return { html: eventHtml };
                 }


### PR DESCRIPTION
The booking details on the calendar will now show: <b>{title}</b>
{booking time (without UTC at the back)}
<b>{resource name}</b>

This change modifies the eventContent function in static/js/calendar.js to include the resource name and remove "UTC" from the time display.