### PR TITLE
feat: Enhance Flatpickr disable date logging

### DIFF
--- a/static/js/new_booking_map.js
+++ b/static/js/new_booking_map.js
@@ -115,10 +115,9 @@ document.addEventListener('DOMContentLoaded', function () {
                         }
                         const todayStr = getTodayDateString();
                         const isPastFivePMToday = dateStr === todayStr && isPastFivePM();
-                        // Log if it's being disabled by the 5 PM rule
-                        // if (isPastFivePMToday) {
-                        //     console.log(`[Debug] Flatpickr disabling ${dateStr} due to 5 PM rule.`);
-                        // }
+                        if (isPastFivePMToday) {
+                            console.log(`[Debug] Flatpickr disabling date ${dateStr} because it is considered 'today' (todayStr: ${todayStr}) and current time is past 5 PM.`);
+                        }
                         return isPastFivePMToday;
                     }
                 ],


### PR DESCRIPTION
Adds a more specific console.log message in the Flatpickr disable callback in new_booking_map.js.

This new log fires when a date is disabled specifically due to the 'today and past 5 PM' rule. It includes the date being checked and the string value of what the script considers 'today' at that moment.

This will aid in debugging scenarios where a date is unexpectedly disabled, by clarifying if the 'today past 5 PM' rule is the cause, especially in cases where your system date might be in question.