### PR TITLE
Fix: Add missing _import_map_configuration_data stub to utils.py

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -401,6 +401,23 @@ def _get_map_configuration_data() -> dict:
         'message': "Stub implementation: No actual map configuration data exported."
     }
 
+def _import_map_configuration_data(config_data: dict) -> tuple[dict, int]:
+    logger = current_app.logger if current_app else logging.getLogger(__name__)
+    logger.warning("_import_map_configuration_data is currently a STUB. Importing map configurations will not actually process data.")
+    # Expected to return a tuple: (summary_dict, status_code)
+    # summary_dict might contain counts of created/updated maps/resources and any errors.
+    summary = {
+        'maps_processed': 0,
+        'maps_created': 0,
+        'maps_updated': 0,
+        'resources_processed': 0,
+        'resources_updated_map_info': 0,
+        'errors': ["Stub implementation: No actual map configuration data imported."],
+        'message': "Map configuration import is currently a STUB."
+    }
+    status_code = 200 # Or 207 if errors were genuinely processed
+    return summary, status_code
+
 def _import_resource_configurations_data(resources_data_list: list) -> tuple[int, int, list]:
     logger = current_app.logger if current_app else logging.getLogger(__name__)
     logger.warning("_import_resource_configurations_data is currently a STUB. Import will not function correctly.")


### PR DESCRIPTION
Restores the function `_import_map_configuration_data` as a stub in `utils.py` to resolve an `ImportError` that prevented `routes/api_maps.py` from importing it.

This error was inadvertently introduced when `utils.py` was previously modified. Adding the stub allows the application to start. The actual map configuration import functionality will need to be verified or implemented separately if found to be non-functional.