### PR TITLE
Feat: Add minimal Socket.IO test page for diagnostics

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,6 @@ APScheduler
 Flask-Migrate
 Pillow>=9.0.0
 google-api-python-client>=2.0.0
-eventlet==0.36.1
+eventlet==0.38.1
 python-socketio==5.11.2
 python-engineio==4.9.1

--- a/routes/ui.py
+++ b/routes/ui.py
@@ -255,6 +255,12 @@ def check_in_at_resource(resource_id):
         return redirect(url_for('ui.serve_login', next=url_for('ui.check_in_at_resource', resource_id=resource_id, _external=True)))
 
 
+@ui_bp.route("/minimal_socket_test")
+def serve_minimal_socket_test():
+    current_app.logger.info("Serving minimal_socket_test.html")
+    return render_template("minimal_socket_test.html")
+
+
 # Function to register this blueprint in the app factory
 def init_ui_routes(app):
     app.register_blueprint(ui_bp)

--- a/templates/minimal_socket_test.html
+++ b/templates/minimal_socket_test.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Minimal Socket.IO Test</title>
+</head>
+<body>
+    <h1>Minimal Socket.IO Test Page</h1>
+    <p>Check the browser console for messages.</p>
+
+    <script src="/socket.io/socket.io.js"></script>
+    <script>
+        try {
+            console.log('Attempting to connect to Socket.IO...');
+            const socket = io();
+
+            socket.on('connect', () => {
+                console.log('Minimal test: Socket.IO connected successfully!');
+                alert('Minimal test: Socket.IO connected successfully!');
+            });
+
+            socket.on('connect_error', (error) => {
+                console.error('Minimal test: Socket.IO connection error:', error);
+                alert('Minimal test: Socket.IO connection error: ' + error);
+            });
+
+            socket.on('disconnect', (reason) => {
+                console.log('Minimal test: Socket.IO disconnected:', reason);
+            });
+
+        } catch (e) {
+            console.error('Minimal test: Error initializing Socket.IO client:', e);
+            alert('Minimal test: Error initializing Socket.IO client: ' + e);
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
This commit introduces a minimal HTML page and a corresponding route (`/minimal_socket_test`) to help diagnose issues with Flask-SocketIO failing to serve the `socket.io.js` client library, which has been resulting in HTTP 400 errors and client-side `io is not defined` errors.

Changes include:
- Adding `templates/minimal_socket_test.html` with a basic Socket.IO client connection attempt.
- Adding a route in `routes/ui.py` to serve this test page.

This also includes the earlier update of `eventlet` to `0.38.1` in `requirements.txt` to address a Python 3.13 startup compatibility issue.

This commit is intended to facilitate your testing of the Socket.IO client loading in a simplified environment.