### PR TITLE
Fix: Add Bootstrap JS to resolve modal error

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -136,6 +136,8 @@
 
     {% block scripts %}
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.6/dist/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
     <script src="/socket.io/socket.io.js"></script>
     <script src="{{ url_for('static', filename='js/script.js') }}" defer></script>
     <script src="{{ url_for('static', filename='libs/flatpickr/flatpickr.min.js') }}"></script>


### PR DESCRIPTION
- Included Popper.js and Bootstrap JavaScript libraries from CDNs into `templates/base.html`. This addresses the " $(...).modal is not a function" TypeError that occurred on pages like `admin/backup_booking_data.html`.
- The scripts are loaded after jQuery and before custom scripts to ensure correct dependency handling.
- The `socket.io.js` continues to show a 400 BAD REQUEST error, which is likely due to a server-side Flask-SocketIO configuration issue. The client-side path remains standard.