### PR TITLE
Add debug print for create_full_backup in api_one_click_backup

### DIFF
--- a/routes/api_system.py
+++ b/routes/api_system.py
@@ -438,6 +438,7 @@ def api_one_click_backup():
     task_id = uuid.uuid4().hex
     current_app.logger.info(f"Generated task_id {task_id} for one-click backup.")
 
+    print(f"DEBUG api_one_click_backup: Value of 'create_full_backup' at function entry: {str(create_full_backup)}, Type: {type(create_full_backup)}")
     if not create_full_backup:
         current_app.logger.error("Azure backup module not available for one-click backup.")
         return jsonify({'success': False, 'message': "Azure backup module is not available. Please ensure the 'azure-storage-file-share' package is installed and the 'AZURE_STORAGE_CONNECTION_STRING' environment variable is correctly configured.", 'task_id': task_id}), 501


### PR DESCRIPTION
This commit adds a temporary print statement inside the `api_one_click_backup` function in `routes/api_system.py`. The print statement will log the value and type of the `create_full_backup` variable as seen by the function at runtime, just before it's checked.

This is to diagnose why `create_full_backup` might be None during a request, even if it appears to be imported correctly at the module level during application startup.

This is a temporary diagnostic measure.