### PR TITLE
Fix: Update client-side validation for map import to require ZIP

### DIFF
--- a/static/js/admin_resource_edit.js
+++ b/static/js/admin_resource_edit.js
@@ -524,8 +524,8 @@ document.addEventListener('DOMContentLoaded', function() {
                 showError(document.getElementById('admin-maps-list-status'), 'No file selected for map configuration import.');
                 return;
             }
-            if (file.type !== 'application/json') {
-                showError(document.getElementById('admin-maps-list-status'), 'Please select a valid JSON file for map configuration.');
+            if (!file.name.toLowerCase().endsWith('.zip')) {
+                showError(document.getElementById('admin-maps-list-status'), 'Please select a valid ZIP file for map configuration.');
                 return;
             }
 


### PR DESCRIPTION
I modified the JavaScript code in `static/js/admin_resource_edit.js` that handles the client-side validation for the map configuration import.

The validation logic was updated to check for files with the `.zip` extension instead of requiring `application/json` MIME type. The associated error message displayed to you has also been updated to instruct you to select a valid ZIP file.

This change ensures that the frontend validation aligns with the backend API, which now exclusively handles ZIP archives for map configuration import/export.