### PR TITLE
Fix: Load Socket.IO client library in backup_booking_data template

### DIFF
--- a/templates/admin/backup_booking_data.html
+++ b/templates/admin/backup_booking_data.html
@@ -215,6 +215,7 @@
 
 {% block scripts %}
 {{ super() }}
+<script src="/socket.io/socket.io.js"></script>
 <script>
     // Socket.IO connection and utility functions (showProgressModal, hideProgressModal, updateServerTime)
     // should remain as they are. For brevity, they are not repeated here.


### PR DESCRIPTION
The 'admin/backup/booking_data' page was encountering an 'Uncaught ReferenceError: io is not defined' JavaScript error. This was because the Socket.IO client library (socket.io.js) was being used by inline JavaScript before the library itself was loaded.

This commit modifies 'templates/admin/backup_booking_data.html' to include the Socket.IO client library by adding: `<script src="/socket.io/socket.io.js"></script>`
within the 'scripts' block, before its usage.
This ensures the 'io' object is available and should allow Socket.IO connections to function correctly on this page.