### PR TITLE
Feat: Default calendar to week view on mobile

### DIFF
--- a/static/js/calendar.js
+++ b/static/js/calendar.js
@@ -260,8 +260,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // --- Logic to initialize and render the calendar ---
     const initializeCalendar = () => {
+        let determinedInitialView = 'dayGridMonth'; // Default to month view
+        if (window.innerWidth < 768) {
+            determinedInitialView = 'timeGridWeek'; // Change to week view for mobile
+        }
         calendarInstance = new FullCalendar.Calendar(calendarEl, {
-            initialView: 'dayGridMonth',
+            initialView: determinedInitialView,
             timeZone: 'local', // Keep timezone as UTC for consistency with server
             selectAllow: function(selectInfo) {
                 // Convert startStr to 'YYYY-MM-DD' format


### PR DESCRIPTION
I modified `static/js/calendar.js` to set the FullCalendar `initialView` option based on screen width.

- On screens narrower than 768px, the calendar on the `/calendar` page will now default to 'timeGridWeek'.
- On screens 768px or wider, the calendar will continue to default to 'dayGridMonth'.

This change enhances the usability of the calendar page on mobile devices by providing a more suitable default view. Manual view switching via the header buttons remains available on all screen sizes.