### PR TITLE
Fix: Set Socket.IO async_mode to threading

### DIFF
--- a/extensions.py
+++ b/extensions.py
@@ -11,5 +11,5 @@ login_manager = LoginManager()
 oauth = OAuth()
 # mail = Mail() # Removed
 csrf = CSRFProtect()
-socketio = SocketIO(async_mode=None, manage_session=False, logger=True, engineio_logger=True)
+socketio = SocketIO(async_mode='threading', manage_session=False, logger=True, engineio_logger=True)
 migrate = Migrate()


### PR DESCRIPTION
I changed the Flask-SocketIO initialization in `extensions.py` to use `async_mode='threading'`.

This is an attempt to resolve issues with `socket.io.js` failing to load (400 Bad Request) and server logs indicating an "unsupported protocol version". Using 'threading' mode can improve compatibility if the application is run with a WSGI server like Werkzeug (Flask's default development server) instead of a server explicitly configured for eventlet or gevent.

While eventlet (with appropriate server setup) is generally recommended for Socket.IO performance, 'threading' mode provides a more broadly compatible fallback.