### PR TITLE
Fix: Client UI respects past_booking_time_adjustment_hours

### DIFF
--- a/routes/ui.py
+++ b/routes/ui.py
@@ -62,7 +62,16 @@ def serve_index():
 @ui_bp.route("/resources")
 @login_required
 def serve_resources():
-    return render_template("resources.html")
+    adjustment_hours = 0  # Default value
+    try:
+        booking_settings = BookingSettings.query.first()
+        if booking_settings and booking_settings.past_booking_time_adjustment_hours is not None:
+            adjustment_hours = booking_settings.past_booking_time_adjustment_hours
+        current_app.logger.info(f"Passing past_booking_adjustment_hours: {adjustment_hours} to resources.html")
+    except Exception as e:
+        current_app.logger.error(f"Error fetching BookingSettings for /resources page: {e}", exc_info=True)
+        # adjustment_hours remains 0 (default)
+    return render_template("resources.html", past_booking_adjustment_hours=adjustment_hours)
 
 @ui_bp.route("/login")
 def serve_login():

--- a/templates/resources.html
+++ b/templates/resources.html
@@ -9,7 +9,7 @@
     <div id="location-selection-instruction" class="instruction-message">{{ _('Please select a location and floor to see the map.') }}</div>
 
     <div id="selection-controls-container" style="display: flex; flex-wrap: wrap; gap: 20px; margin-bottom: 20px;">
-        <div id="inline-calendar-container" style="flex: 1; min-width: 280px; max-width: 320px;" {% if current_user.is_authenticated %}data-user-id="{{ current_user.id }}"{% endif %}>
+        <div id="inline-calendar-container" style="flex: 1; min-width: 280px; max-width: 320px;" {% if current_user.is_authenticated %}data-user-id="{{ current_user.id }}"{% endif %} data-past-booking-adjustment-hours="{{ past_booking_adjustment_hours }}">
             <!-- Flatpickr inline calendar will render here -->
         </div>
         <div id="location-floor-wrapper" style="display: none; flex: 2; min-width: 300px;"> <!-- Wrapper for location buttons and their label -->


### PR DESCRIPTION
This commit ensures that the client-side JavaScript logic for determining the availability of dates and time slots on "today" correctly uses the server-configured `past_booking_time_adjustment_hours` setting.

Previously, your UI used the actual client time, which could lead to discrepancies if the server allowed bookings further into the past or restricted them sooner due to this setting.

Changes:
1.  **`routes/ui.py`**:
    - Modified the `serve_resources` route to fetch `past_booking_time_adjustment_hours` from `BookingSettings`.
    - This value (defaulting to 0 if not set) is passed to the `resources.html` template.

2.  **`templates/resources.html`**:
    - Stores the `past_booking_adjustment_hours` value received from the server in a `data-past-booking-adjustment-hours` attribute on the `inline-calendar-container` div.

3.  **`static/js/new_booking_map.js`**:
    - Reads `past_booking_adjustment_hours` from the data attribute.
    - Implemented a helper function `getEffectiveClientNow(adjustmentHours)` that returns the current client time adjusted by these hours.
    - Updated `initializeFlatpickr` to use this "effective client now" when deciding to disable "today" based on time (e.g., if the effective time is past 17:00).
    - Updated `openResourceDetailModal` to use this "effective client now" when determining if individual time slots for "today" (morning, afternoon, full-day) have passed their end times.

This ensures consistent behavior between the client-side UI presentation of available slots and the server-side booking validation logic regarding past bookings.