### PR TITLE
Fix BuildError for clear_all_booking_data_api

### DIFF
--- a/templates/admin/backup_booking_data.html
+++ b/templates/admin/backup_booking_data.html
@@ -671,7 +671,7 @@
     function executeClearAllBookingData() {
         $('#confirmClearAllModal').modal('hide');
         showProgressModal("{{ _('Clearing all booking data...') }}");
-        fetch("{{ url_for('api_system.clear_all_booking_data_api') }}", { // Ensure this API endpoint is correct
+        fetch("{{ url_for('admin_ui.clear_all_bookings_data') }}", { // Ensure this API endpoint is correct
             method: 'POST',
             headers: { 'X-CSRFToken': '{{ csrf_token() }}' }
         })


### PR DESCRIPTION
I corrected the `url_for` call in the `executeClearAllBookingData` JavaScript function within `templates/admin/backup_booking_data.html`. I changed it from `api_system.clear_all_booking_data_api` (which was causing a BuildError) to the correct endpoint `admin_ui.clear_all_bookings_data`.