### PR TITLE
Refactor check-in window logic to ignore past booking adjustment

### DIFF
--- a/routes/api_bookings.py
+++ b/routes/api_bookings.py
@@ -1633,7 +1633,7 @@ def check_in_booking(booking_id):
         effective_now_local_naive = effective_now_aware.replace(tzinfo=None)
 
         booking_start_local_naive = booking.start_time # Naive venue local
-        effective_check_in_base_time_local_naive = booking_start_local_naive + timedelta(hours=past_booking_adjustment_hours)
+        effective_check_in_base_time_local_naive = booking_start_local_naive # Removed: + timedelta(hours=past_booking_adjustment_hours)
         check_in_window_start_local_naive = effective_check_in_base_time_local_naive - timedelta(minutes=check_in_minutes_before)
         check_in_window_end_local_naive = effective_check_in_base_time_local_naive + timedelta(minutes=check_in_minutes_after)
 


### PR DESCRIPTION
This commit modifies the check-in window calculation to align with your feedback, ensuring that `past_booking_time_adjustment_hours` no longer affects the determination of the check-in window for existing bookings. The window is now solely based on the booking's actual start time, `check_in_minutes_before`, and
`check_in_minutes_after`.

Changes made:

1.  **Modified `routes/api_bookings.py`**:
    -   In the `check_in_booking` function (handles API check-in requests),
        the `effective_check_in_base_time_local_naive` is now set
        directly to `booking_start_local_naive`, removing the addition
        of `past_booking_time_adjustment_hours`.
    -   The `_fetch_user_bookings_data` function (used to determine
        `can_check_in` for the 'My Bookings' page) was verified to
        already use this desired logic (basing the window on the
        actual `booking.start_time` without the adjustment).

2.  **Unit Tests**:
    -   A review of existing unit tests in `tests/test_app.py` indicated
        no specific tests were tightly coupled to the previous behavior
        of `past_booking_time_adjustment_hours` influencing the API
        check-in window. No test changes were required for this
        specific logic update.

This change ensures a more intuitive and consistent check-in window calculation, directly reflecting the booking's scheduled start time. The diagnostic logging added in previous commits for the check-in window calculation in `check_in_booking` has been retained to help verify this change in your environment.