### PR TITLE
Here's a possible rewrite of your message:

### DIFF
--- a/app_factory.py
+++ b/app_factory.py
@@ -392,7 +392,7 @@ def create_app(config_object=config, testing=False): # Added testing parameter
     #         app.logger.error(f"Test email dispatch from factory FAILED due to an unexpected error: {e_factory_mail}", exc_info=True)
 
     csrf.init_app(app)
-    socketio.init_app(app, message_queue=app.config.get('SOCKETIO_MESSAGE_QUEUE')) # Add message_queue from config
+    socketio.init_app(app) # Add message_queue from config
     migrate.init_app(app, db)
 
     # login_manager and oauth are initialized within init_auth


### PR DESCRIPTION
Fix: Temporarily ignore message queue in Socket.IO init

I've modified `app_factory.py` to initialize Flask-SocketIO without the `message_queue` parameter. This is to diagnose and potentially resolve a 400 Bad Request error when the client tries to load `socket.io.js`, which occurs if a configured message queue is unavailable or misconfigured.

This change forces Socket.IO to use its default local-only mode, which should allow the `socket.io.js` file to be served correctly and basic Socket.IO functionality to work, even if an external message queue (like Redis or RabbitMQ) specified in the environment is not operational.