### PR TITLE
I addressed the "TemplateNotFound" error for the admin backup page an…

### DIFF
--- a/templates/admin/backup_booking_data.html
+++ b/templates/admin/backup_booking_data.html
@@ -1,4 +1,4 @@
-{% extends "admin/admin_layout.html" %}
+{% extends "base.html" %}
 
 {% block title %}{{ _("Booking Data Management") }}{% endblock %}
 


### PR DESCRIPTION
…d looked into the Azure module issue.

- I corrected `backup_booking_data.html` to extend `base.html` instead of the non-existent `admin/admin_layout.html`.
- I investigated the "Azure backup module not available" error. It seems `azure_backup.py` tries to import `azure.storage.fileshare`. This package is correctly listed in `requirements.txt`. The error likely means the package isn't installed where your code is running.