### PR TITLE
feat: Add /api/system/today endpoint

### DIFF
--- a/routes/api_system.py
+++ b/routes/api_system.py
@@ -124,6 +124,29 @@ def get_audit_logs():
 def ping():
     return jsonify(message='pong', timestamp=datetime.now(timezone.utc).isoformat()), 200
 
+@api_system_bp.route('/api/system/today', methods=['GET'])
+def get_server_today_date():
+    '''
+    Returns the server's current date in YYYY-MM-DD format.
+    This is used by the frontend calendar to have an authoritative 'today'.
+    '''
+    try:
+        today_date = datetime.now(timezone.utc).strftime('%Y-%m-%d')
+        # Using current_app.logger for consistency if available, otherwise print
+        logger = getattr(current_app, 'logger', None)
+        if logger:
+            logger.debug(f"API call to /api/system/today, returning date: {today_date}")
+        else:
+            print(f"API call to /api/system/today, returning date: {today_date}")
+        return jsonify({'current_date': today_date}), 200
+    except Exception as e:
+        logger = getattr(current_app, 'logger', None)
+        if logger:
+            logger.error(f"Error in /api/system/today endpoint: {e}", exc_info=True)
+        else:
+            print(f"Error in /api/system/today endpoint: {e}")
+        return jsonify({'error': 'Failed to retrieve server date due to an internal error.'}), 500
+
 @api_system_bp.route('/debug/list_routes', methods=['GET'])
 @login_required
 # @permission_required('manage_system') # Or some debug permission


### PR DESCRIPTION
Implements a new GET API endpoint at `/api/system/today`. This endpoint returns the server's current date in UTC as a JSON object: `{"current_date": "YYYY-MM-DD"}`.

This endpoint is intended to be used by the frontend calendar to obtain an authoritative 'today' date, making date-sensitive UI logic (like disabling 'today' past 5 PM) independent of your client's system clock.

The endpoint is added to `routes/api_system.py` and does not require authentication.