### PR TITLE
Fix: Remove legacy incremental backup code and imports

### DIFF
--- a/routes/admin_ui.py
+++ b/routes/admin_ui.py
@@ -25,8 +25,7 @@ from utils import load_scheduler_settings, save_scheduler_settings, DEFAULT_FULL
 import os
 import json
 from apscheduler.jobstores.base import JobLookupError
-# from scheduler_tasks import run_scheduled_booking_csv_backup, run_scheduled_incremental_booking_backup # run_scheduled_booking_csv_backup is legacy
-from scheduler_tasks import run_scheduled_incremental_booking_backup # Added run_scheduled_incremental_booking_backup
+# from scheduler_tasks import run_scheduled_booking_csv_backup # run_scheduled_booking_csv_backup is legacy
 from translations import _ # For flash messages and other translatable strings
 
 admin_ui_bp = Blueprint('admin_ui', __name__, url_prefix='/admin', template_folder='../templates')

--- a/scheduler_tasks.py
+++ b/scheduler_tasks.py
@@ -6,7 +6,7 @@ from utils import add_audit_log, send_email, _get_map_configuration_data, _get_r
 from azure_backup import (
     # backup_bookings_csv, # LEGACY - Functionality commented out
     create_full_backup,
-    backup_incremental_bookings, # This is legacy incremental, may also be removed.
+    # backup_incremental_bookings, # This is legacy incremental, may also be removed. # Ensure this line is removed or commented out if part of a multi-line import
     backup_scheduled_incremental_booking_data, # New unified incremental
     backup_full_booking_data_json_azure # New unified full
 )
@@ -649,32 +649,6 @@ def send_checkin_reminders(app):
             logger.error(f"Scheduler: Error in send_checkin_reminders task's main try block: {e_task}", exc_info=True)
         finally:
             logger.info("Scheduler: Task 'send_checkin_reminders' finished.")
-
-
-def run_scheduled_incremental_booking_backup(app):
-    """
-    Scheduled task entry point to run an incremental backup of booking data.
-    """
-    with app.app_context():
-        logger = app.logger
-        logger.info("Scheduler: Starting run_scheduled_incremental_booking_backup task...")
-        try:
-            # Call the actual backup function from azure_backup.py
-            # socketio_instance and task_id are None for a non-interactive scheduled job
-            # The backup_incremental_bookings function needs to be designed to handle app context
-            # and potentially log its own progress/errors.
-            success = backup_incremental_bookings(
-                app=app,
-                socketio_instance=None, # No specific user socket for scheduled task
-                task_id=None # No specific task ID from user action
-            )
-            if success: # Assuming backup_incremental_bookings returns a boolean or similar success indicator
-                logger.info("Scheduler: Incremental booking backup task executed successfully.")
-            else:
-                logger.warning("Scheduler: Incremental booking backup task executed but reported issues (e.g., returned False or no explicit success). Check azure_backup logs for details.")
-        except Exception as e:
-            logger.error(f"Scheduler: Exception during run_scheduled_incremental_booking_backup execution: {e}", exc_info=True)
-        logger.info("Scheduler: run_scheduled_incremental_booking_backup task finished.")
 
 # --- New Unified Scheduled Backup Tasks ---
 


### PR DESCRIPTION
I removed the unused function `run_scheduled_incremental_booking_backup` from `scheduler_tasks.py` and its associated import of `backup_incremental_bookings` from `azure_backup.py`.

I also removed the unused import of `run_scheduled_incremental_booking_backup` from `routes/admin_ui.py`.

This functionality was marked as legacy and was causing an ImportError because `backup_incremental_bookings` no longer exists (likely replaced by `backup_incremental_bookings_generic` or the newer unified backup system).