### PR TITLE
Fix: Implement sticky header/footer and resolve mobile footer width

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -44,6 +44,7 @@
 
 html {
     height: 100%;
+    overflow-y: hidden; /* Add this line */
 }
 
 /* Dark theme color variables */
@@ -85,6 +86,11 @@ body {
     align-items: center;
     box-shadow: 0 2px 4px rgba(0,0,0,0.1);
     flex-shrink: 0;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 1030;
 }
 
 /* Reset list-like styles for all elements within the header */
@@ -343,7 +349,7 @@ body {
 /* Main Content Styling */
 #main-content {
     margin-left: var(--sidebar-width);
-    padding: 30px 20px;
+    padding: calc(30px + var(--header-height)) 20px 30px 20px;
     overflow-y: auto;
     background-color: var(--background-color-light);
     box-sizing: border-box; /* Added this line */
@@ -1004,6 +1010,7 @@ body.high-contrast footer {
         min-height: var(--footer-height);
         padding-top: 5px;
         padding-bottom: 5px;
+        width: 100%;
     }
     .footer-accessibility-controls {
         display: flex;
@@ -1138,6 +1145,7 @@ body.high-contrast footer {
         padding-top: 10px;
         padding-bottom: 10px;
         /* height: auto; Removed for fixed footer consistency */
+        width: 100%;
     }
     footer > * {
         margin-bottom: 5px;


### PR DESCRIPTION
This commit implements a sticky header and adjusts the main content layout accordingly, ensuring that only the main content area scrolls. It also addresses an issue where the footer was not displaying at full width on mobile devices.

Key changes:
1.  Made `.app-header` `position: fixed` with appropriate `top`, `left`, `right`, and `z-index` properties.
2.  Adjusted `padding-top` of `#main-content` to prevent content from being obscured by the fixed header.
3.  Reinstated `overflow-y: hidden;` on the `html` element to ensure page-level scrolling is disabled, as the header and footer are now fixed and main content handles its own scrolling.
4.  Added `width: 100%;` to the `footer` element within mobile media queries (`@media (max-width: 768px)` and `@media (max-width: 480px)`) to ensure it spans the full viewport width, correcting a reported issue where it appeared truncated.

The desktop admin sidebar (`#sidebar`) layout was verified to be compatible with these changes. The mobile overlay menu remains functional and correctly overlays the new fixed header.