### PR TITLE
Fix BuildError for get_server_time in admin backup page

### DIFF
--- a/templates/admin/backup_booking_data.html
+++ b/templates/admin/backup_booking_data.html
@@ -258,11 +258,11 @@
     function showProgressModal(message) { $('#actionProgressMessage').text(message); $('#actionProgressModal').modal({backdrop: 'static', keyboard: false}); }
     function hideProgressModal() { $('#actionProgressModal').modal('hide'); }
     function updateServerTime() {
-        fetch("{{ url_for('api_system.get_server_time') }}")
+        fetch("{{ url_for('api_system.ping') }}")
         .then(response => response.json())
         .then(data => {
-            if(data.time) {
-                document.getElementById('server-time').textContent = "{{ _('Current Server Time (UTC):') }} " + data.time;
+            if(data.timestamp) {
+                document.getElementById('server-time').textContent = "{{ _('Current Server Time (UTC):') }} " + data.timestamp;
             } else {
                 document.getElementById('server-time').textContent = "{{ _('Could not load server time.') }}";
             }


### PR DESCRIPTION
I corrected the `url_for` call in the `updateServerTime` JavaScript function within `templates/admin/backup_booking_data.html`. I changed it from `api_system.get_server_time` (which doesn't exist) to `api_system.ping`.
I also updated the JavaScript to use `data.timestamp` from the response instead of the previously expected `data.time` to correctly display the server time.