### PR TITLE
Fix: Redefine 'passed slot' logic using slot start time

### DIFF
--- a/routes/api_resources.py
+++ b/routes/api_resources.py
@@ -354,10 +354,9 @@ def get_unavailable_dates():
                     is_slot_time_passed = False
                     if is_server_today:
                         logger.debug(f"[UNAVAIL_DATES][TODAY]   Checking slot: Resource ID {resource_to_check.id}, Slot {slot_def['start'].strftime('%H:%M')}-{slot_def['end'].strftime('%H:%M')} (Venue Local Time)")
-                        # Compare venue's cutoff time (expressed in UTC) with venue's slot end time (now correctly expressed in UTC)
-                        is_slot_time_passed = effective_cutoff_datetime_utc >= slot_end_for_comparison_utc
-                        logger.debug(f"[UNAVAIL_DATES][TODAY]     Effective Cutoff Venue Time (as UTC): {effective_cutoff_datetime_utc.isoformat()}, Slot End Venue Time (as UTC): {slot_end_for_comparison_utc.isoformat()}")
-                        logger.debug(f"[UNAVAIL_DATES][TODAY]     Is Slot Time Passed? {is_slot_time_passed}")
+                        # Compare venue's cutoff time (expressed in UTC) with venue's slot START time (correctly expressed in UTC)
+                        is_slot_time_passed = effective_cutoff_datetime_utc >= slot_start_for_comparison_utc
+                        logger.debug(f"[UNAVAIL_DATES][TODAY]     Effective Cutoff Venue Time (as UTC): {effective_cutoff_datetime_utc.isoformat()}, Slot START Venue Time (as UTC): {slot_start_for_comparison_utc.isoformat()}. Passed?: {is_slot_time_passed}")
                         if is_slot_time_passed:
                             logger.debug(f"[UNAVAIL_DATES][TODAY]     SLOT SKIPPED (time passed).")
                             continue


### PR DESCRIPTION
This commit updates the logic in `get_unavailable_dates` (routes/api_resources.py) for determining if a time slot is "passed". Previously, a slot was considered passed if the
`effective_cutoff_datetime_utc` was at or after the slot's *end* time.

The logic is now changed so that a slot is considered "passed" if the `effective_cutoff_datetime_utc` is at or after the slot's *start* time (`slot_start_for_comparison_utc`). This ensures that if the current effective time (adjusted for global and past booking offsets) has reached the beginning of a standard slot, that slot is no longer considered available for booking via the unavailable dates mechanism.

Corresponding test cases in `TestUnavailableDatesAPI` within `tests/test_app.py` have been updated to reflect this new definition, with assertions adjusted for scenarios where the cutoff falls between a slot's start and end times.