### PR TITLE
Fix: Correct final APScheduler remove_job TypeError in app_factory

### DIFF
--- a/app_factory.py
+++ b/app_factory.py
@@ -586,8 +586,14 @@ def create_app(config_object=config, testing=False): # Added testing parameter
                 app.logger.warning("run_scheduled_incremental_booking_data_task function not found. Unified incremental backup job not added.")
 
             # Remove Old Hardcoded Job for Full Unified Backup (ID: periodic_full_booking_data_job)
-            app.logger.info("Attempting to remove old hardcoded full backup job (ID: periodic_full_booking_data_job) if it exists.")
-            scheduler.remove_job('periodic_full_booking_data_job', ignore_errors=True)
+            app.logger.info("Attempting to remove old hardcoded full backup job (ID: periodic_full_booking_data_job) if it exists.") # Added log line for clarity
+            try:
+                scheduler.remove_job('periodic_full_booking_data_job')
+                app.logger.info("Successfully removed old hardcoded job 'periodic_full_booking_data_job' at startup.")
+            except JobLookupError:
+                app.logger.info("Old hardcoded job 'periodic_full_booking_data_job' not found at startup, skipping removal.")
+            except Exception as e:
+                app.logger.error(f"Error removing old hardcoded job 'periodic_full_booking_data_job' at startup: {e}")
 
             # Configure Unified Full Backup Job
             if run_periodic_full_booking_data_task:


### PR DESCRIPTION
I addressed the last remaining `TypeError` caused by the `ignore_errors` argument in a `scheduler.remove_job()` call within `app_factory.py`. This occurred when attempting to remove the old hardcoded job ID 'periodic_full_booking_data_job' during scheduler initialization.

The call has been updated to use a try-except block, catching `JobLookupError` if the job does not exist, consistent with previous fixes for this issue.

This change should allow your application to start without the APScheduler-related TypeErrors.