### PR TITLE
Fix: Universalize and refine slot passed logic in get_unavailable_dates

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1854,12 +1854,13 @@ class TestUnavailableDatesAPI(AppTests):
 
         # --- Assertions ---
         today_str = mock_now_utc.date().isoformat() # "2025-07-15"
-        print(f"Test: Negative Offset. Today: {today_str}. Unavailable Dates: {unavailable_dates_list}")
-        # Expected: Venue time is 16:00. Cutoff is 15:00.
-        # Afternoon slot 13:00-17:00. The part from 15:00-17:00 should be available.
-        # So, today should NOT be in the unavailable list.
-        self.assertNotIn(today_str, unavailable_dates_list,
-                         f"Today ({today_str}) should NOT be unavailable with negative offset making part of afternoon slot available.")
+        print(f"Test: Negative Offset (New Logic - Universal Cutoff). Today: {today_str}. Unavailable Dates: {unavailable_dates_list}")
+        # Expected (New Logic - Universal Cutoff): Cutoff 15:00 UTC (Venue Time).
+        # Morning slot (08:00-12:00 VT) -> Start 10:00 UTC. Cutoff 15:00 UTC >= Slot Start 10:00 UTC -> Morning PASSED.
+        # Afternoon slot (13:00-17:00 VT) -> Start 15:00 UTC. Cutoff 15:00 UTC >= Slot Start 15:00 UTC -> Afternoon PASSED.
+        # Both standard slots passed, so today *should* be in the unavailable list.
+        self.assertIn(today_str, unavailable_dates_list,
+                         f"Today ({today_str}) SHOULD BE unavailable as the cutoff (15:00 Venue Time) makes both standard slots passed.")
 
     @patch('routes.api_resources.datetime')
     def test_day_unavailable_due_to_conflict_multi_disabled(self, mock_datetime_in_api):


### PR DESCRIPTION
This commit addresses two key aspects of the `get_unavailable_dates` function in `routes/api_resources.py` to ensure accurate determination of unavailable dates for the Flatpickr calendar:

1.  The logic for determining if a slot is "time passed" (`is_slot_time_passed`) now correctly compares the `effective_cutoff_datetime_utc` against the slot's actual UTC *start* time (`slot_start_for_comparison_utc`). Previously, it compared against the slot's end time. This ensures a slot is marked as passed as soon as the cutoff reaches its beginning.

2.  This `is_slot_time_passed` check is now applied universally to all dates processed by the function, not just the current server day (`is_server_today`). This ensures that the cutoff logic correctly affects future dates if the cutoff is advanced (e.g., due to a negative `past_booking_time_adjustment_hours`) or past dates when `allow_past_bookings` is true.

Additionally, the client-side JavaScript in `new_booking_map.js` was confirmed to have the correct `latestSlotEndTimeHour = 17` for its "today" heuristic (this was likely corrected in a prior commit).

Test cases in `TestUnavailableDatesAPI` within `tests/test_app.py` have been reviewed and updated to reflect these refined logic changes, ensuring assertions match the expected outcomes for various cutoff and slot timing scenarios.

These changes should provide a more accurate `unavailableDatesList` to the frontend, correctly reflecting days where no slots are bookable by you due to time cutoffs, existing bookings, conflicts, or permissions.