### PR TITLE
Fix: Prevent TypeError in analytics due to null start_time

### DIFF
--- a/routes/admin_ui.py
+++ b/routes/admin_ui.py
@@ -321,7 +321,8 @@ def analytics_bookings_data():
         bookings_per_day_query = db.session.query(
                 cast(Booking.start_time, Date).label('booking_date'),
                 func.count(Booking.id).label('count')
-            ).filter(Booking.start_time >= thirty_days_ago)\
+            ).filter(Booking.start_time.isnot(None))\
+            .filter(Booking.start_time >= thirty_days_ago)\
             .group_by(cast(Booking.start_time, Date))\
             .order_by(cast(Booking.start_time, Date))\
             .all()


### PR DESCRIPTION
Modified the `analytics_bookings_data` function in `routes/admin_ui.py`. Added a `.filter(Booking.start_time.isnot(None))` to the `bookings_per_day_query`.

This prevents the `TypeError: fromisoformat: argument must be str` that occurred when `Booking.start_time` was None and SQLAlchemy attempted to cast it to a Date type.