### PR TITLE
Fix: Implement ProxyFix for correct HTTPS detection in OAuth flow

### DIFF
--- a/app_factory.py
+++ b/app_factory.py
@@ -1,4 +1,5 @@
 from flask import Flask, jsonify, request # jsonify for error handler, request for error handlers
+from werkzeug.middleware.proxy_fix import ProxyFix
 import os
 import json # Added for json.load and json.dumps
 import logging
@@ -146,6 +147,9 @@ def create_app(config_object=config, testing=False): # Added testing parameter
 
     # 1. Load Configuration
     app.config.from_object(config_object)
+
+    # Add ProxyFix middleware
+    app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1, x_prefix=1)
 
     if testing:
         app.config['TESTING'] = True


### PR DESCRIPTION
- Adds Werkzeug's ProxyFix middleware to the Flask application in `app_factory.py`. This allows the application to correctly identify the `https` scheme from the `X-Forwarded-Proto` header when deployed behind a reverse proxy that terminates SSL.
- Verifies that `OAUTHLIB_INSECURE_TRANSPORT` remains disabled for the Google account linking flow in `auth.py`.

This change addresses the `InsecureTransportError` that occurred during the OAuth callback because the application, when behind a proxy, was perceiving the request as HTTP. You have also been advised to ensure your reverse proxy is correctly setting the `X-Forwarded-Proto` header.