### PR TITLE
Fix: Update eventlet to 0.36.1 for Python 3.13 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,6 @@ APScheduler
 Flask-Migrate
 Pillow>=9.0.0
 google-api-python-client>=2.0.0
-eventlet==0.35.2
+eventlet==0.36.1
 python-socketio==5.11.2
 python-engineio==4.9.1


### PR DESCRIPTION
This commit updates eventlet from 0.35.2 to 0.36.1. The previous version (0.35.2) caused an `AttributeError` during application startup on Python 3.13 environments:
`AttributeError: module 'eventlet.green.thread' has no attribute 'start_joinable_thread'`

Eventlet 0.36.1 includes fixes for compatibility with newer Python versions, resolving this startup error.

This change builds upon previous fixes that addressed Socket.IO connection errors by:
- Ensuring the correct Socket.IO client library is used (served by Flask-SocketIO).
- Pinning compatible versions of Flask-SocketIO, python-socketio, and python-engineio.
- Setting `async_mode='eventlet'` for the SocketIO server.