### PR TITLE
Fix: Uncomment Socket.IO client library in base template

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -135,7 +135,7 @@
     </div>
 
     {% block scripts %}
-    <!-- <script src="/socket.io/socket.io.js"></script> -->
+    <script src="/socket.io/socket.io.js"></script>
     <script src="{{ url_for('static', filename='js/script.js') }}" defer></script>
     <script src="{{ url_for('static', filename='libs/flatpickr/flatpickr.min.js') }}"></script>
     <script src="https://cdn.jsdelivr.net/npm/qrcodejs@1.0.0/qrcode.min.js"></script>


### PR DESCRIPTION
I uncommented the script tag for `/socket.io/socket.io.js` in `templates/base.html`. This ensures the Socket.IO client library is loaded, resolving the `Uncaught ReferenceError: io is not defined` JavaScript error that was occurring on pages attempting to use Socket.IO functionalities, such as admin/backup/booking_data.