### PR TITLE
I've fixed an issue related to how resource imports handle different …

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -686,10 +686,14 @@ def _import_resource_configurations_data(resources_data_list: list): # Return ty
     logger.info(f"Resource configurations import result: {final_message}")
 
     if not errors and status_code == 200:
-        return True
+        # Success case: return tuple (updated_count, created_count, errors, warnings, status_code, message)
+        # created_count is 0 as this function primarily updates.
+        return resources_updated, 0, [], [], 200, final_message
     else:
-        return {'message': final_message, 'errors': errors, 'warnings': warnings, 'status_code': status_code,
-                'resources_processed': resources_processed, 'resources_updated': resources_updated}
+        # Failure/warnings case: extract details and return tuple
+        # created_count is 0.
+        # The variables final_message, errors, warnings, status_code, resources_updated are already available.
+        return resources_updated, 0, errors, warnings, status_code, final_message
 
 
 def _get_user_configurations_data() -> dict:


### PR DESCRIPTION
…return types.

Previously, a function in `utils.py` would sometimes return a simple `True` and sometimes a dictionary. This caused a problem in another part of the code (`routes/api_resources.py`) which was always expecting something it could unpack into multiple values.

Here's how I addressed it:
1. I modified the function in `utils.py` so it always returns a consistent set of six pieces of information: the number of updated items, the number of created items (which will be 0 in this case since this function focuses on updates), a list of errors, a list of warnings, a status code, and a message.

2. I updated the code in `routes/api_resources.py` to correctly use this new set of information when creating its response and logging what happened.

3. I added a new test to `tests/test_app.py` to make sure the import functionality works correctly after these changes, especially for successful imports. This test checks the API's response and the database to confirm everything is as expected.