### PR TITLE
Fix: Ensure calendar edit modal uses local date

### DIFF
--- a/static/js/calendar.js
+++ b/static/js/calendar.js
@@ -293,12 +293,12 @@ document.addEventListener('DOMContentLoaded', () => {
                 const cebmBookingDateInput = document.getElementById('cebm-booking-date');
 
                 if (info.event.start) {
-                    const originalEventStartForDate = new Date(info.event.start); // UTC Date object from FullCalendar
+                    const originalEventStartForDate = new Date(info.event.start); // This is a local Date object
 
-                    // For date input, use original UTC date parts
-                    const year = originalEventStartForDate.getUTCFullYear();
-                    const month = (originalEventStartForDate.getUTCMonth() + 1).toString().padStart(2, '0');
-                    const day = originalEventStartForDate.getUTCDate().toString().padStart(2, '0');
+                    // For date input, use local date parts
+                    const year = originalEventStartForDate.getFullYear();
+                    const month = (originalEventStartForDate.getMonth() + 1).toString().padStart(2, '0'); // getMonth() is 0-indexed
+                    const day = originalEventStartForDate.getDate().toString().padStart(2, '0');
                     cebmBookingDateInput.value = `${year}-${month}-${day}`;
 
                     let selectedStartTimeHHMM;


### PR DESCRIPTION
Corrected the population of the date input field in the booking edit modal on the calendar page (`static/js/calendar.js`).

Previously, the date field was populated using UTC components of the event's start time. This change modifies the logic to use the local date components (`getFullYear()`, `getMonth()`, `getDate()`) from the event's start `Date` object.

Since FullCalendar's `timeZone` is set to 'local', `event.start` is a local `Date` object. Using its local components ensures that the date displayed in the modal accurately reflects the event's local date, improving consistency with the naive local time handling philosophy.