### PR TITLE
Fix: Revert explicit async_mode in SocketIO constructor

### DIFF
--- a/extensions.py
+++ b/extensions.py
@@ -11,5 +11,5 @@ login_manager = LoginManager()
 oauth = OAuth()
 # mail = Mail() # Removed
 csrf = CSRFProtect()
-socketio = SocketIO(async_mode='eventlet', manage_session=False, logger=True, engineio_logger=True)
+socketio = SocketIO(manage_session=False, logger=True, engineio_logger=True)
 migrate = Migrate()


### PR DESCRIPTION
Removed `async_mode='eventlet'` from the `SocketIO()` initialization in `extensions.py`. Explicitly setting this was causing a `ValueError: Invalid async_mode specified` on startup.

Flask-SocketIO, when used with `socketio.run(app, ...)`, will auto-detect `eventlet` (if installed) more reliably. The `manage_session=False` and logger arguments are retained. This change allows the application to start so further diagnostics on the original Socket.IO 400 error can proceed.