### PR TITLE
Fix: Import check_booking_permission in api_resources

### DIFF
--- a/routes/api_resources.py
+++ b/routes/api_resources.py
@@ -13,7 +13,7 @@ from extensions import db
 # Assuming models are defined in models.py
 from models import User, Resource, Booking, FloorMap, Role, ResourcePIN, BookingSettings # Added User, Role, ResourcePIN, BookingSettings
 # Assuming utility functions are in utils.py
-from utils import add_audit_log, resource_to_dict, allowed_file, _import_resource_configurations_data
+from utils import add_audit_log, resource_to_dict, allowed_file, _import_resource_configurations_data, check_booking_permission
 # Assuming permission_required is in auth.py
 from auth import permission_required
 


### PR DESCRIPTION
This commit resolves a `NameError` in the `get_unavailable_dates` function within `routes/api_resources.py`. The function `check_booking_permission` was being called without being imported into the file's scope.

The missing import `from utils import check_booking_permission` has been added, ensuring the function is available and the endpoint can operate as intended, particularly the logic that verifies your permissions for booking a resource before considering its slots for availability.