### PR TITLE
Add temporary debug print at the end of azure_backup.py

### DIFF
--- a/azure_backup.py
+++ b/azure_backup.py
@@ -773,3 +773,9 @@ def download_booking_data_json_backup(filename: str, backup_type: str):
     except Exception as e:
         logger.error(f"Unexpected error downloading unified backup '{filename}': {e}", exc_info=True)
         return None
+
+print(f"DEBUG azure_backup.py: END OF FILE. Type of create_full_backup is {type(create_full_backup)}")
+if callable(create_full_backup):
+    print("DEBUG azure_backup.py: create_full_backup is callable.")
+else:
+    print("DEBUG azure_backup.py: create_full_backup is NOT callable (or is None).")


### PR DESCRIPTION
This commit adds a temporary print statement to the very end of `azure_backup.py` to check the type and callability of the `create_full_backup` function from within the module itself.

This is to further diagnose why `api_system.py` might be failing to import this function, even if the module appears to start loading correctly.

These debug statements are intended for temporary diagnostic purposes and should be removed after the issue is identified.