### PR TITLE
Here's a summary of the recent code changes I've made:

### DIFF
--- a/routes/api_resources.py
+++ b/routes/api_resources.py
@@ -306,6 +306,21 @@ def get_unavailable_dates():
 
             current_iter_date += timedelta(days=1)
 
+        # New logic: Add current server date if server time is past 5 PM UTC
+        # 'now' is already defined as datetime.now(timezone.utc)
+        server_today_date_obj = now.date()
+        server_cutoff_time_utc = time(17, 0, 0, tzinfo=timezone.utc) # 5 PM UTC
+
+        # Combine server's today date with the cutoff time to create a datetime object for comparison
+        server_today_at_cutoff_utc = datetime.combine(server_today_date_obj, server_cutoff_time_utc)
+        # server_today_at_cutoff_utc = server_today_at_cutoff_utc.replace(tzinfo=timezone.utc) # Ensure tzinfo if combine doesn't preserve from time
+
+        if now >= server_today_at_cutoff_utc:
+            server_today_date_str = server_today_date_obj.strftime('%Y-%m-%d')
+            if server_today_date_str not in unavailable_dates_set:
+                unavailable_dates_set.add(server_today_date_str)
+                logger.info(f"Server time is past 5 PM UTC. Adding server's current date {server_today_date_str} to unavailable dates for user {user_id}.")
+
         logger.info(f"Returning {len(unavailable_dates_set)} unavailable dates for user {user_id}.")
         return jsonify(sorted(list(unavailable_dates_set)))
 

--- a/routes/api_system.py
+++ b/routes/api_system.py
@@ -124,29 +124,6 @@ def get_audit_logs():
 def ping():
     return jsonify(message='pong', timestamp=datetime.now(timezone.utc).isoformat()), 200
 
-@api_system_bp.route('/api/system/today', methods=['GET'])
-def get_server_today_date():
-    '''
-    Returns the server's current date in YYYY-MM-DD format.
-    This is used by the frontend calendar to have an authoritative 'today'.
-    '''
-    try:
-        today_date = datetime.now(timezone.utc).strftime('%Y-%m-%d')
-        # Using current_app.logger for consistency if available, otherwise print
-        logger = getattr(current_app, 'logger', None)
-        if logger:
-            logger.debug(f"API call to /api/system/today, returning date: {today_date}")
-        else:
-            print(f"API call to /api/system/today, returning date: {today_date}")
-        return jsonify({'current_date': today_date}), 200
-    except Exception as e:
-        logger = getattr(current_app, 'logger', None)
-        if logger:
-            logger.error(f"Error in /api/system/today endpoint: {e}", exc_info=True)
-        else:
-            print(f"Error in /api/system/today endpoint: {e}")
-        return jsonify({'error': 'Failed to retrieve server date due to an internal error.'}), 500
-
 @api_system_bp.route('/debug/list_routes', methods=['GET'])
 @login_required
 # @permission_required('manage_system') # Or some debug permission

--- a/static/js/new_booking_map.js
+++ b/static/js/new_booking_map.js
@@ -9,11 +9,6 @@ document.addEventListener('DOMContentLoaded', function () {
         return `${yyyy}-${mm}-${dd}`;
     }
 
-    function isPastFivePM() {
-        const now = new Date();
-        return now.getHours() >= 17; // 17 is 5 PM in 24-hour format
-    }
-
     // const mapAvailabilityDateInput = document.getElementById('new-booking-map-availability-date'); // Old input field, now removed from HTML
     const calendarContainer = document.getElementById('inline-calendar-container'); // New container for inline flatpickr
     const userId = calendarContainer ? calendarContainer.dataset.userId : null;
@@ -82,35 +77,12 @@ document.addEventListener('DOMContentLoaded', function () {
 
     // const today = getTodayDateString(); // currentSelectedDateStr is initialized with this
 
-    let serverTodayDateStr = null;
+    // serverTodayDateStr removed
 
-    async function fetchServerDateAndInitializeFlatpickr() {
-        // 1. Fetch server date (with fallback)
-        try {
-            // IMPORTANT: Use a placeholder URL for now, as the API endpoint might not exist yet.
-            // This will be updated later if the actual backend implementation uses a different URL or needs specific headers.
-            const response = await fetch('/api/system/today');
-            if (!response.ok) {
-                throw new Error(`API request to /api/system/today failed with status ${response.status}`);
-            }
-            const data = await response.json();
-            // Validate the received date format strictly
-            if (data && data.current_date && /^\d{4}-\d{2}-\d{2}$/.test(data.current_date)) {
-                serverTodayDateStr = data.current_date;
-                console.log('[Info] Successfully fetched server date:', serverTodayDateStr);
-            } else {
-                console.warn('[Warning] Invalid date format or missing current_date in response from /api/system/today. Falling back to client system date.');
-                serverTodayDateStr = getTodayDateString(); // Fallback defined in the script
-            }
-        } catch (error) {
-            console.warn('[Warning] Could not fetch server date from /api/system/today:', error.message, 'Falling back to client system date.');
-            serverTodayDateStr = getTodayDateString(); // Fallback
-        }
-
-        // 2. Proceed with existing Flatpickr initialization logic
-        // (The following is the existing logic, now nested)
-        const calendarContainer = document.getElementById('inline-calendar-container'); // Ensure this is accessible
-        const userId = calendarContainer ? calendarContainer.dataset.userId : null; // Ensure this is accessible
+    function fetchDataAndInitializeFlatpickr() { // Renamed and async removed
+        // Directly proceed with existing Flatpickr initialization logic that depends on unavailableDatesList
+        const calendarContainer = document.getElementById('inline-calendar-container');
+        const userId = calendarContainer ? calendarContainer.dataset.userId : null;
 
         if (userId && calendarContainer) {
             apiCall(`/api/resources/unavailable_dates?user_id=${userId}`)
@@ -126,65 +98,43 @@ document.addEventListener('DOMContentLoaded', function () {
             if (!calendarContainer) {
                  console.info('Calendar container not found, Flatpickr setup skipped.');
             } else if (!userId) {
-                // This console message might be slightly confusing now that serverTodayDateStr is global,
-                // but initializeFlatpickr([]) will still use it.
                 console.info('User ID not found. Initializing Flatpickr without user-specific unavailable dates.');
             }
-            // Initialize Flatpickr even if no user or unavailable dates, so the calendar shows.
-            // It will use the serverTodayDateStr (or its fallback) for 'today' logic.
-            if (calendarContainer) { // Only initialize if container exists
-                initializeFlatpickr([]);
+            if (calendarContainer) {
+                initializeFlatpickr([]); // Initialize with empty list if no user, calendar still needs to show
             }
         }
     }
 
     function initializeFlatpickr(unavailableDatesList = []) {
         if (calendarContainer) {
-            let effectiveToday = serverTodayDateStr || getTodayDateString(); // Use server date or client fallback
-            let initialDate = effectiveToday; // Default to the authoritative 'today'
-
-            // If current client time is past 5 PM, default calendar to tomorrow (relative to authoritative 'today')
-            if (isPastFivePM()) { // isPastFivePM() uses the client's current time
-                // Create a Date object from effectiveToday. Ensure time is neutral (e.g., T00:00:00) to avoid timezone shifts when using setDate.
-                const dateObj = new Date(effectiveToday + 'T00:00:00');
-                dateObj.setDate(dateObj.getDate() + 1); // Advance to the next day
-
-                const yyyy = dateObj.getFullYear();
-                const mm = String(dateObj.getMonth() + 1).padStart(2, '0');
-                const dd = String(dateObj.getDate()).padStart(2, '0');
-                initialDate = `${yyyy}-${mm}-${dd}`;
-            }
-            currentSelectedDateStr = initialDate; // currentSelectedDateStr is used by Flatpickr and other functions
+            // currentSelectedDateStr is an outer scope variable.
+            // Initialize/update it here before Flatpickr uses it for defaultDate.
+            currentSelectedDateStr = getTodayDateString();
 
             flatpickr(calendarContainer, {
                 inline: true,
-                static: true,
+                static: true, // Keep existing options
                 dateFormat: "Y-m-d",
                 disable: [
                     function(date) {
                         const dateStr = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
 
-                        // --- Add this logging ---
-                        const isDisabledByList = unavailableDatesList.includes(dateStr);
-                        if (unavailableDatesList.length > 0) { // Log only if the list has been populated
-                            console.log(`[Debug] Flatpickr disable check for ${dateStr}: inList = ${isDisabledByList}`);
-                        }
-                        // --- End of added logging ---
+                        // unavailableDatesList is passed to initializeFlatpickr
+                        const isDisabled = unavailableDatesList.includes(dateStr);
 
-                        if (isDisabledByList) {
-                            return true;
+                        // Optional: keep a simple log for debugging
+                        // Added a condition to ensure some logging for relevant test dates if list is empty
+                        if (unavailableDatesList.length > 0 || dateStr.startsWith("2025-06")) {
+                            console.log(`[Debug] Flatpickr disable check for ${dateStr}: inList = ${isDisabled} (list length: ${unavailableDatesList.length})`);
                         }
-                        const effectiveTodayStr = serverTodayDateStr || getTodayDateString(); // Use server date or client fallback
-                        const isEffectivelyPastFivePMToday = dateStr === effectiveTodayStr && isPastFivePM();
-                        if (isEffectivelyPastFivePMToday) {
-                            console.log(`[Debug] Flatpickr disabling date ${dateStr} because it matches effective 'today' (effectiveTodayStr: ${effectiveTodayStr}) and current client time is past 5 PM.`);
-                        }
-                        return isEffectivelyPastFivePMToday;
+
+                        return isDisabled;
                     }
                 ],
-                defaultDate: currentSelectedDateStr,
+                defaultDate: currentSelectedDateStr, // Set defaultDate to client's current date
                 onChange: function(selectedDates, dateStr, instance) {
-                    currentSelectedDateStr = dateStr;
+                    currentSelectedDateStr = dateStr; // Update on change
 
                     if (dateSelectionInstructionDiv) dateSelectionInstructionDiv.style.display = 'none';
                     if (locationFloorWrapperDiv) locationFloorWrapperDiv.style.display = 'flex'; // Assuming flex display
@@ -205,7 +155,8 @@ document.addEventListener('DOMContentLoaded', function () {
                     });
                 }
             });
-            if (mainBookingFormDateInput) {
+            // Also update the main booking form's date input if it exists, to reflect this initial date
+            if (mainBookingFormDateInput && mainBookingFormDateInput.value !== currentSelectedDateStr) {
                 mainBookingFormDateInput.value = currentSelectedDateStr;
             }
         } else {
@@ -213,7 +164,7 @@ document.addEventListener('DOMContentLoaded', function () {
         }
     }
 
-    fetchServerDateAndInitializeFlatpickr();
+    fetchDataAndInitializeFlatpickr(); // Call the refactored function
 
     // function updateFloorSelectOptions() { // Removed }
 


### PR DESCRIPTION
**refactor: Make all date disabling server-authoritative**

I've implemented a shift in logic for handling date availability in the Flatpickr calendar on your new booking page. All decisions about whether a date is unavailable, including disabling the current day due to time constraints (e.g., "past 5 PM"), are now made server-side.

Key changes:

Backend:
- I modified `/api/resources/unavailable_dates` (in `routes/api_resources.py`):
  - This endpoint now checks the server's current time. If it's past a defined cutoff (5 PM UTC), the server's current date is added to the list of unavailable dates it returns.
- I removed the `/api/system/today` endpoint (from `routes/api_system.py`):
  - This endpoint is no longer needed as the frontend does not require a separate server date for client-side 'today' logic.

Frontend (`static/js/new_booking_map.js`):
- I simplified the Flatpickr `disable` callback:
  - It now solely relies on the `unavailableDatesList` provided by `/api/resources/unavailable_dates`.
  - All client-side logic for checking "today past 5 PM" has been removed.
- I removed the JavaScript function `isPastFivePM()`.
- I removed the mechanism for fetching `/api/system/today` and storing `serverTodayDateStr`.
- I simplified the `defaultDate` initialization for Flatpickr to use the client's current date for the initial view, as all disabling is server-controlled.

This refactoring centralizes date availability logic on the server, leading to more consistent behavior regardless of your client system time settings (except for the initial calendar view's default date).