### PR TITLE
Fix: Include jQuery and verify Socket.IO client path

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -135,6 +135,7 @@
     </div>
 
     {% block scripts %}
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script src="/socket.io/socket.io.js"></script>
     <script src="{{ url_for('static', filename='js/script.js') }}" defer></script>
     <script src="{{ url_for('static', filename='libs/flatpickr/flatpickr.min.js') }}"></script>


### PR DESCRIPTION
- I added the jQuery library to `templates/base.html` from a CDN to resolve the "$ is not defined" JavaScript error you experienced on pages extending base.html, such as `admin/backup_booking_data.html`.
- I verified that the client-side path for `socket.io.js` in `templates/base.html` is `/socket.io/socket.io.js`, which is the standard path for Flask-SocketIO. If the 400 BAD REQUEST error for this file persists, it indicates a probable server-side configuration issue with Flask-SocketIO initialization or serving.