### PR TITLE
Fix: Correct handling of currentDeleteTaskId for backup deletion

### DIFF
--- a/templates/admin/backup_system.html
+++ b/templates/admin/backup_system.html
@@ -593,7 +593,7 @@
                         confirmationMessage = `{{ _('Are you sure you want to delete backup') }} '${displayTimestamp}'? {{ _('This action cannot be undone.') }}`;
                         actionVerb = "{{ _('delete') }}";
                         method = 'POST';
-                        currentDeleteTaskId = null;
+                        // currentDeleteTaskId = null; // Removed: Will be set from server response to ensure progress handler has correct ID
                     } else if (isVerifyJs) {
                         endpoint = '/api/admin/verify_backup';
                         confirmationMessage = `{{ _('Are you sure you want to verify backup') }} ${displayTimestamp}?`;


### PR DESCRIPTION
Removes the premature nullification of `currentDeleteTaskId` in the client-side event listener for the delete backup button.

Previously, `currentDeleteTaskId` was set to `null` immediately upon clicking the delete button, before the new task ID was received from the server's HTTP response. This caused subsequent Socket.IO messages for that delete operation to be ignored due to a task ID mismatch, preventing the backup list from refreshing.

With this change, `currentDeleteTaskId` retains its value (which might be from a previous operation or initially null) until the HTTP response from the delete initiation request is received. The `fetch().then()` callback then correctly sets `currentDeleteTaskId` to the new task's ID. This allows the Socket.IO message handler (`backup_delete_progress`) to correctly identify and process messages for the active delete task.