### PR TITLE
Refactor: Refine admin booking statuses and system cancellation logic

### DIFF
--- a/routes/admin_api_bookings.py
+++ b/routes/admin_api_bookings.py
@@ -346,8 +346,22 @@ def update_booking_status(booking_id):
     new_status = data['new_status']
     current_status = booking.status
 
-    ALLOWED_STATUSES = ['pending', 'approved', 'rejected', 'cancelled', 'checked_in', 'completed', 'cancelled_by_user', 'cancelled_by_admin', 'no_show', 'awaiting_payment', 'payment_failed', 'confirmed_pending_payment', 'rescheduled', 'awaiting_confirmation', 'under_review', 'on_hold', 'archived', 'expired', 'draft', 'system_cancelled', 'error', 'pending_approval', 'pending_resource_confirmation', 'active', 'inactive', 'user_confirmed', 'admin_confirmed', 'auto_approved', 'auto_cancelled', 'payment_pending', 'payment_received', 'fulfillment_pending', 'fulfillment_complete', 'action_required', 'dispute_raised', 'dispute_resolved', 'refund_pending', 'refund_completed', 'partially_refunded', 'voided', 'pending_cancellation', 'cancellation_requested', 'attended', 'absent', 'tentative', 'waitlisted', 'blocked', 'requires_modification', 'pending_reschedule', 'reschedule_confirmed', 'reschedule_declined', 'pending_payment_confirmation', 'payment_disputed', 'subscription_active', 'subscription_cancelled', 'subscription_ended', 'subscription_pending', 'trial', 'past_due']
-    # Extended from original example: 'approved', 'pending', 'checked_in', 'completed', 'cancelled'
+    ALLOWED_STATUSES = [
+        'pending',
+        'approved',
+        'rejected',
+        'cancelled',
+        'checked_in',
+        'completed',
+        'cancelled_by_user', # Retaining this as it's a common scenario, even if not explicitly set elsewhere in *these* files
+        'cancelled_by_admin',
+        'cancelled_admin_acknowledged', # Follow-up to cancelled_by_admin
+        'system_cancelled_no_checkin', # Set by scheduler, admin might need to view/filter
+        'confirmed', # Used in conflict/quota logic
+        'no_show', # Common manual admin status
+        'on_hold', # Useful manual admin status
+        'under_review' # Useful manual admin status
+    ]
 
     if new_status not in ALLOWED_STATUSES:
         return jsonify({'error': 'Invalid new_status provided.'}), 400

--- a/utils.py
+++ b/utils.py
@@ -1658,7 +1658,7 @@ def check_resources_availability_for_user(resources_list: list[Resource], target
                 Booking.resource_id == resource.id,
                 Booking.start_time < slot_end_dt,
                 Booking.end_time > slot_start_dt,
-                Booking.status.notin_(['cancelled', 'rejected'])
+                Booking.status.notin_(['cancelled', 'rejected', 'system_cancelled_no_checkin', 'cancelled_by_system'])
             ).all()
 
             is_generally_booked = bool(general_bookings_overlap)


### PR DESCRIPTION
This commit addresses two main points based on your feedback:

1.  **Refined Admin-Settable Booking Statuses:**
    - The `ALLOWED_STATUSES` list in the `update_booking_status` function (`routes/admin_api_bookings.py`) has been significantly shortened.
    - It now only includes statuses that are actively used in workflows (user, admin, scheduler) or are considered essential for manual administrative actions (e.g., 'pending', 'approved', 'rejected', 'cancelled', 'checked_in', 'completed', 'cancelled_by_admin', 'system_cancelled_no_checkin', 'confirmed', 'no_show', 'on_hold', 'under_review').
    - This prevents administrators from setting statuses that are obscure, deprecated, or not relevant to current application logic.

2.  **Ensured System Cancellations Free Resources:**
    - Modified the `check_resources_availability_for_user` function in `utils.py`.
    - The function now correctly excludes bookings with system cancellation statuses (specifically 'system_cancelled_no_checkin' and the preemptively added 'cancelled_by_system') when determining general resource availability.
    - This ensures that when a booking is automatically cancelled by the system (e.g., due to no check-in), the underlying resource slot is properly shown as available for new bookings in UI components that use this utility function.
    - The primary booking conflict check in `routes/api_bookings.py` already correctly handled this by not including system cancellation statuses in its `active_conflict_statuses` list.

These changes improve the clarity of booking statuses for administrators and ensure that automated system cancellations correctly release resources for future use.