### PR TITLE
I've addressed the RuntimeError that was occurring when `url_for` was…

### DIFF
--- a/config.py
+++ b/config.py
@@ -7,6 +7,9 @@ basedir = Path(__file__).resolve().parent
 
 # --- Core Flask App Configurations ---
 SECRET_KEY = os.environ.get('SECRET_KEY', 'dev_secret_key_123!@#_fallback_for_config.py')
+SERVER_NAME = os.environ.get('SERVER_NAME') # e.g., 'localhost:5000' or 'yourdomain.com'
+APPLICATION_ROOT = os.environ.get('APPLICATION_ROOT', '/')
+PREFERRED_URL_SCHEME = os.environ.get('PREFERRED_URL_SCHEME', 'http') # Use 'https' in production
 # For Flask-Session type extension
 SESSION_TYPE = os.environ.get('SESSION_TYPE', 'filesystem')
 SESSION_FILE_DIR = basedir / 'flask_session' # Directory for session files


### PR DESCRIPTION
… used to generate external URLs within the `send_checkin_reminders` scheduler task. This happened because some necessary Flask app configurations were missing in non-testing environments.

Here's what I did:

1.  **Updated `config.py`**:
    - I added `SERVER_NAME`, `APPLICATION_ROOT`, and `PREFERRED_URL_SCHEME` configurations, which are now sourced from environment variables. These are loaded into the Flask app's configuration, making them available to `url_for`.

2.  **Updated Unit Tests (`tests/test_scheduler_tasks.py`)**:
    - I removed the mock for `scheduler_tasks.url_for`.
    - I configured the test Flask app instance with `SERVER_NAME`, `APPLICATION_ROOT`, and `PREFERRED_URL_SCHEME`.
    - I added a dummy Flask Blueprint and route for 'ui.check_in_at_resource' to allow `url_for` to resolve correctly during tests.
    - All unit tests pass with these changes, confirming `url_for` now works as expected in the test environment, simulating the scheduler context.

This ensures that URLs for check-in reminders can be correctly generated by background tasks.