### PR TITLE
Fix: Comprehensive update for resource import/export and map display …

### DIFF
--- a/routes/api_maps.py
+++ b/routes/api_maps.py
@@ -518,92 +518,55 @@ def get_map_details(map_id):
         # user_role_ids = [role.id for role in current_user.roles] # This will be generated inside the loop now as user_role_ids_set
 
         for resource in mapped_resources_query:
-            parsed_map_coords = json.loads(resource.map_coordinates) if resource.map_coordinates else None
-            role_ids_from_map_coords = None
-            if parsed_map_coords and isinstance(parsed_map_coords, dict):
-                role_ids_from_map_coords = parsed_map_coords.get('allowed_role_ids')
-                if role_ids_from_map_coords is not None and not isinstance(role_ids_from_map_coords, list):
-                    current_app.logger.warning(f"Resource {resource.id} 'allowed_role_ids' in map_coordinates is not a list: {role_ids_from_map_coords}. Treating as no specific map roles defined.")
-                    role_ids_from_map_coords = None # Treat as if not present if malformed
-
             current_user_can_book_flag = False # Default deny
 
             if current_user.is_admin:
-                current_app.logger.debug(f"User {current_user.username} is admin. Map access granted for resource {resource.id}.")
+                current_app.logger.debug(f"User {current_user.username} is admin. Map access granted for resource {resource.id} via admin override.")
                 current_user_can_book_flag = True
-            elif role_ids_from_map_coords is not None: # This implies it's a list (empty or populated)
-                if not role_ids_from_map_coords: # Empty list means public for authenticated users
-                    current_app.logger.debug(f"Resource {resource.id} 'allowed_role_ids' in map_coordinates is empty. Granting map access (public for authenticated users).")
+            elif not resource.roles: # No roles assigned to resource, public for authenticated users
+                current_app.logger.debug(f"Resource {resource.id} has no specific roles assigned (resource.roles is empty). Granting map access (public for authenticated users).")
+                current_user_can_book_flag = True
+            else: # Resource has roles, check for overlap
+                user_role_ids_set = {user_role.id for user_role in current_user.roles}
+                resource_role_ids_set = {res_role.id for res_role in resource.roles}
+                current_app.logger.debug(f"Resource {resource.id} (resource.roles): Comparing user roles {user_role_ids_set} with resource's assigned roles {resource_role_ids_set}.")
+                if not user_role_ids_set.isdisjoint(resource_role_ids_set):
+                    current_app.logger.debug(f"Resource {resource.id} (resource.roles): Overlap found. Map access granted.")
                     current_user_can_book_flag = True
                 else:
-                    # It's a populated list of role IDs.
-                    malformed_id_found_in_coords = False
-                    processed_role_ids_from_coords = set()
-                    for r_id in role_ids_from_map_coords:
-                        try:
-                            processed_role_ids_from_coords.add(int(r_id))
-                        except (ValueError, TypeError):
-                            malformed_id_found_in_coords = True
-                            current_app.logger.warning(f"Resource {resource.id} 'allowed_role_ids' in map_coordinates contains a non-integer role ID: '{r_id}'. Denying map access due to malformed ID.")
-                            break
-
-                    if malformed_id_found_in_coords:
-                        current_user_can_book_flag = False
-                    else:
-                        user_role_ids_set = {role.id for role in current_user.roles}
-                        current_app.logger.debug(f"Resource {resource.id} (map_coordinates): Comparing user roles {user_role_ids_set} with processed resource roles {processed_role_ids_from_coords} from map_coordinates.")
-                        if not user_role_ids_set.isdisjoint(processed_role_ids_from_coords):
-                            current_app.logger.debug(f"Resource {resource.id} (map_coordinates): Overlap found. Map access granted.")
-                            current_user_can_book_flag = True
-                        else:
-                            current_app.logger.debug(f"Resource {resource.id} (map_coordinates): No overlap. Map access denied.")
-                            current_user_can_book_flag = False
-            else:
-                # role_ids_from_map_coords is None (e.g. 'allowed_role_ids' key missing, or map_coordinates was None/not dict)
-                # This means the resource is considered public to all authenticated users for map view.
-                current_app.logger.debug(f"Resource {resource.id} has no 'allowed_role_ids' in map_coordinates or map_coordinates is invalid. Granting map access (public for authenticated users).")
-                current_user_can_book_flag = True
+                    current_app.logger.debug(f"Resource {resource.id} (resource.roles): No overlap. Map access denied.")
+                    current_user_can_book_flag = False # Explicitly set, though already default
 
             bookings_on_date = Booking.query.filter(
                 Booking.resource_id == resource.id,
-                func.date(Booking.start_time) == target_date_obj, # func.date needs sqlalchemy import
+                func.date(Booking.start_time) == target_date_obj,
                 sqlfunc.trim(sqlfunc.lower(Booking.status)).in_(active_booking_statuses_for_conflict_map_details)
             ).all()
             bookings_info = [{'title': b.title, 'user_name': b.user_name,
                               'start_time': b.start_time.strftime('%H:%M:%S'),
                               'end_time': b.end_time.strftime('%H:%M:%S')} for b in bookings_on_date]
 
+            # Parse map_coordinates (which no longer contains allowed_role_ids)
+            parsed_map_coords = json.loads(resource.map_coordinates) if resource.map_coordinates else None
+
             resource_info = {
                 'id': resource.id, 'name': resource.name, 'capacity': resource.capacity,
                 'equipment': resource.equipment,
                 'image_url': url_for('static', filename=f'resource_uploads/{resource.image_filename}', _external=False) if resource.image_filename else None,
-                'map_coordinates': parsed_map_coords, # Use already parsed coordinates
+                'map_coordinates': parsed_map_coords,
                 'booking_restriction': resource.booking_restriction, 'status': resource.status,
                 'published_at': resource.published_at.isoformat() if resource.published_at else None,
-                'allowed_user_ids': resource.allowed_user_ids, # This is for specific user restriction, not map roles
+                'allowed_user_ids': resource.allowed_user_ids,
                 'is_under_maintenance': resource.is_under_maintenance,
                 'maintenance_until': resource.maintenance_until.isoformat() if resource.maintenance_until else None,
                 'bookings_on_date': bookings_info,
                 'current_user_can_book': current_user_can_book_flag
             }
 
-            # Populate 'roles' for display based on role_ids_from_map_coords
-            allowed_roles_info_display = []
-            if role_ids_from_map_coords and isinstance(role_ids_from_map_coords, list):
-                # Attempt to fetch role names for display.
-                # Ensure IDs are integers for querying.
-                valid_role_ids_for_query = []
-                for r_id in role_ids_from_map_coords:
-                    try:
-                        valid_role_ids_for_query.append(int(r_id))
-                    except (ValueError, TypeError):
-                        current_app.logger.warning(f"Resource {resource.id} has non-integer role ID '{r_id}' in map_coordinates.allowed_role_ids. Skipping for display.")
+            # Populate 'roles' for display directly from resource.roles
+            allowed_roles_info_display = [{'id': role.id, 'name': role.name} for role in resource.roles]
+            resource_info['roles'] = allowed_roles_info_display
 
-                if valid_role_ids_for_query:
-                    roles_for_display = Role.query.filter(Role.id.in_(valid_role_ids_for_query)).all()
-                    allowed_roles_info_display = [{'id': role.id, 'name': role.name} for role in roles_for_display]
-
-            resource_info['roles'] = allowed_roles_info_display # Roles allowed by map_coordinates
             mapped_resources_list.append(resource_info)
 
         current_app.logger.info(f"User {current_user.username} fetched map details for map ID {map_id} for date {target_date_obj}. Total resources processed: {len(mapped_resources_list)}.")


### PR DESCRIPTION
…logic

This commit addresses issues with how resource configurations (especially `floor_map_id`, `map_coordinates`, and role associations) are handled during import/export and how they are interpreted for map display.

Key changes:

1.  **Resource Export (`_get_resource_configurations_data` in `utils.py`):**
    - Ensures `floor_map_id` is included in the export.
    - The `map_coordinates` field in the exported JSON now correctly includes an `allowed_role_ids` key, populated with role IDs from the `resource.roles` (SQLAlchemy relationship). This makes the exported `map_coordinates` self-contained for role information related to map display.

2.  **Resource Import (`_import_resource_configurations_data` in `utils.py`):**
    - Correctly processes and assigns `floor_map_id` to resources.
    - Uses the `allowed_role_ids` list found within the imported `map_coordinates` dictionary as the authoritative source to update the `resource.roles` (SQLAlchemy relationship).
    - The `resource.map_coordinates` field in the database now stores *only* the coordinate data (e.g., x, y, type), excluding the `allowed_role_ids` which are now managed via the `resource.roles` relationship.
    - A top-level `roles` field in the import data is ignored for populating `resource.roles`, ensuring consistency.

3.  **Map Display API (`get_map_details` in `routes/api_maps.py`):**
    - The `current_user_can_book` flag (determining if you can interact with a resource on the map) is now correctly determined by checking the `current_user.roles` against the `resource.roles` (SQLAlchemy relationship).
    - The list of roles displayed for a resource on the map is also derived directly from `resource.roles`.
    - The `map_coordinates` object sent in the API response now only contains coordinate data, not nested role IDs, as the permission logic is handled by the backend using `resource.roles`.

4.  **Tests:**
    - Updated tests in `tests/test_utils.py` for the import/export functions to reflect these changes in data structure and role handling.
    - Updated tests in `tests/test_api_maps.py` to ensure the `get_map_details` API correctly uses `resource.roles` for permissions and serves the appropriate data structure.

This comprehensive set of changes ensures that resource role information and map-specific data are consistently managed and interpreted throughout the import, export, and map display processes.