### PR TITLE
Add further temporary debug prints to azure_backup.py

### DIFF
--- a/azure_backup.py
+++ b/azure_backup.py
@@ -1,3 +1,4 @@
+print("DEBUG azure_backup.py: TOP OF FILE - Module import started.")
 import os
 import hashlib
 import logging
@@ -59,6 +60,7 @@ BOOKING_DATA_INCREMENTAL_DIR_SUFFIX = "incrementals"
 LAST_UNIFIED_BOOKING_INCREMENTAL_TIMESTAMP_FILE = os.path.join(DATA_DIR, 'last_unified_booking_incremental_timestamp.txt')
 LAST_BOOKING_DATA_PROTECTION_INCREMENTAL_TIMESTAMP_FILE = os.path.join(DATA_DIR, 'last_booking_data_protection_incremental_timestamp.txt')
 
+print(f"DEBUG azure_backup.py: Path constants defined. BASE_DIR is {BASE_DIR}, DATA_DIR is {DATA_DIR}, STATIC_DIR is {STATIC_DIR}")
 
 def _get_service_client():
     print(f"DEBUG azure_backup.py _get_service_client(): Called")


### PR DESCRIPTION
This commit adds more specific temporary print statements to the very beginning of `azure_backup.py` and after its global path constant definitions.

This is to diagnose if the module is failing during its own initial import process, before any of its functions are called by other modules like `api_system.py`.

These debug statements are intended for temporary diagnostic purposes and should be removed after the issue is identified.