### PR TITLE
Fix BuildError for 'ui.index' in check_in_status.html template

### DIFF
--- a/templates/check_in_status.html
+++ b/templates/check_in_status.html
@@ -46,7 +46,7 @@
                     {% endif %}
 
                     <hr>
-                    <a href="{{ url_for('ui.index') }}" class="btn btn-secondary mr-2">Go to Homepage</a>
+                    <a href="{{ url_for('ui.serve_index') }}" class="btn btn-secondary mr-2">Go to Homepage</a>
                     {# 'resource_id' might not be passed if it's a generic failure before resource context is known #}
                     {# 'resource_name' is usually passed, so we check its existence too #}
                     {% if not success and resource_id is defined and resource_id and resource_name is defined and resource_name %}


### PR DESCRIPTION
This commit resolves a werkzeug.routing.exceptions.BuildError that occurred when rendering the `templates/check_in_status.html` template. The error was "Could not build url for endpoint 'ui.index'...", as this endpoint name was incorrect.

The `url_for` call for the "Go to Homepage" link within the template was mistakenly using 'ui.index'.

The fix involves:
- Correcting the `url_for` call in `templates/check_in_status.html` to use `ui.serve_index`, which is the correct endpoint for the application's homepage.