### PR TITLE
style: Use div instead of p for modal read-only details

### DIFF
--- a/templates/calendar.html
+++ b/templates/calendar.html
@@ -25,10 +25,10 @@
         <p>{{ _('Resource:') }} <strong id="cebm-resource-name">N/A</strong></p>
 
         <!-- Read-only details -->
-        <p>{{ _('Resource name:') }} <strong id="cebm-ro-resource-name">N/A</strong></p>
-        <p>{{ _('Location:') }} <strong id="cebm-ro-location-floor">N/A</strong></p>
-        <p>{{ _('Booking Title:') }} <strong id="cebm-ro-booking-title">N/A</strong></p>
-        <p>{{ _('Date:') }} <strong id="cebm-ro-datetime-range">N/A</strong></p>
+        <div>{{ _('Resource name:') }} <strong id="cebm-ro-resource-name">N/A</strong></div>
+        <div>{{ _('Location:') }} <strong id="cebm-ro-location-floor">N/A</strong></div>
+        <div>{{ _('Booking Title:') }} <strong id="cebm-ro-booking-title">N/A</strong></div>
+        <div>{{ _('Date:') }} <strong id="cebm-ro-datetime-range">N/A</strong></div>
 
         <input type="hidden" id="cebm-booking-id">
         <input type="hidden" id="cebm-resource-id">


### PR DESCRIPTION
I changed the HTML tags for the read-only booking information (Resource Name, Location, Booking Title, Date) in the calendar's edit modal from <p> to <div>.

This change is intended to reduce the default vertical spacing that paragraph tags typically have, leading to a more compact display of these details, as per your feedback.

- I modified `templates/calendar.html` to replace <p> with <div> for the specified elements.
- No JavaScript changes were necessary as element selection relies on IDs, which remain unchanged.