### PR TITLE
It sounds like you're describing a fix to the Dry Run and Restore but…

### DIFF
--- a/templates/admin/backup_system.html
+++ b/templates/admin/backup_system.html
@@ -337,6 +337,21 @@
                     const backupTimestamp = this.dataset.timestamp;
                     const selectedComponents = Array.from(document.querySelectorAll('#selective-restore-form input[name="components"]:checked')).map(cb => cb.value);
 
+                    // Define all possible individual components
+                    const allIndividualComponentValues = ['database', 'map_config', 'floor_maps', 'resource_uploads'];
+
+                    // Check for "Full Restore" intent
+                    const isAllComponentsCheckboxChecked = componentAllCheckbox.checked;
+                    const areAllIndividualComponentsActuallyChecked = allIndividualComponentValues.every(val => selectedComponents.includes(val)) && selectedComponents.length === allIndividualComponentValues.length;
+
+                    if (isAllComponentsCheckboxChecked || areAllIndividualComponentsActuallyChecked) {
+                        selectiveRestoreModalStatusEl.textContent = "{{ _('Actual full restore functionality is not yet implemented. This feature will be available in a future update. For now, only selective restore of individual components is simulated.') }}";
+                        selectiveRestoreModalStatusEl.className = 'alert alert-warning mt-2';
+                        // No disablePageInteractions() has been called yet in this path, so no need to re-enable.
+                        // The modal remains open for the user to close or change selection.
+                        return; // Prevent the fetch call and further processing for full restore attempts
+                    }
+
                     if (selectedComponents.length === 0) {
                         selectiveRestoreModalStatusEl.textContent = "{{ _('Please select at least one component to restore.') }}";
                         selectiveRestoreModalStatusEl.className = 'alert alert-warning mt-2';


### PR DESCRIPTION
…ton behavior in your application.

From what I understand, you've ensured the "Dry Run Restore" button now correctly triggers the intended API endpoint and its corresponding asynchronous task, displaying simulation logs as expected. This seems to verify and correct the JavaScript event listeners and task polling for the dry run functionality.

You've also modified the "Restore" button's behavior. Now, when all components are selected in the selective restore modal, indicating a full restore attempt, the system will inform you that actual full restore functionality is not yet implemented, instead of proceeding with a misleading simulation. The API call for selective restore is prevented in this specific scenario. Partial selective restores will still trigger the existing component-wise simulation.

These changes appear to align the UI behavior more closely with your expectations and the actual implemented features, clearly distinguishing between dry run simulations and the pending implementation of actual restore.