### PR TITLE
Fix: Resolve ReferenceError in FullCalendar event update

### DIFF
--- a/static/js/calendar.js
+++ b/static/js/calendar.js
@@ -209,9 +209,10 @@ document.addEventListener('DOMContentLoaded', () => {
             // Update the event on the calendar
             if (calendarEventToUpdate) {
                 calendarEventToUpdate.setProp('title', title);
-                // Use the localStartDate and localEndDate, FullCalendar will handle timezone conversion
-                calendarEventToUpdate.setStart(localStartDate.toISOString());
-                calendarEventToUpdate.setEnd(localEndDate.toISOString());
+                // Use the naiveLocalISOStart and naiveLocalISOEnd, FullCalendar (with timeZone: 'local')
+                // will interpret these as local time.
+                calendarEventToUpdate.setStart(naiveLocalISOStart);
+                calendarEventToUpdate.setEnd(naiveLocalISOEnd);
             }
             // calendarInstance.refetchEvents(); // Corrected, but the original instruction implies this was a standalone line to change
 


### PR DESCRIPTION
I corrected a `ReferenceError` in the `saveBookingChanges` function within `static/js/calendar.js`. The error occurred when attempting to update the event on the FullCalendar instance using `setStart` and `setEnd` methods with undefined variables (`localStartDate` and `localEndDate`).

These methods are now correctly called with `naiveLocalISOStart` and `naiveLocalISOEnd`, which are defined naive local ISO time strings. FullCalendar, configured with `timeZone: 'local'`, will interpret these strings correctly as local times.

This resolves the client-side JavaScript error that occurred after a booking was successfully saved via the edit modal, ensuring a smoother user experience for you. The validation line for checking start/end time order was also confirmed to be using the correct variables.