### PR TITLE
I've implemented a workaround for an Azure backup TypeError related t…

### DIFF
--- a/azure_backup.py
+++ b/azure_backup.py
@@ -127,8 +127,20 @@ def upload_file(share_client, source_path, file_path):
     file_client = share_client.get_file_client(file_path)
 
     try:
+        # Check if the file exists and delete it if it does.
+        try:
+            file_client.get_file_properties()
+            # If get_file_properties() does not raise ResourceNotFoundError, the file exists.
+            logger.info(f"File '{file_path}' already exists in share '{share_client.share_name}'. Deleting it before upload.")
+            file_client.delete_file()
+            logger.info(f"Successfully deleted existing file '{file_path}' from share '{share_client.share_name}'.")
+        except ResourceNotFoundError:
+            # File does not exist, no need to delete.
+            logger.info(f"File '{file_path}' does not exist in share '{share_client.share_name}'. Proceeding with upload.")
+            pass # Proceed to upload
+
         with open(source_path, "rb") as f_source:
-            file_client.upload_file(f_source, overwrite=True) # Using overwrite=True as it's common for backups
+            file_client.upload_file(f_source) # Changed overwrite=True to overwrite=False (or remove)
         logger.info(f"Successfully uploaded '{source_path}' to '{share_client.share_name}/{file_path}'.")
         return True
     except FileNotFoundError:


### PR DESCRIPTION
…o overwriting files.

I modified the `upload_file` function in `azure_backup.py` to manually delete an existing file before uploading a new version. This avoids using the `overwrite=True` parameter in `file_client.upload_file()`, which I suspect is causing a TypeError with azure-core 1.34.0.

Here's how the new logic works:
1. I check if the remote file exists.
2. If it exists, I delete it.
3. Then, I upload the new file without the `overwrite` parameter.