### PR TITLE
I'm going to update the upcoming bookings logic.

### DIFF
--- a/routes/api_bookings.py
+++ b/routes/api_bookings.py
@@ -85,7 +85,7 @@ def _fetch_user_bookings_data(user_name, booking_type, page, per_page, status_fi
             check_in_window_start_local_naive = effective_check_in_base_time_local_naive - timedelta(minutes=check_in_minutes_before)
             check_in_window_end_local_naive = effective_check_in_base_time_local_naive + timedelta(minutes=check_in_minutes_after)
 
-            is_upcoming = booking_start_local_naive >= effective_now_local_naive
+            is_upcoming = booking.end_time > effective_now_local_naive
 
             if (booking_type == 'upcoming' and not is_upcoming) or \
                (booking_type == 'past' and is_upcoming):


### PR DESCRIPTION
I'll modify the definition of an upcoming booking in the `_fetch_user_bookings_data` function in `routes/api_bookings.py`.

A booking is now considered 'upcoming' if its end time is after the current effective time, rather than its start time. This aligns with your request for how upcoming bookings should be displayed on the 'My Bookings' page.