### PR TITLE
Fix: Add all missing placeholders to azure_backup.py

### DIFF
--- a/azure_backup.py
+++ b/azure_backup.py
@@ -800,3 +800,64 @@ def download_booking_data_json_backup(filename: str, backup_type: str):
     except Exception as e:
         logger.error(f"Unexpected error downloading unified backup '{filename}': {e}", exc_info=True)
         return None
+
+# --- Placeholder Functions for api_system.py Imports ---
+
+def verify_backup_set(backup_timestamp, socketio_instance=None, task_id=None):
+    logger.warning(f"Placeholder function 'verify_backup_set' called for {backup_timestamp}. Not implemented.")
+    _emit_progress(socketio_instance, task_id, 'verify_backup_progress', "Verification not implemented.", detail='NOT_IMPLEMENTED', level='WARNING')
+    return {'status': 'not_implemented', 'message': 'Verification feature is not implemented.', 'checks': [], 'errors': ['Not implemented']}
+
+def delete_backup_set(backup_timestamp, socketio_instance=None, task_id=None):
+    logger.warning(f"Placeholder function 'delete_backup_set' called for {backup_timestamp}. Not implemented.")
+    _emit_progress(socketio_instance, task_id, 'backup_delete_progress', "Deletion not implemented.", detail='NOT_IMPLEMENTED', level='WARNING')
+    return False
+
+def restore_database_component(backup_timestamp, db_share_client, dry_run=False, socketio_instance=None, task_id=None):
+    logger.warning(f"Placeholder 'restore_database_component' for {backup_timestamp}, dry_run={dry_run}. Not implemented.")
+    _emit_progress(socketio_instance, task_id, 'restore_progress', "DB component restore not implemented.", level='WARNING')
+    return False, "DB component restore not implemented.", None, None # success, message, db_path, actions
+
+def download_map_config_component(backup_timestamp, config_share_client, dry_run=False, socketio_instance=None, task_id=None):
+    logger.warning(f"Placeholder 'download_map_config_component' for {backup_timestamp}, dry_run={dry_run}. Not implemented.")
+    _emit_progress(socketio_instance, task_id, 'restore_progress', "Map config download not implemented.", level='WARNING')
+    return False, "Map config download not implemented.", None, None # success, message, local_path, actions
+
+def restore_media_component(backup_timestamp, media_component_name, azure_remote_folder, local_target_folder, media_share_client, dry_run=False, socketio_instance=None, task_id=None):
+    logger.warning(f"Placeholder 'restore_media_component' for {backup_timestamp}, component {media_component_name}. Not implemented.")
+    _emit_progress(socketio_instance, task_id, 'restore_progress', f"{media_component_name} restore not implemented.", level='WARNING')
+    return False, f"{media_component_name} restore not implemented.", None # success, message, actions
+
+def restore_incremental_bookings(app, socketio_instance=None, task_id=None): # app argument added
+    logger.warning("Placeholder 'restore_incremental_bookings'. Not implemented.")
+    _emit_progress(socketio_instance, task_id, 'restore_progress', "Incremental booking restore not implemented.", level='WARNING')
+    return {'status': 'not_implemented', 'message': 'Not implemented'}
+
+def restore_bookings_from_full_db_backup(app, timestamp_str, socketio_instance=None, task_id=None): # app argument added
+    logger.warning(f"Placeholder 'restore_bookings_from_full_db_backup' for {timestamp_str}. Not implemented.")
+    _emit_progress(socketio_instance, task_id, 'restore_progress', "Booking restore from full DB not implemented.", level='WARNING')
+    return {'status': 'not_implemented', 'message': 'Not implemented'}
+
+def backup_incremental_bookings(app, socketio_instance=None, task_id=None): # app argument added
+    logger.warning("Placeholder 'backup_incremental_bookings'. Not implemented.")
+    _emit_progress(socketio_instance, task_id, 'incremental_booking_backup_progress', "Incremental booking backup not implemented.", level='WARNING')
+    return False
+
+def backup_full_bookings_json(app, socketio_instance=None, task_id=None): # app argument added
+    logger.warning("Placeholder 'backup_full_bookings_json'. Not implemented.")
+    _emit_progress(socketio_instance, task_id, 'full_booking_export_progress', "Full booking JSON export not implemented.", level='WARNING')
+    return False
+
+def list_available_full_booking_json_exports():
+    logger.warning("Placeholder 'list_available_full_booking_json_exports'. Not implemented.")
+    return []
+
+def restore_bookings_from_full_json_export(app, filename, socketio_instance=None, task_id=None): # app argument added
+    logger.warning(f"Placeholder 'restore_bookings_from_full_json_export' for {filename}. Not implemented.")
+    _emit_progress(socketio_instance, task_id, 'restore_progress', "Booking restore from JSON export not implemented.", level='WARNING')
+    return {'status': 'not_implemented', 'message': 'Not implemented'}
+
+def delete_incremental_booking_backup(filename, backup_type=None, socketio_instance=None, task_id=None): # Added backup_type to match expected signature from api_system
+    logger.warning(f"Placeholder 'delete_incremental_booking_backup' for {filename}. Not implemented.")
+    _emit_progress(socketio_instance, task_id, 'delete_incremental_booking_backup_progress', "Delete incremental booking backup not implemented.", level='WARNING')
+    return False


### PR DESCRIPTION
This commit adds placeholder functions to `azure_backup.py` for all names that `routes/api_system.py` attempts to import. This resolves the persistent `ImportError` that was occurring because `azure_backup.py` did not define all the names `api_system.py` expected in its `from azure_backup import (...)` statement.

The previous `ImportError` was specific to the first missing name Python encountered (e.g., 'restore_full_backup', then 'verify_backup_set'). By adding placeholders for all listed imports, the `azure_backup` module should now be fully importable by `api_system.py`.

This allows the application to proceed to the next stage of error handling, such as the `RuntimeError` raised by `_get_service_client` if `AZURE_STORAGE_CONNECTION_STRING` is not set, which will now be correctly caught within the API endpoint functions in `api_system.py`.