### PR TITLE
Fix: Correct map resource display for multiple bookings

### DIFF
--- a/routes/api_system.py
+++ b/routes/api_system.py
@@ -1149,3 +1149,27 @@ def api_admin_reload_configurations():
         current_app.logger.error(f"Error during configuration reload by {current_user.username}: {e}", exc_info=True)
         add_audit_log(action="RELOAD_CONFIGURATIONS_ERROR", details=f"Error: {str(e)}", user_id=current_user.id)
         return jsonify({'success': False, 'message': f'An error occurred during configuration reload: {str(e)}'}), 500
+
+@api_system_bp.route('/api/settings/booking_config_status', methods=['GET'])
+@login_required
+def get_booking_config_status():
+    """
+    Fetches the 'allow_multiple_resources_same_time' setting from BookingSettings.
+    """
+    try:
+        settings = BookingSettings.query.first()
+        allow_multiple = False # Default value
+        if settings:
+            if hasattr(settings, 'allow_multiple_resources_same_time'):
+                allow_multiple = settings.allow_multiple_resources_same_time
+            else:
+                current_app.logger.warning("BookingSettings found, but 'allow_multiple_resources_same_time' attribute is missing. Defaulting to False.")
+        else:
+            current_app.logger.warning("BookingSettings not found in the database. Defaulting 'allow_multiple_resources_same_time' to False.")
+
+        # current_app.logger.debug(f"API /api/settings/booking_config_status returning: {allow_multiple}")
+        return jsonify({'allow_multiple_resources_same_time': allow_multiple}), 200
+    except Exception as e:
+        current_app.logger.error(f"Error fetching booking_config_status for user {current_user.username}: {e}", exc_info=True)
+        # In case of error, still return the default value to prevent frontend issues
+        return jsonify({'allow_multiple_resources_same_time': False, 'error': 'Failed to fetch setting due to a server error.'}), 500


### PR DESCRIPTION
This commit addresses an issue where the visual representation of resource availability on the map (in `static/js/new_booking_map.js`) did not correctly account for the 'Allow users to book multiple resources for the same time slot' setting.

When this setting was true, resource areas on the map might still appear as unavailable if you had other bookings that conflicted time-wise, even if the resource area itself was otherwise free or bookable by you.

The fix involves:
1. Fetching Booking Settings:
   - A new API endpoint `/api/settings/booking_config_status` was created in `routes/api_system.py` to expose the `allow_multiple_resources_same_time` setting.
   - `static/js/new_booking_map.js` now calls this endpoint on initialization to get the current setting.

2. Adjusting Map Display Logic:
   - The `loadMapDetails` function in `static/js/new_booking_map.js` now uses the fetched `allow_multiple_resources_same_time` setting.
   - If the setting is true, conflicts with your own other bookings are ignored when determining the availability and clickability of a resource area on the map. The area will still correctly show as unavailable if it's generally booked by another user, under maintenance, or if you lack permissions for that specific resource.

This ensures that the map display is consistent with the backend availability logic and provides an accurate visual guide to you when multiple bookings are allowed.