### PR TITLE
Fix: Enable creation of new resources via JSON import

### DIFF
--- a/routes/api_resources.py
+++ b/routes/api_resources.py
@@ -771,7 +771,7 @@ def import_resources_admin():
 
     response_data = {
         'message': message,
-        'created': created_count,  # This will be 0
+        'created': created_count,
         'updated': updated_count,
         'errors': errors_list
     }


### PR DESCRIPTION
The JSON import functionality for resources previously only updated existing resources found by ID. This change modifies the import logic to create new resources if the ID from the JSON file is not found in the database.

Key changes:
- Modified `_import_resource_configurations_data` in `utils.py`:
    - Initializes `created_count`.
    - If a resource ID from the JSON is not found, a new `Resource` object is created and populated with the data from the JSON. The ID from the JSON is used for the new resource if it's an integer.
    - Handles various field types for new resources, including tags, datetimes, JSON strings for `allowed_user_ids`, and role assignments.
    - Returns the correct `created_count`.
    - Updates the summary message to include created resources.
- Verified `import_resources_admin` in `routes/api_resources.py`:
    - Confirmed it correctly unpacks and uses the `created_count` in the API response.
    - Removed a misleading comment that indicated `created_count` would always be zero.
- Added unit tests in `tests/test_app.py`:
    - `test_import_new_resources_only`: Ensures only new resources are created.
    - `test_import_mixed_new_and_existing_resources`: Ensures new resources are created and existing ones updated in a mixed file.
    - `test_import_new_resource_with_invalid_id`: Ensures resources with invalid (non-integer) IDs are skipped and errors reported.
    - `test_import_new_resource_with_non_existent_role`: Ensures resources are created even if referencing non-existent roles (with warnings).

This resolves the issue where importing a JSON file with new resources resulted in no data being added and no clear error message.