### PR TITLE
Fix: Prevent TypeError in backup_system.html JavaScript

### DIFF
--- a/templates/admin/backup_system.html
+++ b/templates/admin/backup_system.html
@@ -585,7 +585,7 @@
                     availableBackupsTbody.innerHTML = `<tr><td colspan="${colCount}">{{ _("No backups available for this page.") }}</td></tr>`;
                     if(paginationNav) paginationNav.style.display = totalSystemBackupPages > 0 ? 'block' : 'none'; // Show nav if there are other pages
                     if(bulkDeleteButton) bulkDeleteButton.style.display = totalSystemBackupItems > 0 ? 'inline-block' : 'none';
-                    if(masterBackupCheckbox) masterBackupCheckbox.checked = false; masterBackupCheckbox.disabled = true;
+                    if(masterBackupCheckbox) { masterBackupCheckbox.checked = false; masterBackupCheckbox.disabled = true; }
                     if (totalSystemBackupItems === 0 && bulkDeleteButton) bulkDeleteButton.style.display = 'none'; // Specifically hide if no backups at all
                 } else {
                      if(bulkDeleteButton) bulkDeleteButton.style.display = 'inline-block';


### PR DESCRIPTION
Corrects a TypeError in the displayBackupsPage function within templates/admin/backup_system.html. The error occurred when attempting to set properties on the masterBackupCheckbox element which could be null if not yet added to the DOM.

The line:
if(masterBackupCheckbox) masterBackupCheckbox.checked = false; masterBackupCheckbox.disabled = true;

was changed to:
if(masterBackupCheckbox) { masterBackupCheckbox.checked = false; masterBackupCheckbox.disabled = true; }

This ensures properties are only accessed if the element exists, resolving the "TypeError: Cannot set properties of null (setting 'disabled')" error.