### PR TITLE
Fix: Refine analytics query to prevent TypeError from empty start_time

### DIFF
--- a/routes/admin_ui.py
+++ b/routes/admin_ui.py
@@ -322,6 +322,7 @@ def analytics_bookings_data():
                 cast(Booking.start_time, Date).label('booking_date'),
                 func.count(Booking.id).label('count')
             ).filter(Booking.start_time.isnot(None))\
+            .filter(Booking.start_time != '')\
             .filter(Booking.start_time >= thirty_days_ago)\
             .group_by(cast(Booking.start_time, Date))\
             .order_by(cast(Booking.start_time, Date))\


### PR DESCRIPTION
I modified the `analytics_bookings_data` function in `routes/admin_ui.py`. I added an additional filter `.filter(Booking.start_time != '')` to the `bookings_per_day_query`, alongside the existing `.filter(Booking.start_time.isnot(None))`.

This prevents the `TypeError: fromisoformat: argument must be str` that occurred when `Booking.start_time` was an empty string and SQLAlchemy attempted to cast it to a Date type.