### PR TITLE
fix: Instrument Dry Run JS and clarify Restore simulation

### DIFF
--- a/static/js/admin_backup_common.js
+++ b/static/js/admin_backup_common.js
@@ -146,6 +146,11 @@ function pollTaskStatus(taskId, logAreaId, statusMessageEl, operationType) {
         console.log(`Polling for task ${taskId} was cancelled or already stopped.`);
         return;
     }
+
+    if (operationType === 'restore_dry_run') {
+        console.log(`pollTaskStatus: Polling for restore_dry_run task ${taskId}. LogArea: ${logAreaId}.`);
+    }
+
     fetch(`/api/task/${taskId}/status`)
         .then(response => {
             if (!response.ok) {

--- a/static/js/restore_dry_run_event_listener.js
+++ b/static/js/restore_dry_run_event_listener.js
@@ -8,6 +8,9 @@ document.addEventListener('DOMContentLoaded', function () {
         availableBackupsTable.addEventListener('click', function (event) {
             const target = event.target;
             if (target.classList.contains('restore-dry-run-btn')) {
+                const backupTimestamp = target.dataset.timestamp; // Get timestamp early for logging
+                console.log('Dry Run button clicked. Timestamp:', backupTimestamp); // Logging added
+
                 event.preventDefault();
 
                 if (currentDryRunTaskId && activePolls[currentDryRunTaskId]) {
@@ -42,6 +45,9 @@ document.addEventListener('DOMContentLoaded', function () {
 
                 appendLog('restore-log-area', `Initiating dry run restore for backup ${backupTimestamp}...`, "", "info", restoreStatusMessageEl);
 
+                console.log('CSRF Token for Dry Run:', csrfToken); // Logging CSRF Token
+                console.log('Using Backup Timestamp for Fetch URL:', backupTimestamp); // Logging timestamp for fetch
+
                 fetch(`/api/admin/restore_dry_run/${backupTimestamp}`, {
                     method: 'POST',
                     headers: {
@@ -49,7 +55,7 @@ document.addEventListener('DOMContentLoaded', function () {
                         'Accept': 'application/json',
                         'Content-Type': 'application/json'
                     },
-                    // body: JSON.stringify({}) // No body needed for this request as timestamp is in URL
+                    body: JSON.stringify({}) // Explicitly empty JSON body
                 })
                 .then(response => response.json())
                 .then(data => {
@@ -58,6 +64,8 @@ document.addEventListener('DOMContentLoaded', function () {
                         displayedLogCounts[currentDryRunTaskId] = 0;
 
                         appendLog('restore-log-area', `Dry run task successfully initiated. Task ID: ${currentDryRunTaskId}`, "", "info", restoreStatusMessageEl);
+
+                        console.log('Starting pollTaskStatus for Dry Run. Task ID:', currentDryRunTaskId, 'Log Area: restore-log-area', 'Status Element:', restoreStatusMessageEl, 'OpType: restore_dry_run'); // Logging before poll
 
                         if (activePolls[currentDryRunTaskId]) clearInterval(activePolls[currentDryRunTaskId]); // Clear old poll if any
                         activePolls[currentDryRunTaskId] = setInterval(() => {

--- a/templates/admin/backup_system.html
+++ b/templates/admin/backup_system.html
@@ -337,33 +337,37 @@
                     const backupTimestamp = this.dataset.timestamp;
                     const selectedComponents = Array.from(document.querySelectorAll('#selective-restore-form input[name="components"]:checked')).map(cb => cb.value);
 
-                    // Define all possible individual components
-                    const allIndividualComponentValues = ['database', 'map_config', 'floor_maps', 'resource_uploads'];
-
-                    // Check for "Full Restore" intent
-                    const isAllComponentsCheckboxChecked = componentAllCheckbox.checked;
-                    const areAllIndividualComponentsActuallyChecked = allIndividualComponentValues.every(val => selectedComponents.includes(val)) && selectedComponents.length === allIndividualComponentValues.length;
-
-                    if (isAllComponentsCheckboxChecked || areAllIndividualComponentsActuallyChecked) {
-                        selectiveRestoreModalStatusEl.textContent = "{{ _('Actual full restore functionality is not yet implemented. This feature will be available in a future update. For now, only selective restore of individual components is simulated.') }}";
-                        selectiveRestoreModalStatusEl.className = 'alert alert-warning mt-2';
-                        // No disablePageInteractions() has been called yet in this path, so no need to re-enable.
-                        // The modal remains open for the user to close or change selection.
-                        return; // Prevent the fetch call and further processing for full restore attempts
-                    }
-
+                    // Retain the check for no components selected first.
                     if (selectedComponents.length === 0) {
-                        selectiveRestoreModalStatusEl.textContent = "{{ _('Please select at least one component to restore.') }}";
-                        selectiveRestoreModalStatusEl.className = 'alert alert-warning mt-2';
+                        if (selectiveRestoreModalStatusEl) {
+                            selectiveRestoreModalStatusEl.textContent = "{{ _('Please select at least one component to restore.') }}";
+                            selectiveRestoreModalStatusEl.className = 'alert alert-warning mt-2';
+                        }
                         return;
                     }
+
+                    // New: Display informational message that this is a simulation
+                    // This message will appear in the modal.
+                    if (selectiveRestoreModalStatusEl) {
+                        selectiveRestoreModalStatusEl.textContent = "{{ _('Note: This will run a *simulation* of restoring the selected components. No live data will be changed. Actual restore functionality will be implemented separately.') }}";
+                        selectiveRestoreModalStatusEl.className = 'alert alert-info mt-2';
+                    }
+
+                    // The previous logic for blocking "full restore" has been removed as per new instructions.
+                    // The form will now proceed to simulate for any valid selection.
 
                     disablePageInteractions(); // Disable interactions on main page
                     if(restoreLogAreaEl) { restoreLogAreaEl.innerHTML = ''; restoreLogAreaEl.style.display = 'block'; }
                     if(backupLogAreaEl && backupLogAreaEl.style.display !== 'none') backupLogAreaEl.style.display = 'none';
-                    appendLog('restore-log-area', `{{ _('Initiating selective restore for') }} ${backupTimestamp}...`, `Components: ${selectedComponents.join(', ')}`, 'info', restoreStatusMessageEl);
-                    selectiveRestoreModalStatusEl.textContent = "{{ _('Processing...') }}";
-                    selectiveRestoreModalStatusEl.className = 'alert alert-info mt-2';
+
+                    // The main page log and status will indicate the start of the operation.
+                    // The modal message (set above) will remain visible until the task starts successfully and closes the modal,
+                    // or if an error occurs before then.
+                    appendLog('restore-log-area', `{{ _('Initiating selective restore simulation for') }} ${backupTimestamp}...`, `Components: ${selectedComponents.join(', ')}`, 'info', restoreStatusMessageEl);
+                    // No longer setting modal status to "Processing..." here, let the info message persist longer.
+                    // selectiveRestoreModalStatusEl.textContent = "{{ _('Processing...') }}";
+                    // selectiveRestoreModalStatusEl.className = 'alert alert-info mt-2';
+
 
                     fetch('/api/admin/selective_restore', {
                         method: 'POST',


### PR DESCRIPTION
Phase 1 of backup operations enhancement:

1.  I've aggressively instrumented JavaScript for the "Dry Run Restore" button with detailed console logging. This will help diagnose any persistent issues in specific user environments if the button still fails to trigger the dry run simulation. The underlying logic for event handling, API calls, and task polling has been re-verified.

2.  I've modified the JavaScript for the "Restore" button's selective restore modal. Before the API call to `/api/admin/selective_restore` is made (for any combination of selected components), a message is now displayed within the modal informing you that the operation will be a *simulation* of restoring the selected components and that no live data will be changed. This clarifies the current behavior and distinguishes it from a future actual restore implementation.

These changes aim to ensure the "Dry Run" button can be effectively debugged if issues persist, and to provide clear expectations for the "Restore" button's current simulated functionality.