### PR TITLE
Debug: Add boundary logging for check_booking_permission call

### DIFF
--- a/routes/api_bookings.py
+++ b/routes/api_bookings.py
@@ -317,7 +317,9 @@ def create_booking():
         current_offset_hours = booking_settings.global_time_offset_hours
 
     # Permission Enforcement Logic
+    current_app.logger.info("--- About to call check_booking_permission ---")
     can_book, permission_error_message = check_booking_permission(current_user, resource, current_app.logger)
+    current_app.logger.info(f"--- Returned from check_booking_permission (can_book: {can_book}) ---")
     if not can_book:
         # The logger calls are now inside check_booking_permission
         return jsonify({'error': permission_error_message}), 403


### PR DESCRIPTION
I've added logging statements before and after the call to `check_booking_permission` in the `create_booking` route in `routes/api_bookings.py`.

This is to help determine if the `check_booking_permission` function, or the route segment calling it, is being executed multiple times, which could explain the persistent duplicate logs from `utils.py`.