### PR TITLE
I've added some diagnostics to help understand the `url_for` RuntimeE…

### DIFF
--- a/config.py
+++ b/config.py
@@ -7,9 +7,24 @@ basedir = Path(__file__).resolve().parent
 
 # --- Core Flask App Configurations ---
 SECRET_KEY = os.environ.get('SECRET_KEY', 'dev_secret_key_123!@#_fallback_for_config.py')
-SERVER_NAME = os.environ.get('SERVER_NAME') # e.g., 'localhost:5000' or 'yourdomain.com'
+
+# SERVER_NAME Configuration with logging/print for diagnostics
+SERVER_NAME_FROM_ENV = os.environ.get('SERVER_NAME')
+if SERVER_NAME_FROM_ENV:
+    SERVER_NAME = SERVER_NAME_FROM_ENV
+    print(f"INFO: [config.py] SERVER_NAME configured from environment variable: {SERVER_NAME}")
+else:
+    SERVER_NAME = 'localhost:5000' # Default fallback
+    print(f"WARNING: [config.py] SERVER_NAME environment variable not set. Using default: {SERVER_NAME}. This may not be suitable for production or external URL generation by the scheduler.")
+
+# Ensure APPLICATION_ROOT and PREFERRED_URL_SCHEME also have their existing defaults
 APPLICATION_ROOT = os.environ.get('APPLICATION_ROOT', '/')
 PREFERRED_URL_SCHEME = os.environ.get('PREFERRED_URL_SCHEME', 'http') # Use 'https' in production
+
+print(f"INFO: [config.py] Final effective SERVER_NAME: {SERVER_NAME}")
+print(f"INFO: [config.py] Final effective APPLICATION_ROOT: {APPLICATION_ROOT}")
+print(f"INFO: [config.py] Final effective PREFERRED_URL_SCHEME: {PREFERRED_URL_SCHEME}")
+
 # For Flask-Session type extension
 SESSION_TYPE = os.environ.get('SESSION_TYPE', 'filesystem')
 SESSION_FILE_DIR = basedir / 'flask_session' # Directory for session files

--- a/scheduler_tasks.py
+++ b/scheduler_tasks.py
@@ -523,6 +523,7 @@ def send_checkin_reminders(app):
                         logger.warning(f"Scheduler: User {user.username} has no email address. Skipping reminder for booking ID {booking.id}.")
                     else:
                         try:
+                            logger.info(f"Scheduler: [send_checkin_reminders] Attempting to generate checkin_url. SERVER_NAME='{current_app.config.get('SERVER_NAME')}', APPLICATION_ROOT='{current_app.config.get('APPLICATION_ROOT')}', PREFERRED_URL_SCHEME='{current_app.config.get('PREFERRED_URL_SCHEME')}'")
                             checkin_url = url_for('ui.check_in_at_resource', resource_id=booking.resource_id, _external=True)
                             booking_start_str = booking_start_local_naive.strftime("%Y-%m-%d %H:%M:%S") + " (Venue Local Time)"
                             email_subject = f"Check-in Reminder: {booking.title or resource.name}"


### PR DESCRIPTION
…rror in the scheduler.

This update introduces changes to help diagnose the persistent RuntimeError ("Unable to build URLs outside an active request without 'SERVER_NAME' configured") when `url_for` is called in the `send_checkin_reminders` scheduler task.

Here's what I did:

1.  **Enhanced `config.py`**:
    -   `SERVER_NAME` now has a default fallback value ('localhost:5000') if the `SERVER_NAME` environment variable is not set.
    -   I added `print()` statements during the loading of `config.py` to log the source (environment or fallback) and final effective values of `SERVER_NAME`, `APPLICATION_ROOT`, and `PREFERRED_URL_SCHEME`. This will help you verify how these configurations are initially determined.

2.  **Diagnostic Logging in `scheduler_tasks.py`**:
    -   I added a `logger.info()` statement in the `send_checkin_reminders` function, immediately before the `url_for()` call. This log will output the values of `SERVER_NAME`, `APPLICATION_ROOT`, and `PREFERRED_URL_SCHEME` as seen by `current_app.config` within the scheduler's execution context.

These changes aim to provide clear logging to pinpoint why the necessary configurations for external URL generation are not effectively available or are incorrect when the scheduler task runs.