### PR TITLE
Refactor check-in reminder task for improved logic

### DIFF
--- a/templates/email/booking_auto_cancelled_no_checkin.html
+++ b/templates/email/booking_auto_cancelled_no_checkin.html
@@ -74,17 +74,17 @@
         </div>
         <div class="content">
             <p>Dear {{ user_name }},</p>
-            <p>This email is to inform you that your booking for <strong>{{ resource_name }}</strong> from <strong>{{ start_time }}</strong> to <strong>{{ end_time }}</strong> has been automatically cancelled.</p>
-            <p><strong>Reason:</strong> This is because the booking was not checked in within the allowed time period of {{ release_minutes }} minutes after the scheduled start time.</p>
+            <p>This email is to inform you that your booking for <strong>{{ resource_name }}</strong> from <strong>{{ start_time_local }}</strong> to <strong>{{ end_time_local }}</strong> has been automatically cancelled.</p>
+            <p><strong>Reason:</strong> {{ explanation }}</p>
         </div>
 
         <div class="booking-details">
             <h3>Booking Details:</h3>
             <p><strong>Resource:</strong> {{ resource_name }}</p>
             <p><strong>Booking Title:</strong> {{ booking_title | default('N/A') }}</p>
-            <p><strong>Scheduled Start:</strong> {{ start_time }}</p>
-            <p><strong>Scheduled End:</strong> {{ end_time }}</p>
-            <p><strong>Cancelled At (Deadline):</strong> {{ cancelled_at_time }}</p>
+            <p><strong>Scheduled Start:</strong> {{ start_time_local }}</p>
+            <p><strong>Scheduled End:</strong> {{ end_time_local }}</p>
+            <p><strong>Check-in Deadline:</strong> {{ check_in_deadline_local }}</p>
             <p><strong>Location:</strong> {{ location | default('N/A') }}</p>
             <p><strong>Floor:</strong> {{ floor | default('N/A') }}</p>
         </div>

--- a/templates/email/booking_auto_cancelled_no_checkin_text.html
+++ b/templates/email/booking_auto_cancelled_no_checkin_text.html
@@ -1,15 +1,15 @@
 Dear {{ user_name }},
 
-This email is to inform you that your booking for {{ resource_name }} from {{ start_time }} to {{ end_time }} has been automatically cancelled.
+This email is to inform you that your booking for {{ resource_name }} from {{ start_time_local }} to {{ end_time_local }} has been automatically cancelled.
 
-Reason: This is because the booking was not checked in within the allowed time period of {{ release_minutes }} minutes after the scheduled start time.
+Reason: {{ explanation }}
 
 Booking Details:
 - Resource: {{ resource_name }}
 - Booking Title: {{ booking_title | default('N/A') }}
-- Scheduled Start: {{ start_time }}
-- Scheduled End: {{ end_time }}
-- Cancelled At (Deadline): {{ cancelled_at_time }}
+- Scheduled Start: {{ start_time_local }}
+- Scheduled End: {{ end_time_local }}
+- Check-in Deadline: {{ check_in_deadline_local }}
 - Location: {{ location | default('N/A') }}
 - Floor: {{ floor | default('N/A') }}
 


### PR DESCRIPTION
This commit updates the `send_checkin_reminders` scheduler task to address issues with check-in email notifications and cancellations.

Key changes:
- The task now checks if a booking's check-in window has passed.
- If the check-in time (`start_time + check_in_minutes_after`) has passed and the booking is still 'approved', the booking status is changed to 'system_cancelled_no_checkin'. An audit log is created, and a cancellation email is sent to you.
- If the booking is within the reminder window (`start_time - checkin_reminder_minutes_before`) and has not passed its start time or check-in deadline, a reminder email is sent.
- The query for selecting bookings to process has been broadened to include all 'approved' bookings not yet checked in.
- Email templates for auto-cancellation (`booking_auto_cancelled_no_checkin.html/txt`) were updated to use a dynamic `explanation` field, making them suitable for cancellations triggered by this new logic as well as the existing `auto_release_unclaimed_bookings` task.
- Added comprehensive unit tests for the `send_checkin_reminders` function to cover the new reminder and cancellation scenarios.