### PR TITLE
I've enhanced the trace logging in the `get_unavailable_dates` function.

### DIFF
--- a/routes/api_resources.py
+++ b/routes/api_resources.py
@@ -267,6 +267,7 @@ def get_unavailable_dates():
         current_iter_date = start_range_date
         while current_iter_date <= end_range_date:
             current_processing_date = current_iter_date
+            logger.debug(f"--- Processing date: {current_processing_date} ---")
             logger.debug(f"[VERBOSE_UNAVAIL] Processing Date: {current_processing_date}")
 
             # a. Past Date Check
@@ -335,15 +336,13 @@ def get_unavailable_dates():
                 # Ensure target_user is defined in this function's scope (it is, as a parameter)
                 # Ensure logger is defined (it is, as current_app.logger)
 
-                if resource_to_check.id == 51: # Or another specific ID you are seeing issues with
-                    logger.debug(f"--- (get_unavailable_dates) About to call check_booking_permission for resource ID 51 on date {current_processing_date} ---")
+                logger.debug(f"--- (get_unavailable_dates) About to call check_booking_permission for resource ID {resource_to_check.id} ('{resource_to_check.name}') on date {current_processing_date} ---")
                 can_book_this_resource, _ = check_booking_permission(
                     user=target_user,
                     resource=resource_to_check,
                     logger_instance=logger
                 )
-                if resource_to_check.id == 51:
-                    logger.debug(f"--- (get_unavailable_dates) Returned from check_booking_permission for resource ID 51 (can_book: {can_book_this_resource}) on date {current_processing_date} ---")
+                logger.debug(f"--- (get_unavailable_dates) Returned from check_booking_permission for resource ID {resource_to_check.id} ('{resource_to_check.name}') (can_book: {can_book_this_resource}) on date {current_processing_date} ---")
                 logger.debug(f"[VERBOSE_UNAVAIL] Date: {current_processing_date}, Resource: {resource_to_check.id} ('{resource_to_check.name}'), Permitted: {can_book_this_resource}")
 
                 if not can_book_this_resource:


### PR DESCRIPTION
Here's what I did in `routes/api_resources.py`:

- I added a log statement at the start of each date iteration within the main `while` loop. This will show you which date is currently being processed.
- I removed the specific resource ID filter (it was ID 51) for the logs around the `check_booking_permission` call. Now, these logs will execute for all resources being checked on each date.
- I included the resource ID and name in these debug logs to give you better context.

These changes will provide a more detailed trace when you're debugging. This should help you understand the full execution flow and identify why certain dates might not be processed or reported as you expect.