### PR TITLE
Fix: Resolve all ImportErrors related to obsolete tasks and dependencies

### DIFF
--- a/app_factory.py
+++ b/app_factory.py
@@ -30,6 +30,7 @@ from routes.gmail_auth import init_gmail_auth_routes # Added for Gmail OAuth flo
 # For scheduler
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.jobstores.base import JobLookupError # Added import
+# TODO: Imports for 'run_scheduled_incremental_booking_data_task' and 'run_periodic_full_booking_data_task' commented out as these functions are obsolete in scheduler_tasks.py.
 from scheduler_tasks import (
     cancel_unchecked_bookings,
     apply_scheduled_resource_status_changes,
@@ -38,8 +39,8 @@ from scheduler_tasks import (
     auto_checkout_overdue_bookings,
     auto_release_unclaimed_bookings,
     send_checkin_reminders,
-    run_scheduled_incremental_booking_data_task, # New task for unified incrementals
-    run_periodic_full_booking_data_task # New task for unified periodic fulls
+    # run_scheduled_incremental_booking_data_task, # New task for unified incrementals
+    # run_periodic_full_booking_data_task # New task for unified periodic fulls
 )
 # Conditional import for azure_backup
 try:

--- a/routes/api_system.py
+++ b/routes/api_system.py
@@ -52,7 +52,8 @@ try:
         # Imports for new booking restore functionalities
         # list_available_booking_csv_backups, # Removed
         # restore_bookings_from_csv_backup, # Removed
-        list_available_incremental_booking_backups, # Keeping non-CSV legacy for now
+        # TODO: Obsolete? Import commented out as 'list_available_incremental_booking_backups' is likely obsolete.
+        # list_available_incremental_booking_backups, # Keeping non-CSV legacy for now
         restore_incremental_bookings, # Keeping non-CSV legacy for now
         restore_bookings_from_full_db_backup,
         backup_incremental_bookings, # Added for manual incremental backup
@@ -89,7 +90,8 @@ except ImportError as e_detailed_azure_import: # Capture the exception instance
     restore_database_component = None
     download_map_config_component = None
     restore_media_component = None
-    list_available_incremental_booking_backups = None
+    # TODO: Obsolete? Usage of 'list_available_incremental_booking_backups' commented out.
+    # list_available_incremental_booking_backups = None
     restore_incremental_bookings = None
     restore_bookings_from_full_db_backup = None
     backup_incremental_bookings = None


### PR DESCRIPTION
This commit resolves a cascade of ImportErrors that occurred during application startup. The root cause was a combination of obsolete functions, their usage in various modules, and a circular dependency.

Changes made:

1.  **`azure_backup.py`**:
    *   Resolved a circular dependency with `utils.py` by moving the
        import of `update_task_log` into the `_emit_progress` function.
    *   Ensured that functions you identified as obsolete
        (`backup_scheduled_incremental_booking_data`,
        `backup_full_booking_data_json_azure`,
        `list_available_incremental_booking_backups`) are not present.

2.  **`scheduler_tasks.py`**:
    *   Commented out imports for `backup_scheduled_incremental_booking_data`
        and `backup_full_booking_data_json_azure` from `azure_backup.py`
        as these functions are obsolete.
    *   Commented out the definitions of task functions
        `run_scheduled_incremental_booking_data_task` and
        `run_periodic_full_booking_data_task` as they relied on the
        above obsolete functions. Added TODO notes for review.

3.  **`utils.py`**:
    *   Commented out the import of `run_scheduled_incremental_booking_data_task`
        and `run_periodic_full_booking_data_task` from `scheduler_tasks.py`
        because these functions were commented out in `scheduler_tasks.py`.
        Added a TODO note.

4.  **`routes/api_system.py`**:
    *   Commented out the import of `list_available_incremental_booking_backups`
        from `azure_backup.py` as it is considered obsolete.
    *   Commented out its handling in the `except ImportError` block.
        Added TODO notes.

5.  **`app_factory.py`**:
    *   Commented out the imports for `run_scheduled_incremental_booking_data_task`
        and `run_periodic_full_booking_data_task` from `scheduler_tasks.py`
        as these functions are obsolete. Added a TODO note.

These changes collectively prevent the application from crashing due to the previously reported ImportErrors.

Note: A separate underlying issue causing the application to time out during startup (approx. 400 seconds) still exists and requires further investigation. This commit focuses solely on resolving the ImportError chain.