### PR TITLE
Fix: Configure Gunicorn for Flask-SocketIO in Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: gunicorn --bind=0.0.0.0 --timeout 600 wsgi:app
+web: gunicorn --worker-class eventlet --bind=0.0.0.0 --timeout 600 wsgi:app
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ APScheduler
 Flask-Migrate
 Pillow>=9.0.0
 google-api-python-client>=2.0.0
+eventlet


### PR DESCRIPTION
I modified the Procfile to use `--worker-class eventlet` for Gunicorn. This is necessary for Flask-SocketIO to function correctly and serve its client-side JavaScript library (`socket.io.js`) when the application is run using Gunicorn (e.g., in a PaaS environment).

I also added `eventlet` to `requirements.txt` as it's a required dependency for this Gunicorn worker type.

This change aims to resolve the 400 Bad Request error for `/socket.io/socket.io.js` and the subsequent `io is not defined` JavaScript error.