### PR TITLE
Fix: Prevent 'Confirm Clear All Data' modal from auto-displaying

### DIFF
--- a/templates/admin/backup_booking_data.html
+++ b/templates/admin/backup_booking_data.html
@@ -483,6 +483,7 @@
     }
 
     $(document).ready(function() {
+        $('#confirmClearAllModal').modal('hide'); // Ensure modal is hidden on page load
         updateServerTime(); setInterval(updateServerTime, 60000);
 
         showProgressModal("{{ _('Loading initial page data...') }}");


### PR DESCRIPTION
The 'Confirm Clear All Booking Data' modal on the
`admin/backup/booking_data.html` page was incorrectly appearing on page load.

This commit ensures the modal is explicitly hidden at the start of the `$(document).ready()` function in the page's JavaScript. The modal's HTML structure was also re-verified to be correct for default hidden behavior.

This prevents the modal from being shown prematurely and ensures it only appears when the corresponding 'Clear All Booking Data' button is clicked.