### PR TITLE
Fix: Resolve RuntimeError for application context

### DIFF
--- a/app_factory.py
+++ b/app_factory.py
@@ -539,7 +539,8 @@ def create_app(config_object=config, testing=False): # Added testing parameter
             # or if the function itself is designed to fetch current_app.
             # If app_context is needed: with app.app_context(): unified_schedule_settings = load_unified_backup_schedule_settings()
             # However, load_unified_backup_schedule_settings uses current_app.config directly, which should be fine here.
-            unified_schedule_settings = load_unified_backup_schedule_settings()
+            # Updated: load_unified_backup_schedule_settings now requires 'app' argument.
+            unified_schedule_settings = load_unified_backup_schedule_settings(app)
             app.logger.info(f"Loaded unified backup schedule settings: {unified_schedule_settings}")
 
             # Remove Old Job Configuration for Incrementals (ID: scheduled_booking_data_protection_job)

--- a/routes/api_system.py
+++ b/routes/api_system.py
@@ -379,7 +379,7 @@ def api_download_booking_data_backup(backup_type, filename):
 def get_unified_backup_schedule():
     current_app.logger.info(f"User {current_user.username} fetching unified backup schedule settings.")
     try:
-        settings = load_unified_backup_schedule_settings()
+        settings = load_unified_backup_schedule_settings(current_app) # Pass current_app
         return jsonify(settings), 200
     except Exception as e:
         current_app.logger.exception("Error fetching unified backup schedule settings:")

--- a/utils.py
+++ b/utils.py
@@ -475,10 +475,10 @@ def _save_schedule_to_json(data_to_save): # Example
     logger.debug(f"_save_schedule_to_json STUB with data: {data_to_save}")
     return True, "Stub save successful"
 
-def load_unified_backup_schedule_settings():
-    logger = current_app.logger if current_app else logging.getLogger(__name__)
-    config_file = current_app.config['UNIFIED_SCHEDULE_CONFIG_FILE']
-    default_settings = current_app.config['DEFAULT_UNIFIED_SCHEDULE_DATA']
+def load_unified_backup_schedule_settings(app): # app instance passed as argument
+    logger = app.logger # Use app.logger
+    config_file = app.config['UNIFIED_SCHEDULE_CONFIG_FILE'] # Use app.config
+    default_settings = app.config['DEFAULT_UNIFIED_SCHEDULE_DATA'] # Use app.config
 
     if not os.path.exists(config_file):
         logger.warning(f"Unified backup schedule file '{config_file}' not found. Returning default settings.")
@@ -615,7 +615,8 @@ def reschedule_unified_backup_jobs(app_instance):
     # If called from a place without app context, app_instance.config should be used by
     # load_unified_backup_schedule_settings, or settings passed to it.
     # For now, assuming it's called from api_system.py route, so app_context is available.
-    unified_schedule_settings = load_unified_backup_schedule_settings()
+    # THIS IS NOW CHANGED: load_unified_backup_schedule_settings now takes 'app'
+    unified_schedule_settings = load_unified_backup_schedule_settings(app_instance)
     app_instance.logger.info(f"Loaded settings for rescheduling: {unified_schedule_settings}")
 
     # Reschedule Incremental Backup Job


### PR DESCRIPTION
Modified `utils.load_unified_backup_schedule_settings` to accept an explicit `app` argument instead of relying on `current_app`. This resolves a `RuntimeError: Working outside of application context` that occurred when this function was called during scheduler initialization in `app_factory.py` before the app context was fully available for `current_app`.

Changes:
- `utils.load_unified_backup_schedule_settings` now takes `app` and uses `app.config` and `app.logger`.
- Updated callers in `app_factory.py` to pass the `app` instance.
- Updated callers in `routes.api_system.py` (the GET endpoint for schedule settings) to pass `current_app`.
- Verified that `utils.reschedule_unified_backup_jobs` correctly uses its `app_instance` argument.