### PR TITLE
Fix BuildError for 'auth.login' endpoint in UI check-in flow

### DIFF
--- a/routes/ui.py
+++ b/routes/ui.py
@@ -246,7 +246,7 @@ def check_in_at_resource(resource_id):
             flash("Please log in to check-in for this resource.", "info")
 
         # Redirect to login, then auth logic should handle 'next' and session flags.
-        return redirect(url_for('auth.login', next=url_for('ui.check_in_at_resource', resource_id=resource_id, _external=True)))
+        return redirect(url_for('ui.serve_login', next=url_for('ui.check_in_at_resource', resource_id=resource_id, _external=True)))
 
 
 # Function to register this blueprint in the app factory


### PR DESCRIPTION
This commit resolves a werkzeug.routing.exceptions.BuildError that occurred in the `check_in_at_resource` function within `routes/ui.py`. The error was "Could not build url for endpoint 'auth.login' ...", as no such endpoint exists.

The `url_for` call responsible for redirecting unauthenticated users to the login page was incorrectly targeting 'auth.login'.

The fix involves:
- Correcting the `url_for` call in `routes/ui.py` to point to 'ui.serve_login', which is the correct endpoint for your user-facing login page as configured by `login_manager.login_view`.

This ensures you are redirected to the proper login page when attempting to check in without being authenticated.