### PR TITLE
Fix: Exempt Socket.IO routes from CSRF protection

### DIFF
--- a/app_factory.py
+++ b/app_factory.py
@@ -346,6 +346,7 @@ def create_app(config_object=config, testing=False): # Added testing parameter
 
     csrf.init_app(app)
     socketio.init_app(app) # Add message_queue from config
+    csrf.exempt(socketio)
     migrate.init_app(app, db)
 
     # login_manager and oauth are initialized within init_auth


### PR DESCRIPTION
The application was returning a 400 Bad Request error when the client attempted to fetch '/socket.io/socket.io.js'. This prevented the Socket.IO client library from loading, leading to 'io is not defined' JavaScript errors on pages attempting to use Socket.IO.

This commit modifies 'app_factory.py' to exempt Socket.IO-handled routes from Flask-WTF's CSRF protection. This is achieved by adding 'csrf.exempt(socketio)' after both the CSRF and Socket.IO extensions are initialized with the Flask app.

This change should allow the '/socket.io/socket.io.js' file to be served correctly, resolving the 400 error and enabling proper Socket.IO functionality.