### PR TITLE
Improve error handling for one-click backup

### DIFF
--- a/routes/api_system.py
+++ b/routes/api_system.py
@@ -437,7 +437,7 @@ def api_one_click_backup():
 
     if not create_full_backup:
         current_app.logger.error("Azure backup module not available for one-click backup.")
-        return jsonify({'success': False, 'message': 'Backup module is not configured or available.', 'task_id': task_id}), 500
+        return jsonify({'success': False, 'message': "Azure backup module is not available. Please ensure the 'azure-storage-file-share' package is installed and the 'AZURE_STORAGE_CONNECTION_STRING' environment variable is correctly configured.", 'task_id': task_id}), 501
     try:
         timestamp_str = datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S')
         map_config_data = _get_map_configuration_data() # Uses models directly, ensure they are imported

--- a/templates/admin/backup_system.html
+++ b/templates/admin/backup_system.html
@@ -72,6 +72,9 @@
             <section id="backup-section" class="mb-4">
                 <h5>{{ _('One Click Backup') }}</h5>
                 <p>{{ _('Perform a full backup of the database, map configurations, and uploaded media files.') }}</p>
+                <div class="alert alert-info alert-sm" role="alert">
+                    <small><i class="fas fa-info-circle"></i> {{ _('Note: The One Click Backup feature requires Azure Storage to be configured. This includes installing the necessary Python package (azure-storage-file-share) and setting the AZURE_STORAGE_CONNECTION_STRING environment variable.') }}</small>
+                </div>
                 <button id="one-click-backup-btn" class="btn btn-primary"><i class="fas fa-cloud-upload-alt"></i> {{ _('Perform Full Backup Now') }}</button>
                 <div id="backup-status-message" class="mt-2"></div>
             </section>


### PR DESCRIPTION
This commit enhances the user experience when the one-click backup feature fails due to missing Azure dependencies.

Changes include:
- Modified `routes/api_system.py` to return a more specific error message (HTTP 501) when the Azure backup module (azure_backup.py) cannot be loaded. The message now advises checking for the `azure-storage-file-share` package and the `AZURE_STORAGE_CONNECTION_STRING` environment variable.
- Verified that the frontend JavaScript (`static/js/admin_backup_common.js`) correctly displays the detailed error message provided by the backend.
- Added an informational note on the System Backup & Restore page (`templates/admin/backup_system.html`) to proactively inform administrators about the Azure Storage requirements for this feature.