### PR TITLE
Fix: Set app.logger.propagate to False to prevent duplicate logs

### DIFF
--- a/app_factory.py
+++ b/app_factory.py
@@ -203,6 +203,8 @@ def create_app(config_object=config, testing=False): # Added testing parameter
     app_effective_log_level = log_level_map.get(app_log_level_config, logging.INFO)
     app.logger.setLevel(app_effective_log_level)
     logging.info(f"Flask app.logger level set to {app_log_level_config} (effective: {app.logger.level}).")
+    app.logger.propagate = False
+    logging.info("Disabled propagation for app.logger to prevent duplicate console logs.")
 
     # Ensure DEBUG level is comprehensively set if configured
     if app.config.get('LOG_LEVEL') == 'DEBUG':


### PR DESCRIPTION
Updated `app_factory.py` to set `app.logger.propagate = False`. This prevents logs handled by the Flask app's logger from also being passed to the root logger, which was leading to duplicate output in your console.

This is a further attempt to resolve the duplicate logging issue based on your feedback after the initial fix.