### PR TITLE
Fix: Refine client-side handling of backup delete completion

### DIFF
--- a/templates/admin/backup_system.html
+++ b/templates/admin/backup_system.html
@@ -300,14 +300,32 @@
                 socket.on('backup_delete_progress', function(data) {
                     console.log('Backup delete progress event:', data);
                     if (data.task_id !== currentDeleteTaskId) return;
-                    let messageType = data.level ? data.level.toLowerCase() : 'info';
+
+                    let messageType = data.level ? data.level.toLowerCase() : 'info'; // Used by appendLog and potentially for UI styling
                     appendLog('restore-log-area', data.status, data.detail, messageType, restoreStatusMessageEl);
+
                     const lowerStatus = data.status.toLowerCase();
                     const lowerDetail = data.detail ? data.detail.toLowerCase() : "";
 
-                    if (lowerStatus.includes("finished") || lowerStatus.includes("failed") || lowerStatus.includes("error") || lowerDetail.includes("success") || lowerDetail.includes("failure") || lowerDetail.includes("critical_error")) {
-                        enablePageInteractions(); currentDeleteTaskId = null;
-                        if (messageType === 'success' || (data.detail && data.detail.toUpperCase().includes("SUCCESS"))) {
+                    // Determine if the task is considered finished, failed, or errored for enabling interactions
+                    const isTaskCompletedOrFailed =
+                        lowerStatus.includes("finished") || // Catches "Backup set deletion process finished."
+                        lowerStatus.includes("failed") ||
+                        lowerStatus.includes("error") || // Catches "critical_error" in status
+                        (data.detail && data.detail.toUpperCase() === "SUCCESS") || // Route's direct success signal
+                        lowerDetail.includes("failure") ||
+                        lowerDetail.includes("critical_error"); // Explicit check for "critical_error" in detail
+
+                    if (isTaskCompletedOrFailed) {
+                        enablePageInteractions();
+                        currentDeleteTaskId = null;
+
+                        // Determine if the deletion was definitively successful for reloading the backup list
+                        const wasDeleteSuccessful =
+                            (data.detail && data.detail.toUpperCase() === "SUCCESS") || // Route's direct success
+                            (lowerStatus.includes("backup set deletion process finished") && lowerDetail.includes("overall success: true")); // azure_backup.py's final success
+
+                        if (wasDeleteSuccessful) {
                             loadAvailableBackups();
                         }
                     }


### PR DESCRIPTION
This commit improves the client-side JavaScript logic for the backup deletion process on the admin backup page.

Previously, intermediate success messages from the server during a multi-step delete operation could prematurely trigger the reloading of the backup list. This could lead to the 'Refresh Available Backups' button and other UI elements being disabled and not reliably re-enabled if subsequent operations or the final 'loadAvailableBackups' call had issues.

The `socket.on('backup_delete_progress', ...)` handler in `templates/admin/backup_system.html` has been updated to:
1.  Use a more robust set of conditions (`isTaskCompletedOrFailed`) to determine when to re-enable page interactions. This ensures that any message indicating the task is truly over (finished, failed, error, or explicit success/failure details) correctly enables the UI.
2.  Implement a more specific condition (`wasDeleteSuccessful`) for calling `loadAvailableBackups()`. This condition now precisely targets only the definitive final success messages from the server:
    - The direct success message from the API route (`data.detail.toUpperCase() === "SUCCESS"`).
    - The final success message from the underlying `azure_backup.py` script (`data.status` includes "backup set deletion process finished" and `data.detail` includes "overall success: true").

These changes prevent `loadAvailableBackups()` from being triggered by intermediate success-level messages related to sub-steps of the deletion, ensuring it's called only once upon the confirmed successful completion of the entire delete operation. This should resolve issues where the refresh button remained disabled after a delete action.