### PR TITLE
Fix: Update map import UI to accept ZIP files

### DIFF
--- a/templates/admin_maps.html
+++ b/templates/admin_maps.html
@@ -35,7 +35,7 @@
     <section id="list-maps-section">
         <h2>{{ _('Existing Floor Maps') }}</h2>
         <button id="export-map-config-btn" class="button" style="margin-bottom: 10px;">{{ _('Export Map Configuration') }}</button>
-        <input type="file" id="import-map-config-file" accept=".json" style="display: none; margin-left: 10px;">
+        <input type="file" id="import-map-config-file" accept=".zip" style="display: none; margin-left: 10px;">
         <button id="import-map-config-btn" class="button" style="margin-bottom: 10px; margin-left: 5px;">{{ _('Import Map Configuration') }}</button>
         <div id="admin-maps-list-status"></div>
         <div class="responsive-table-container">


### PR DESCRIPTION
I modified the admin maps template (`templates/admin_maps.html`) to update the file input field for map configuration imports. The `accept` attribute on the input has been changed from `.json` to `.zip` to correctly guide you to upload the new ZIP archive format.

No explicit client-side JavaScript validation for this specific file input was found within the template that would need changing. The backend API has already been updated to process ZIP files.