### PR TITLE
Refactor: Explicitly configure app.logger handler and remove debug logs

### DIFF
--- a/app_factory.py
+++ b/app_factory.py
@@ -203,8 +203,19 @@ def create_app(config_object=config, testing=False): # Added testing parameter
     app_effective_log_level = log_level_map.get(app_log_level_config, logging.INFO)
     app.logger.setLevel(app_effective_log_level)
     logging.info(f"Flask app.logger level set to {app_log_level_config} (effective: {app.logger.level}).")
+
+    # Clear existing handlers and add a new explicit one
+    app.logger.handlers.clear()
+    logging.info("Cleared existing handlers from app.logger.")
+
+    stream_handler_app = logging.StreamHandler()
+    formatter_app = logging.Formatter('[%(asctime)s] %(levelname)s in %(module)s: %(message)s')
+    stream_handler_app.setFormatter(formatter_app)
+    app.logger.addHandler(stream_handler_app)
+    logging.info("Added new explicit StreamHandler to app.logger.")
+
     app.logger.propagate = False
-    logging.info("Disabled propagation for app.logger to prevent duplicate console logs.")
+    logging.info("Ensured app.logger.propagate is False.")
 
     # Ensure DEBUG level is comprehensively set if configured
     if app.config.get('LOG_LEVEL') == 'DEBUG':

--- a/routes/api_bookings.py
+++ b/routes/api_bookings.py
@@ -317,9 +317,7 @@ def create_booking():
         current_offset_hours = booking_settings.global_time_offset_hours
 
     # Permission Enforcement Logic
-    current_app.logger.info("--- About to call check_booking_permission ---")
     can_book, permission_error_message = check_booking_permission(current_user, resource, current_app.logger)
-    current_app.logger.info(f"--- Returned from check_booking_permission (can_book: {can_book}) ---")
     if not can_book:
         # The logger calls are now inside check_booking_permission
         return jsonify({'error': permission_error_message}), 403


### PR DESCRIPTION
- In `app_factory.py`:
  - I cleared any existing handlers from `app.logger`.
  - I added a single, explicit `StreamHandler` to `app.logger` with a specific format.
  - I ensured `app.logger.propagate = False` remains set. This aims to provide definitive control over `app.logger`'s output and resolve potential duplicate logging issues stemming from its configuration.

- In `routes/api_bookings.py`:
  - I removed temporary diagnostic logging statements around the `check_booking_permission` call in the `create_booking` route, as they are no longer needed for the current investigation.