### PR TITLE
Hotfix: Resolve JS redeclaration error in booking modal

### DIFF
--- a/static/js/new_booking_map.js
+++ b/static/js/new_booking_map.js
@@ -918,8 +918,6 @@ document.addEventListener('DOMContentLoaded', function () {
                     fullDayBtn.disabled = true;
                 } else {
                     // If Full Day hasn't passed, check constituent slots
-                    const firstHalfBooked = firstHalfBtn.classList.contains('time-slot-booked');
-                    const secondHalfBooked = secondHalfBtn.classList.contains('time-slot-booked');
                     const firstHalfBooked = firstHalfBtn.classList.contains('time-slot-booked'); // General booking conflict
                     const secondHalfBooked = secondHalfBtn.classList.contains('time-slot-booked'); // General booking conflict
 


### PR DESCRIPTION
This commit fixes a JavaScript syntax error in
`static/js/new_booking_map.js` within the `openResourceDetailModal` function. The error "Identifier '...' has already been declared" was caused by an erroneous redeclaration of variables (e.g., `firstHalfBooked`, `secondHalfBooked`) using `const` when evaluating the state of the "Full Day" booking button.

The redundant `const` keywords have been removed, ensuring that these variables are assigned to correctly within their scope. This resolves the syntax error and allows the booking modal to load and function as intended.

This fix is subsequent to changes that ensure the modal's time slot availability correctly respects the 'Allow users to book multiple resources for the same time slot' setting.