### PR TITLE
Refactor: Allow quick table refresh for backup list actions

### DIFF
--- a/templates/admin/backup_system.html
+++ b/templates/admin/backup_system.html
@@ -248,7 +248,7 @@
                         currentBackupTaskId = null;
                         // Reload backups if the backup was successful (or partially successful and worth reloading)
                         if (lowerStatus.includes("completed with overall success: true") || (messageType === 'success' || (data.detail && data.detail.toUpperCase().includes("SUCCESS")))) {
-                            loadAvailableBackups();
+                            loadAvailableBackups(true); // Quick refresh
                         }
                     }
                 });
@@ -326,7 +326,7 @@
                             (lowerStatus.includes("backup set deletion process finished") && lowerDetail.includes("overall success: true")); // azure_backup.py's final success
 
                         if (wasDeleteSuccessful) {
-                            loadAvailableBackups();
+                            loadAvailableBackups(true); // Quick refresh
                         }
                     }
                 });
@@ -411,8 +411,10 @@
                 });
             }
 
-            function loadAvailableBackups() {
-                disablePageInteractions();
+            function loadAvailableBackups(isQuickRefresh = false) {
+                if (!isQuickRefresh) {
+                    disablePageInteractions();
+                }
                 appendLog('restore-log-area', "{{ _('Fetching available full system backups...') }}", '', 'info', restoreStatusMessageEl);
                 if(availableBackupsTbody) availableBackupsTbody.innerHTML = '<tr><td colspan="2">{{ _("Loading...") }}</td></tr>';
                 if(paginationNav) paginationNav.style.display = 'none';
@@ -447,7 +449,9 @@
                     if(paginationNav) paginationNav.style.display = 'none';
                 })
                 .finally(() => {
-                    enablePageInteractions();
+                    if (!isQuickRefresh) {
+                        enablePageInteractions();
+                    }
                 });
             }
 
@@ -517,7 +521,7 @@
                 }
             }
 
-            if(listBackupsButton) listBackupsButton.addEventListener('click', loadAvailableBackups);
+            if(listBackupsButton) listBackupsButton.addEventListener('click', function() { loadAvailableBackups(false); });
             if(prevPageBtn) prevPageBtn.addEventListener('click', function(e) {
                 e.preventDefault();
                 if (currentPage > 1) { currentPage--; displayBackupsPage(); }


### PR DESCRIPTION
This commit refactors the `loadAvailableBackups` JavaScript function to support a 'quick refresh' mode. This is primarily to improve your experience after actions like deleting a backup, where only the table needs to update without re-disabling all page interactions.

Changes:
1.  The `loadAvailableBackups` function in `templates/admin/backup_system.html` now accepts an `isQuickRefresh` boolean parameter (defaulting to `false`).
    - If `isQuickRefresh` is `true`, the function fetches and repopulates the backup table but skips calling `disablePageInteractions()` and `enablePageInteractions()`.
    - If `isQuickRefresh` is `false` (default), it preserves the original behavior of disabling interactions during the load and re-enabling them after.

2.  The `socket.on('backup_delete_progress', ...)` event handler has been updated:
    - After a successful delete, it now calls `loadAvailableBackups(true)`. This ensures the table refreshes quickly. The `enablePageInteractions()` call already present in this handler (before calling `loadAvailableBackups`) takes care of re-enabling UI elements after the delete operation itself.

3.  The event listener for the main 'Refresh Available Backups' button (`list-backups-btn`) has been modified to explicitly call `loadAvailableBackups(false)`. This ensures that a manual refresh by you performs a full refresh cycle, including disabling UI elements during the process.

4.  The call to `loadAvailableBackups` in the `socket.on('backup_progress', ...)` handler (after a new backup is made) was also confirmed/updated to use `loadAvailableBackups(true)`, as `enablePageInteractions` is called prior, making a quick table refresh appropriate.

This set of changes aims to make the UI more responsive for quick table updates triggered by actions like 'Delete', while maintaining the full refresh behavior for your initiated refreshes or initial loads.