### PR TITLE
Fix: Import map_coordinates correctly

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -811,6 +811,30 @@ def _import_resource_configurations_data(resources_data_list: list): # Return ty
                 maintenance_until_str = resource_data.get('maintenance_until')
                 resource.maintenance_until = _parse_iso_datetime(maintenance_until_str) # _parse_iso_datetime handles None
 
+                # Handle map_coordinates and map_allowed_role_ids
+                map_coordinates_data = resource_data.get('map_coordinates')
+                if isinstance(map_coordinates_data, dict):
+                    allowed_role_ids = map_coordinates_data.pop('allowed_role_ids', None)
+                    if allowed_role_ids is not None:
+                        resource.map_allowed_role_ids = json.dumps(allowed_role_ids)
+                    else:
+                        resource.map_allowed_role_ids = None
+                    resource.map_coordinates = json.dumps(map_coordinates_data)
+                elif map_coordinates_data is None:
+                    resource.map_coordinates = None
+                    resource.map_allowed_role_ids = None
+                elif isinstance(map_coordinates_data, str):
+                    # If it's a string, use it as is for map_coordinates, and set allowed_role_ids to None
+                    # as we cannot extract it. Log a warning.
+                    warnings.append(f"Resource ID {backup_id}: 'map_coordinates' was a string. Using as is. 'allowed_role_ids' could not be extracted and is set to None.")
+                    resource.map_coordinates = map_coordinates_data
+                    resource.map_allowed_role_ids = None # Cannot extract if already a string
+                else:
+                    warnings.append(f"Resource ID {backup_id}: 'map_coordinates' data is not a dictionary, string, or None. Type: {type(map_coordinates_data)}. Skipping map_coordinates.")
+                    # Optionally, set to None or keep existing if preferred
+                    # resource.map_coordinates = None # Or resource.map_coordinates to keep existing
+                    # resource.map_allowed_role_ids = None # Or resource.map_allowed_role_ids to keep existing
+
                 # Handle Roles (Many-to-Many)
                 backed_up_role_ids_data = resource_data.get('roles', [])
                 if backed_up_role_ids_data is not None: # Check if 'roles' key was present
@@ -870,6 +894,27 @@ def _import_resource_configurations_data(resources_data_list: list): # Return ty
 
                 maintenance_until_str = resource_data.get('maintenance_until')
                 new_resource.maintenance_until = _parse_iso_datetime(maintenance_until_str)
+
+                # Handle map_coordinates and map_allowed_role_ids for new resource
+                map_coordinates_data_new = resource_data.get('map_coordinates')
+                if isinstance(map_coordinates_data_new, dict):
+                    allowed_role_ids_new = map_coordinates_data_new.pop('allowed_role_ids', None)
+                    if allowed_role_ids_new is not None:
+                        new_resource.map_allowed_role_ids = json.dumps(allowed_role_ids_new)
+                    else:
+                        new_resource.map_allowed_role_ids = None
+                    new_resource.map_coordinates = json.dumps(map_coordinates_data_new)
+                elif map_coordinates_data_new is None:
+                    new_resource.map_coordinates = None
+                    new_resource.map_allowed_role_ids = None
+                elif isinstance(map_coordinates_data_new, str):
+                    warnings.append(f"New Resource (Backup ID {backup_id}): 'map_coordinates' was a string. Using as is. 'allowed_role_ids' could not be extracted and is set to None.")
+                    new_resource.map_coordinates = map_coordinates_data_new
+                    new_resource.map_allowed_role_ids = None
+                else:
+                    warnings.append(f"New Resource (Backup ID {backup_id}): 'map_coordinates' data is not a dictionary, string, or None. Type: {type(map_coordinates_data_new)}. Skipping map_coordinates.")
+                    # new_resource.map_coordinates = None
+                    # new_resource.map_allowed_role_ids = None
 
                 # Handle Roles (Many-to-Many) for new resource
                 backed_up_role_ids_data = resource_data.get('roles', []) # Default to empty list


### PR DESCRIPTION
This commit fixes an issue where the `map_coordinates` field, including `allowed_role_ids`, was not being correctly imported for resources.

The `_import_resource_configurations_data` function in `utils.py` has been updated to:
- Properly parse the `map_coordinates` dictionary from the import data.
- Extract `allowed_role_ids` and store it as a JSON string in `resource.map_allowed_role_ids`.
- Store the remaining `map_coordinates` data (x, y, width, height, type) as a JSON string in `resource.map_coordinates`.
- Handle cases where `map_coordinates` might be null, an empty dictionary, or a pre-existing JSON string.

Additionally, I've added new test cases in `tests/test_utils.py` to cover these import scenarios for `map_coordinates`.