### PR TITLE
Fix: Add missing _import_resource_configurations_data stub to utils.py

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -387,6 +387,29 @@ def import_bookings_from_csv_file(csv_file_path, app_instance, clear_existing: b
     logger.info(f"{import_context_message_prefix}import_bookings_from_csv_file for {csv_file_path} - STUB. Clear: {clear_existing}")
     return {'processed': 0, 'created': 0, 'updated': 0, 'skipped_duplicates': 0, 'skipped_fk_violation': 0, 'skipped_other_errors': 0, 'errors': ["Stub implementation"], 'status': 'stub_executed'}
 
+def _import_resource_configurations_data(resources_data_list: list) -> tuple[int, int, list]:
+    logger = current_app.logger if current_app else logging.getLogger(__name__)
+    logger.warning("_import_resource_configurations_data is currently a STUB. Import will not function correctly.")
+    # Args: resources_data_list (list of dicts)
+    # Returns: tuple (created_count, updated_count, errors_list)
+    created_count = 0
+    updated_count = 0
+    errors = []
+
+    # Example of how it might iterate, actual logic is missing
+    # for resource_data in resources_data_list:
+    #     try:
+    #         # ... find or create resource ...
+    #         # ... update fields ...
+    #         # if new: created_count += 1
+    #         # else: updated_count += 1
+    #         pass # Placeholder for actual import logic
+    #     except Exception as e:
+    #         errors.append(f"Error processing resource data {resource_data.get('name', 'Unknown')}: {str(e)}")
+
+    errors.append("This function is a stub and did not process any data.")
+    return created_count, updated_count, errors
+
 def _load_schedule_from_json(): # Example, might need current_app context
     logger = current_app.logger if current_app else logging.getLogger(__name__)
     logger.debug("_load_schedule_from_json STUB")


### PR DESCRIPTION
Restores the function `_import_resource_configurations_data` as a stub in `utils.py` to resolve an `ImportError` that prevented `routes/api_resources.py` from importing it.

This error was introduced inadvertently when previously modifying `utils.py` to implement availability calculation logic. Adding the stub allows the application to start. The actual import functionality for resource configurations will need to be verified or implemented separately if it's found to be non-functional due to the stub.