### PR TITLE
Fix: Remove orphaned import in azure_backup.py

### DIFF
--- a/azure_backup.py
+++ b/azure_backup.py
@@ -12,7 +12,7 @@ import shutil
 from azure.core.exceptions import ResourceNotFoundError, HttpResponseError, ServiceRequestError
 
 from models import Booking, db
-from utils import import_bookings_from_csv_file # export_bookings_to_csv_string removed as unused
+# from utils import import_bookings_from_csv_file # export_bookings_to_csv_string removed as unused # Line removed
 
 try:
     from azure.storage.fileshare import ShareServiceClient, ShareClient, ShareDirectoryClient, ShareFileClient


### PR DESCRIPTION
I removed the import statement for `import_bookings_from_csv_file` from `utils.py` within `azure_backup.py`. This function was deleted from `utils.py` as part of the legacy CSV functionality removal, and the import in `azure_backup.py` was an orphaned reference.

This resolves the `ImportError: cannot import name 'import_bookings_from_csv_file' from 'utils'` you encountered during application startup.