### PR TITLE
Fix: Implement robust task ID handling for One Click Backup

### DIFF
--- a/templates/admin/backup_system.html
+++ b/templates/admin/backup_system.html
@@ -228,6 +228,7 @@
             let currentVerifyTaskId = null;
             let currentDeleteTaskId = null;
             let isAwaitingDeleteTaskIdFromServer = false;
+            let isAwaitingBackupTaskIdFromServer = false;
 
             // Pagination Variables
             let currentPage = 1;
@@ -239,6 +240,15 @@
             if (typeof socket !== 'undefined') {
                 socket.on('backup_progress', function(data) {
                     console.log('Backup progress event:', data);
+                    console.log('DEBUG backup_progress: ENTRYPOINT. data.task_id =', data.task_id, '; currentBackupTaskId =', currentBackupTaskId, '; isAwaitingBackupTaskIdFromServer =', isAwaitingBackupTaskIdFromServer);
+
+                    if (isAwaitingBackupTaskIdFromServer && !currentBackupTaskId && data.task_id) {
+                        console.log('DEBUG backup_progress: Capturing task ID from backup socket message:', data.task_id);
+                        currentBackupTaskId = data.task_id;
+                        isAwaitingBackupTaskIdFromServer = false; // We've captured an ID, stop actively awaiting from fetch for this purpose.
+                        console.log('DEBUG backup_progress: currentBackupTaskId is now', currentBackupTaskId, '; isAwaitingBackupTaskIdFromServer is now false (captured from socket).');
+                    }
+
                     if (data.task_id !== currentBackupTaskId) {
                         console.log('DEBUG backup_progress: Task ID mismatch. data.task_id =', data.task_id, 'currentBackupTaskId =', currentBackupTaskId, '. Bailing out.');
                         return;
@@ -247,7 +257,7 @@
                     let messageType = data.level ? data.level.toLowerCase() : 'info';
                     appendLog('backup-log-area', data.status, data.detail, messageType, backupStatusMessageEl);
 
-                    const lowerStatus = data.status.toLowerCase();
+                    const lowerStatus = data.status.toLowerCase(); // Existing lowerStatus definition is fine here
                     console.log('DEBUG backup_progress: Received data.status =', data.status, '; data.detail =', data.detail, '; data.level =', data.level);
 
                     // Specific check for the final success message
@@ -386,10 +396,14 @@
             // Event Handlers & Functions
             if (backupButton) {
                 backupButton.addEventListener('click', function () {
-                    currentBackupTaskId = null;
+                    // currentBackupTaskId = null; // Removed: Should be set by fetch response and nulled by backup_progress handler.
                     if (backupLogAreaEl) { backupLogAreaEl.innerHTML = ''; backupLogAreaEl.style.display = 'block'; }
                     if (restoreLogAreaEl) { restoreLogAreaEl.style.display = 'none'; }
                     appendLog('backup-log-area', "{{ _('Initiating backup request...') }}", '', 'info', backupStatusMessageEl);
+
+                    isAwaitingBackupTaskIdFromServer = true;
+                    console.log('DEBUG Backup Click: isAwaitingBackupTaskIdFromServer set to true.');
+
                     disablePageInteractions();
                     fetch('/api/admin/one_click_backup', {
                         method: 'POST',
@@ -398,6 +412,8 @@
                     .then(response => response.json())
                     .then(data => {
                         currentBackupTaskId = data.task_id;
+                        isAwaitingBackupTaskIdFromServer = false;
+                        console.log('DEBUG Backup Fetch Callback: currentBackupTaskId set to', data.task_id, '; isAwaitingBackupTaskIdFromServer is now false.');
                         const messageType = data.success ? 'info' : 'error';
                         appendLog('backup-log-area', data.message || (data.success ? "{{ _('Backup process started on server.') }}" : "{{ _('Failed to start backup process.') }}"), `Task ID: ${data.task_id || 'N/A'}`, messageType, backupStatusMessageEl);
                         if (!data.success) {


### PR DESCRIPTION
Applies the same task ID capture logic (using an 'isAwaiting...IdFromServer' flag) to the "One Click Backup" functionality as was previously implemented for the "Delete" operation.

Changes in `templates/admin/backup_system.html`:
1.  The premature nullification of `currentBackupTaskId` in the backup button's click handler was removed.
2.  A new boolean variable `isAwaitingBackupTaskIdFromServer` is initialized and used to manage the state of awaiting a task ID from the server.
3.  The backup button's click handler now sets `isAwaitingBackupTaskIdFromServer = true` before making the fetch call.
4.  The `fetch().then()` callback for backup initiation now sets `currentBackupTaskId` from the server's response and resets `isAwaitingBackupTaskIdFromServer` to `false`.
5.  The `socket.on('backup_progress', ...)` handler is updated:
    - It logs the state of relevant variables at entry.
    - It includes logic to capture the `currentBackupTaskId` from the first relevant Socket.IO message if `isAwaitingBackupTaskIdFromServer` is true and `currentBackupTaskId` has not yet been set by the fetch response.
    - The check `if (data.task_id !== currentBackupTaskId)` now correctly filters messages after the task ID has been established either by fetch or socket capture.

This makes the client-side handling of backup task IDs more resilient to race conditions where Socket.IO messages might arrive before the initiating HTTP response, ensuring UI updates occur correctly upon task completion.