### PR TITLE
Debug: Add specific boolean comparison logging for time changes

### DIFF
--- a/routes/api_bookings.py
+++ b/routes/api_bookings.py
@@ -1060,7 +1060,16 @@ def update_booking_by_user(booking_id):
             current_app.logger.info(f"[API PUT /api/bookings/{booking_id}] Parsed new_start_time (naive venue local): {parsed_new_start_time.isoformat() if parsed_new_start_time else 'None'}")
             current_app.logger.info(f"[API PUT /api/bookings/{booking_id}] Parsed new_end_time (naive venue local): {parsed_new_end_time.isoformat() if parsed_new_end_time else 'None'}")
             current_app.logger.info(f"[API PUT /api/bookings/{booking_id}] ---- End Time Change Check Debug ----")
+
+            current_app.logger.info(f"[API PUT /api/bookings/{booking_id}] --- Detailed Time Comparison ---")
+            current_app.logger.info(f"[API PUT /api/bookings/{booking_id}] Comparing old_start_time: {old_start_time.isoformat() if old_start_time else 'None'} (type: {type(old_start_time)}) with parsed_new_start_time: {parsed_new_start_time.isoformat() if parsed_new_start_time else 'None'} (type: {type(parsed_new_start_time)})")
+            current_app.logger.info(f"[API PUT /api/bookings/{booking_id}] Result of (parsed_new_start_time != old_start_time): {parsed_new_start_time != old_start_time if parsed_new_start_time and old_start_time else 'Comparison N/A'}")
+
+            current_app.logger.info(f"[API PUT /api/bookings/{booking_id}] Comparing old_end_time: {old_end_time.isoformat() if old_end_time else 'None'} (type: {type(old_end_time)}) with parsed_new_end_time: {parsed_new_end_time.isoformat() if parsed_new_end_time else 'None'} (type: {type(parsed_new_end_time)})")
+            current_app.logger.info(f"[API PUT /api/bookings/{booking_id}] Result of (parsed_new_end_time != old_end_time): {parsed_new_end_time != old_end_time if parsed_new_end_time and old_end_time else 'Comparison N/A'}")
             time_changed = parsed_new_start_time != old_start_time or parsed_new_end_time != old_end_time
+            current_app.logger.info(f"[API PUT /api/bookings/{booking_id}] Final time_changed value: {time_changed}")
+            current_app.logger.info(f"[API PUT /api/bookings/{booking_id}] --- End Detailed Time Comparison ---")
 
             if time_changed and resource.is_under_maintenance:
                 maintenance_active = False


### PR DESCRIPTION
This commit adds highly specific logging in `update_booking_by_user` (routes/api_bookings.py) around the datetime comparison that determines if a booking's time has changed.

It logs:
- The types and values of old and new start/end times.
- The direct boolean result of comparing old vs. new start time.
- The direct boolean result of comparing old vs. new end time.
- The final boolean value of the `time_changed` variable.

This is to further diagnose why updates might be reported as "No changes supplied" when time values appear to differ in logs.