### PR TITLE
Fix: Enable page scrolling to ensure header visibility on mobile

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -43,7 +43,6 @@
 } */
 
 html {
-    overflow: hidden;
     height: 100%;
 }
 


### PR DESCRIPTION
I've removed `overflow: hidden;` from the `html` selector in `static/style.css`.

This change allows the entire page to scroll if its content exceeds the viewport height. This primarily addresses an issue where the header menu could become inaccessible (cut off at the top) on mobile views, particularly if dynamic content or the height of on-screen elements (like an open sidebar or keyboard) caused the page to overflow while scrolling was disabled on the root element.

The main content areas (`#main-content`, `#sidebar`) continue to manage their own internal scrolling as before. This change is not expected to introduce double scrollbars or negatively affect desktop layout due to the existing height calculations and overflow management within those specific components.