### PR TITLE
Refactor: Remove unused Socket.IO from backup settings page

### DIFF
--- a/templates/admin/backup_settings.html
+++ b/templates/admin/backup_settings.html
@@ -4,7 +4,6 @@
 
 {% block head_extra %}
 {{ super() }}
-<script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.7.4/socket.io.min.js" integrity="sha512-skuhu6jj+sQnhLq1Txsack8VfnIrX8wL+MTFilYlFFT/NuLJm7eya7zOROs39Jy5cjASMEWqxLzijRVmKhsqWQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 <style>
     .log-area {
         max-height: 200px;


### PR DESCRIPTION
The Socket.IO JavaScript library was included in the `backup_settings.html` template but was not actively used for any functionality on this specific page.

- Standard forms on this page use POST requests.
- The UTC clock and any background task polling are handled by `admin_backup_common.js` using HTTP fetch, not Socket.IO.

This commit removes the unnecessary JavaScript include, reducing a needless dependency for this page.