### PR TITLE
Debug: Add detailed time logging for booking updates

### DIFF
--- a/routes/api_bookings.py
+++ b/routes/api_bookings.py
@@ -1051,6 +1051,15 @@ def update_booking_by_user(booking_id):
             # old_start_time and old_end_time from DB are naive venue local (after migration)
             # parsed_new_start_time and parsed_new_end_time are now also naive venue local
 
+            current_app.logger.info(f"[API PUT /api/bookings/{booking_id}] ---- Time Change Check Debug ----")
+            current_app.logger.info(f"[API PUT /api/bookings/{booking_id}] Original DB old_start_time (naive venue local): {old_start_time.isoformat() if old_start_time else 'None'}")
+            current_app.logger.info(f"[API PUT /api/bookings/{booking_id}] Original DB old_end_time (naive venue local): {old_end_time.isoformat() if old_end_time else 'None'}")
+            current_app.logger.info(f"[API PUT /api/bookings/{booking_id}] Incoming new_start_iso from request: {new_start_iso}")
+            current_app.logger.info(f"[API PUT /api/bookings/{booking_id}] Incoming new_end_iso from request: {new_end_iso}")
+            current_app.logger.info(f"[API PUT /api/bookings/{booking_id}] current_offset_hours: {current_offset_hours}")
+            current_app.logger.info(f"[API PUT /api/bookings/{booking_id}] Parsed new_start_time (naive venue local): {parsed_new_start_time.isoformat() if parsed_new_start_time else 'None'}")
+            current_app.logger.info(f"[API PUT /api/bookings/{booking_id}] Parsed new_end_time (naive venue local): {parsed_new_end_time.isoformat() if parsed_new_end_time else 'None'}")
+            current_app.logger.info(f"[API PUT /api/bookings/{booking_id}] ---- End Time Change Check Debug ----")
             time_changed = parsed_new_start_time != old_start_time or parsed_new_end_time != old_end_time
 
             if time_changed and resource.is_under_maintenance:


### PR DESCRIPTION
Adds extensive logging to the `update_booking_by_user` function in `routes/api_bookings.py`. This logging captures the state of various time-related variables (original database times, incoming request times, offset hours, and parsed/converted new times) just before the system checks if a time change has actually occurred.

This is intended to help diagnose an issue where updates are incorrectly reported as "No changes supplied" even when the date/time appears to have been modified by you.