### PR TITLE
Refine check-in window logic and clean up logs

### DIFF
--- a/routes/api_bookings.py
+++ b/routes/api_bookings.py
@@ -81,7 +81,7 @@ def _fetch_user_bookings_data(user_name, booking_type, page, per_page, status_fi
             booking_start_local_naive = booking.start_time
 
             # Check-in window calculation in local naive time
-            effective_check_in_base_time_local_naive = booking_start_local_naive + timedelta(hours=past_booking_adjustment_hours)
+            effective_check_in_base_time_local_naive = booking_start_local_naive
             check_in_window_start_local_naive = effective_check_in_base_time_local_naive - timedelta(minutes=check_in_minutes_before)
             check_in_window_end_local_naive = effective_check_in_base_time_local_naive + timedelta(minutes=check_in_minutes_after)
 
@@ -92,19 +92,19 @@ def _fetch_user_bookings_data(user_name, booking_type, page, per_page, status_fi
                 continue # Skip if not matching the requested type
 
             # Log variables for can_check_in calculation
-            logger.info(f"[Booking ID: {booking.id}] Check-in Calc: booking.status = {booking.status}")
-            logger.info(f"[Booking ID: {booking.id}] Check-in Calc: booking.checked_in_at = {booking.checked_in_at}")
-            logger.info(f"[Booking ID: {booking.id}] Check-in Calc: booking_start_local_naive = {booking_start_local_naive}")
-            logger.info(f"[Booking ID: {booking.id}] Check-in Calc: past_booking_adjustment_hours = {past_booking_adjustment_hours}")
-            logger.info(f"[Booking ID: {booking.id}] Check-in Calc: effective_check_in_base_time_local_naive = {effective_check_in_base_time_local_naive}")
-            logger.info(f"[Booking ID: {booking.id}] Check-in Calc: check_in_minutes_before = {check_in_minutes_before}")
-            logger.info(f"[Booking ID: {booking.id}] Check-in Calc: check_in_minutes_after = {check_in_minutes_after}")
-            logger.info(f"[Booking ID: {booking.id}] Check-in Calc: check_in_window_start_local_naive = {check_in_window_start_local_naive}")
-            logger.info(f"[Booking ID: {booking.id}] Check-in Calc: check_in_window_end_local_naive = {check_in_window_end_local_naive}")
-            logger.info(f"[Booking ID: {booking.id}] Check-in Calc: effective_now_local_naive = {effective_now_local_naive}")
+            # logger.info(f"[Booking ID: {booking.id}] Check-in Calc: booking.status = {booking.status}")
+            # logger.info(f"[Booking ID: {booking.id}] Check-in Calc: booking.checked_in_at = {booking.checked_in_at}")
+            # logger.info(f"[Booking ID: {booking.id}] Check-in Calc: booking_start_local_naive = {booking_start_local_naive}")
+            # logger.info(f"[Booking ID: {booking.id}] Check-in Calc: past_booking_adjustment_hours = {past_booking_adjustment_hours}")
+            # logger.info(f"[Booking ID: {booking.id}] Check-in Calc: effective_check_in_base_time_local_naive = {effective_check_in_base_time_local_naive}")
+            # logger.info(f"[Booking ID: {booking.id}] Check-in Calc: check_in_minutes_before = {check_in_minutes_before}")
+            # logger.info(f"[Booking ID: {booking.id}] Check-in Calc: check_in_minutes_after = {check_in_minutes_after}")
+            # logger.info(f"[Booking ID: {booking.id}] Check-in Calc: check_in_window_start_local_naive = {check_in_window_start_local_naive}")
+            # logger.info(f"[Booking ID: {booking.id}] Check-in Calc: check_in_window_end_local_naive = {check_in_window_end_local_naive}")
+            # logger.info(f"[Booking ID: {booking.id}] Check-in Calc: effective_now_local_naive = {effective_now_local_naive}")
 
             window_comparison_result = (check_in_window_start_local_naive <= effective_now_local_naive <= check_in_window_end_local_naive)
-            logger.info(f"[Booking ID: {booking.id}] Check-in Calc: window_comparison_result = {window_comparison_result}")
+            # logger.info(f"[Booking ID: {booking.id}] Check-in Calc: window_comparison_result = {window_comparison_result}")
 
             can_check_in = (
                 enable_check_in_out and
@@ -112,7 +112,7 @@ def _fetch_user_bookings_data(user_name, booking_type, page, per_page, status_fi
                 booking.status == 'approved' and
                 window_comparison_result
             )
-            logger.info(f"[Booking ID: {booking.id}] Check-in Calc: FINAL can_check_in = {can_check_in}")
+            # logger.info(f"[Booking ID: {booking.id}] Check-in Calc: FINAL can_check_in = {can_check_in}")
 
             display_check_in_token = None
             if booking.check_in_token and booking.checked_in_at is None and booking.status == 'approved':


### PR DESCRIPTION
This commit addresses your feedback on how the check-in window should be calculated for existing bookings on the 'My Bookings' page.

- I modified `_fetch_user_bookings_data` in `routes/api_bookings.py` so that the `past_booking_time_adjustment_hours` setting no longer shifts the effective start time for check-in window calculations. The check-in window is now always based on the booking's actual start time.
- The `past_booking_time_adjustment_hours` setting will now only affect the validation of new booking creation times (how far in the past a booking can be made when general past bookings are disabled).
- I commented out verbose diagnostic logging previously added for the check-in window calculation, as the root cause was identified and addressed. Essential logging for the `enable_check_in_out` flag remains.