### PR TITLE
Fix: Resolve transitive ImportErrors from obsolete functions

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -598,7 +598,8 @@ def save_unified_backup_schedule_settings(data):
         logger.error(f"Error saving unified backup schedule settings to '{config_file}': {e}")
         return False, f"Failed to write settings to file: {e}"
 
-from scheduler_tasks import run_scheduled_incremental_booking_data_task, run_periodic_full_booking_data_task
+# TODO: Imports commented out as 'run_scheduled_incremental_booking_data_task' and 'run_periodic_full_booking_data_task' in scheduler_tasks.py are obsolete.
+# from scheduler_tasks import run_scheduled_incremental_booking_data_task, run_periodic_full_booking_data_task
 from apscheduler.jobstores.base import JobLookupError
 
 def reschedule_unified_backup_jobs(app_instance):


### PR DESCRIPTION
This commit addresses a series of ImportErrors that arose from obsolete backup-related functions and circular dependencies.

Original issue: `ImportError` for `backup_scheduled_incremental_booking_data` in `scheduler_tasks.py` importing from `azure_backup.py`.

Chain of fixes:
1. I identified that `backup_scheduled_incremental_booking_data` and `backup_full_booking_data_json_azure` in `azure_backup.py` were considered obsolete by you.
2. I resolved a circular dependency (`utils.py` -> `scheduler_tasks.py` -> `azure_backup.py` -> `utils.py`) by moving the import of `update_task_log` from `utils` to be inside the `_emit_progress` function in `azure_backup.py`.
3. I removed (commented out) the imports of the two obsolete functions from `azure_backup.py` within `scheduler_tasks.py`.
4. I commented out the task functions in `scheduler_tasks.py` (`run_scheduled_incremental_booking_data_task`, `run_periodic_full_booking_data_task`) that relied on these obsolete functions, adding TODO notes.
5. This led to a new `ImportError` in `utils.py`, which was trying to import the now-commented-out task functions from `scheduler_tasks.py`.
6. I resolved the `ImportError` in `utils.py` by commenting out the problematic import line for `run_scheduled_incremental_booking_data_task` and `run_periodic_full_booking_data_task`, also adding a TODO note.

All identified ImportErrors related to this chain have been resolved. The application no longer crashes due to these specific import issues.

Note: A separate, underlying issue causing the application to time out during startup remains and requires further investigation.