### PR TITLE
Fix: Resolve aria-hidden warning for progress modal

### DIFF
--- a/templates/admin/backup_booking_data.html
+++ b/templates/admin/backup_booking_data.html
@@ -528,6 +528,12 @@
         // Load Unified Backup Schedule Settings - this happens in parallel / independently.
         loadUnifiedBackupSchedule();
 
+        $('#actionProgressModal').on('hide.bs.modal', function () {
+            // Explicitly move focus to the body before the modal is hidden
+            // to prevent aria-hidden conflicts if the modal or its content had focus.
+            document.body.focus();
+        });
+
         // Attach event listeners for new schedule section
         $('#unified_full_schedule_type').on('change', handleScheduleTypeChange);
         $('#saveUnifiedBackupScheduleBtn').on('click', saveUnifiedBackupSchedule);


### PR DESCRIPTION
- Added an event listener to `templates/admin/backup_booking_data.html` for the `hide.bs.modal` event on `#actionProgressModal`.
- When the modal begins to hide, focus is now explicitly moved to `document.body`. This prevents the accessibility warning "Blocked aria-hidden on an element because its descendant retained focus" by ensuring the modal or its children do not have focus when `aria-hidden="true"` is applied.

- The `socket.io.js` continues to show a 400 BAD REQUEST error, which is likely due to a server-side Flask-SocketIO configuration issue. The client-side path remains standard.