### PR TITLE
fix: Ensure booking slots display as local time, independent of globa…

### DIFF
--- a/static/js/calendar.js
+++ b/static/js/calendar.js
@@ -3,6 +3,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const calendarEl = document.getElementById('calendar');
     const calendarStatusFilterSelect = document.getElementById('calendar-status-filter'); // Changed ID
 
+    const calendarElementForOffset = document.getElementById('calendar');
+    const offsetHours = calendarElementForOffset ? parseInt(calendarElementForOffset.dataset.globalOffset) || 0 : 0;
+
     let unavailableDates = []; // Store fetched unavailable dates
 
     // Modal elements
@@ -73,9 +76,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
             // Define the predefined slots
             const predefinedSlots = [
-                { text: "08:00 - 12:00 UTC", value: "08:00,12:00" },
-                { text: "13:00 - 17:00 UTC", value: "13:00,17:00" },
-                { text: "08:00 - 17:00 UTC", value: "08:00,17:00" }
+                { text: "08:00 - 12:00", value: "08:00,12:00" }, // Removed UTC
+                { text: "13:00 - 17:00", value: "13:00,17:00" }, // Removed UTC
+                { text: "08:00 - 17:00", value: "08:00,17:00" }  // Removed UTC
             ];
 
             slotsSelect.innerHTML = '<option value="">-- Select a time slot --</option>'; // Reset
@@ -291,14 +294,18 @@ document.addEventListener('DOMContentLoaded', () => {
                 const cebmBookingDateInput = document.getElementById('cebm-booking-date');
 
                 if (info.event.start) {
-                    const startDate = new Date(info.event.start); // Local representation of event's start
-                    const year = startDate.getFullYear();
-                    const month = (startDate.getMonth() + 1).toString().padStart(2, '0');
-                    const day = startDate.getDate().toString().padStart(2, '0');
+                    const originalEventStartForModal = new Date(info.event.start); // This is a UTC Date object
+
+                    // For date input, use original UTC date parts
+                    const year = originalEventStartForModal.getUTCFullYear();
+                    const month = (originalEventStartForModal.getUTCMonth() + 1).toString().padStart(2, '0');
+                    const day = originalEventStartForModal.getUTCDate().toString().padStart(2, '0');
                     cebmBookingDateInput.value = `${year}-${month}-${day}`;
 
-                    const startHours = info.event.start.getUTCHours().toString().padStart(2, '0');
-                    const startMinutes = info.event.start.getUTCMinutes().toString().padStart(2, '0');
+                    // For selectedStartTimeHHMM, use offset-adjusted time
+                    const displayEventStartForModal = new Date(originalEventStartForModal.getTime() + offsetHours * 60 * 60 * 1000);
+                    const startHours = displayEventStartForModal.getUTCHours().toString().padStart(2, '0');
+                    const startMinutes = displayEventStartForModal.getUTCMinutes().toString().padStart(2, '0');
                     const selectedStartTimeHHMM = `${startHours}:${startMinutes}`;
 
                     fetchAndDisplayAvailableSlots(info.event.extendedProps.resource_id, cebmBookingDateInput.value, selectedStartTimeHHMM);
@@ -469,25 +476,30 @@ document.addEventListener('DOMContentLoaded', () => {
                     let eventHtml = `<b>${displayTitle}</b>`;
 
                     if (arg.event.start) {
-                        const startHours = arg.event.start.getUTCHours().toString().padStart(2, '0');
-                        const startMinutes = arg.event.start.getUTCMinutes().toString().padStart(2, '0');
-                        const startTimeUTC = `${startHours}:${startMinutes}`;
+                        const originalEventStart = arg.event.start; // UTC Date object
+                        const displayEventStart = new Date(originalEventStart.getTime() + offsetHours * 60 * 60 * 1000);
 
-                        let endTimeUTC = '';
+                        const startHours = displayEventStart.getUTCHours().toString().padStart(2, '0');
+                        const startMinutes = displayEventStart.getUTCMinutes().toString().padStart(2, '0');
+                        const startTimeDisplay = `${startHours}:${startMinutes}`;
+
+                        let endTimeDisplay = '';
                         if (arg.event.end) {
-                            const endHours = arg.event.end.getUTCHours().toString().padStart(2, '0');
-                            const endMinutes = arg.event.end.getUTCMinutes().toString().padStart(2, '0');
-                            endTimeUTC = `${endHours}:${endMinutes}`;
+                            const originalEventEnd = arg.event.end; // UTC Date object
+                            const displayEventEnd = new Date(originalEventEnd.getTime() + offsetHours * 60 * 60 * 1000);
+                            const endHours = displayEventEnd.getUTCHours().toString().padStart(2, '0');
+                            const endMinutes = displayEventEnd.getUTCMinutes().toString().padStart(2, '0');
+                            endTimeDisplay = `${endHours}:${endMinutes}`;
                         }
 
                         let fullTimeString = '';
                         // Construct the time string only if it's not an all-day event or if time is not midnight
-                        if (!arg.event.allDay || (startTimeUTC !== '00:00' || (endTimeUTC && endTimeUTC !== '00:00'))) {
-                            fullTimeString = startTimeUTC;
-                            if (endTimeUTC && endTimeUTC !== startTimeUTC) {
-                                fullTimeString += ` - ${endTimeUTC}`;
+                        if (!arg.event.allDay || (startTimeDisplay !== '00:00' || (endTimeDisplay && endTimeDisplay !== '00:00'))) {
+                            fullTimeString = startTimeDisplay;
+                            if (endTimeDisplay && endTimeDisplay !== startTimeDisplay) {
+                                fullTimeString += ` - ${endTimeDisplay}`;
                             }
-                            fullTimeString += ' UTC';
+                            // Removed ' UTC' suffix
                         }
 
                         if (fullTimeString) {

--- a/static/js/my_bookings.js
+++ b/static/js/my_bookings.js
@@ -57,6 +57,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
 
     function createBookingCardElement(booking, checkInOutEnabled, allow_check_in_without_pin) {
+        const bookingsListElement = document.getElementById('my-bookings-list');
+        const offsetHours = parseInt(bookingsListElement.dataset.globalOffset) || 0;
+
         if (!bookingItemTemplate) {
             console.error("Booking item template not found!");
             return document.createElement('div'); // Return an empty div or handle error appropriately
@@ -81,13 +84,22 @@ document.addEventListener('DOMContentLoaded', () => {
         const resourceSpan = bookingCardDiv.querySelector('.resource-name-value');
         if (resourceSpan) resourceSpan.textContent = booking.resource_name || 'N/A';
 
-        const startDate = new Date(booking.start_time);
-        const endDate = new Date(booking.end_time);
+        const startDate = new Date(booking.start_time); // booking.start_time is ISO UTC
+        const endDate = new Date(booking.end_time);   // booking.end_time is ISO UTC
+
+        // Apply offset for time display
+        const displayStartDate = new Date(startDate.getTime() + offsetHours * 60 * 60 * 1000);
+        const displayEndDate = new Date(endDate.getTime() + offsetHours * 60 * 60 * 1000);
+
+        // Date part should be based on original UTC date to correctly represent the slot's calendar day
         const optionsDate = { weekday: 'short', year: 'numeric', month: 'short', day: 'numeric', timeZone: 'UTC' };
         const formattedDate = startDate.toLocaleDateString(undefined, optionsDate);
+
+        // Time part uses the displayStartDate/EndDate, but still formatted *as if* it's UTC
+        // because the offset has already been baked into its millisecond value.
         const optionsTime = { hour: '2-digit', minute: '2-digit', hour12: false, timeZone: 'UTC' };
-        const formattedStartTime = startDate.toLocaleTimeString(undefined, optionsTime);
-        const formattedEndTime = endDate.toLocaleTimeString(undefined, optionsTime);
+        const formattedStartTime = displayStartDate.toLocaleTimeString(undefined, optionsTime);
+        const formattedEndTime = displayEndDate.toLocaleTimeString(undefined, optionsTime);
 
         const dateSpan = bookingCardDiv.querySelector('.booking-date-value');
         if (dateSpan) dateSpan.textContent = formattedDate;

--- a/templates/calendar.html
+++ b/templates/calendar.html
@@ -16,7 +16,7 @@
     </select>
 </div>
 
-<div id="calendar"></div>
+<div id="calendar" data-global-offset="{{ global_time_offset_hours | default(0) }}"></div>
 
 <div id="calendar-edit-booking-modal" class="modal" style="display:none;" role="dialog" aria-modal="true" aria-labelledby="cebm-title">
     <div class="modal-content">

--- a/templates/index.html
+++ b/templates/index.html
@@ -14,8 +14,8 @@
                         <li>
                             <strong>{{ _('Resource:') }}</strong> {{ booking.resource_booked.name if booking.resource_booked else booking.title }}<br>
                             <strong>{{ _('Title:') }}</strong> {{ booking.title or _('N/A') }}<br>
-                            <strong>{{ _('Start:') }}</strong> {{ booking.start_time.strftime('%Y-%m-%d %H:%M') }}<br>
-                            <strong>{{ _('End:') }}</strong> {{ booking.end_time.strftime('%Y-%m-%d %H:%M') }}
+                            <strong>{{ _('Start:') }}</strong> {{ booking.start_time.strftime('%Y-%m-%d') }} {{ booking.start_time | display_local_slot_time(global_time_offset_hours) }}<br>
+                            <strong>{{ _('End:') }}</strong> {{ booking.end_time.strftime('%Y-%m-%d') }} {{ booking.end_time | display_local_slot_time(global_time_offset_hours) }}
                         </li>
                     {% endfor %}
                 </ul>

--- a/templates/my_bookings.html
+++ b/templates/my_bookings.html
@@ -52,7 +52,7 @@
         </div> -->
     </div>
 
-    <div id="my-bookings-list">
+    <div id="my-bookings-list" data-global-offset="{{ global_time_offset_hours | default(0) }}">
         <div id="upcoming-bookings-section">
             <h2>{{ _('Upcoming Bookings') }}</h2>
 			<div class="form-check form-switch mb-2">

--- a/utils.py
+++ b/utils.py
@@ -1811,3 +1811,33 @@ def get_current_effective_time():
     utc_now = datetime.now(timezone.utc)
     effective_time = utc_now + timedelta(hours=offset_hours)
     return effective_time
+
+def format_display_time_with_offset(utc_dt, offset_hours_int):
+    """
+    Formats a UTC datetime object to a HH:MM string, adjusted by an offset.
+    Intended for use as a Jinja filter.
+    """
+    if not isinstance(utc_dt, datetime):
+        return utc_dt # Return as is if not a datetime object
+    try:
+        # Ensure offset_hours_int is an integer
+        offset_val = int(offset_hours_int)
+        # Apply offset
+        # Ensure utc_dt is timezone-aware (UTC) before adding offset
+        if utc_dt.tzinfo is None:
+            aware_utc_dt = utc_dt.replace(tzinfo=timezone.utc)
+        else:
+            aware_utc_dt = utc_dt.astimezone(timezone.utc)
+
+        display_dt = aware_utc_dt + timedelta(hours=offset_val)
+        # Format as HH:MM
+        return display_dt.strftime('%H:%M')
+    except (ValueError, TypeError) as e:
+        # Fallback if offset is invalid or utc_dt is problematic
+        # Consider logging the error: current_app.logger.warning(f"Error in time filter: {e}")
+        # Ensure utc_dt is timezone-aware for consistent fallback formatting
+        if utc_dt.tzinfo is None:
+            aware_utc_dt = utc_dt.replace(tzinfo=timezone.utc)
+        else:
+            aware_utc_dt = utc_dt.astimezone(timezone.utc)
+        return aware_utc_dt.strftime('%H:%M') # Default to UTC HH:MM


### PR DESCRIPTION
…l offset

This commit corrects the display of booking start and end times across user-facing pages (My Bookings, Calendar, Index/Homepage) to ensure they always show the intended local slot time (e.g., "13:00-17:00") regardless of the configured `global_time_offset_hours`.

The `global_time_offset_hours` is correctly used for:
- The "Current Server Time" clock.
- Converting your input local slot times to UTC for storage.
- Internal server logic needing an "effective current time".

Previously, booking times were displayed as their raw stored UTC values. This fix ensures they are converted back to the intended local slot time for display.

Changes:
- `routes/ui.py`: Routes for My Bookings, Calendar, and Index pages now fetch and pass `global_time_offset_hours` to their templates.
- `templates/my_bookings.html` & `templates/calendar.html`: Embed `global_time_offset_hours` via a `data-global-offset` attribute for JavaScript access.
- `static/js/my_bookings.js`: `createBookingCardElement` now reads the offset and applies it to UTC booking times before formatting HH:MM for display.
- `static/js/calendar.js`: Event time displays (in grid and modal) now read the offset and apply it to UTC event times before formatting HH:MM. Predefined slot labels in the modal are updated to reflect local times.
- `utils.py`: Added `format_display_time_with_offset` helper function for a Jinja filter to convert UTC datetimes to local slot time strings (HH:MM). (Note: Filter registration is a manual step in Flask setup).
- `templates/index.html`: Upcoming booking times now use the new Jinja filter logic to display local slot times.