### PR TITLE
Fix: Serialize datetime.time objects in api_admin_get_table_data

### DIFF
--- a/routes/api_system.py
+++ b/routes/api_system.py
@@ -1001,7 +1001,9 @@ def api_admin_get_table_data(table_name: str):
             record_dict_raw = row._asdict()
             record_dict_final = {}
             for col_name, val in record_dict_raw.items():
-                if isinstance(val, datetime):
+                if isinstance(val, datetime): # This handles datetime.datetime
+                    record_dict_final[col_name] = val.isoformat()
+                elif isinstance(val, time): # Add this condition for datetime.time
                     record_dict_final[col_name] = val.isoformat()
                 elif isinstance(val, uuid.UUID):
                     record_dict_final[col_name] = str(val)


### PR DESCRIPTION
The api_admin_get_table_data endpoint was failing when encountering a datetime.time object in table data, as it's not directly JSON serializable.

This commit updates the serialization logic to check for datetime.time instances and converts them to their ISO 8601 string representation (HH:MM:SS) before returning the JSON response. This resolves the TypeError and allows data containing time objects to be fetched correctly through the admin table view.