### PR TITLE
Refactor: Align map area role storage with resource details

### DIFF
--- a/routes/api_resources.py
+++ b/routes/api_resources.py
@@ -1163,7 +1163,21 @@ def update_resource_map_info_admin(resource_id):
 
     # Update fields like floor_map_id, map_coordinates, booking_restriction, allowed_user_ids, role_ids
     if 'floor_map_id' in data: resource.floor_map_id = data['floor_map_id']
-    if 'coordinates' in data: resource.map_coordinates = json.dumps(data['coordinates']) if data['coordinates'] else None
+
+    if 'coordinates' in data and data['coordinates'] is not None:
+        coords_payload = data['coordinates']
+        # Ensure coords_payload is a dictionary before attempting to pop
+        if isinstance(coords_payload, dict):
+            allowed_role_ids = coords_payload.pop('allowed_role_ids', None)
+            resource.map_allowed_role_ids = json.dumps(allowed_role_ids) if allowed_role_ids is not None else None
+            resource.map_coordinates = json.dumps(coords_payload) if coords_payload else None
+        else:
+            # If coords_payload is not a dict (e.g., already None or a string), handle appropriately
+            resource.map_coordinates = json.dumps(coords_payload) if coords_payload else None # Or handle as an error case
+            resource.map_allowed_role_ids = None
+    else:
+        resource.map_coordinates = None
+        resource.map_allowed_role_ids = None
     # ... (other fields from original app.py's update_resource_map_info)
 
     try:

--- a/utils.py
+++ b/utils.py
@@ -380,6 +380,7 @@ def resource_to_dict(resource: Resource) -> dict:
         'roles': [{'id': r.id, 'name': r.name} for r in resource.roles],
         'floor_map_id': resource.floor_map_id,
         'map_coordinates': json.loads(resource.map_coordinates) if resource.map_coordinates else None,
+        'map_allowed_role_ids': json.loads(resource.map_allowed_role_ids) if resource.map_allowed_role_ids else None,
         'is_under_maintenance': resource.is_under_maintenance,
         'maintenance_until': resource.maintenance_until.isoformat() if resource.maintenance_until else None,
     }


### PR DESCRIPTION
I've modified the `update_resource_map_info_admin` endpoint in `routes/api_resources.py` to correctly process and store roles associated with map areas.

Previously, `allowed_role_ids` within the `coordinates` payload were being stored nested inside the `resource.map_coordinates` JSON string. This change ensures that:
- `allowed_role_ids` are extracted from the `coordinates` payload.
- The extracted list of role IDs is stored as a JSON string in the `resource.map_allowed_role_ids` field.
- The remaining geometric data (x, y, width, height, type) is stored as a JSON string in the `resource.map_coordinates` field.

This aligns the behavior with how `update_resource_details_admin` handles these distinct pieces of information, ensuring consistent data storage for map-specific roles.

Additionally, the `resource_to_dict` function in `utils.py` has been updated to correctly serialize `map_allowed_role_ids` (parsing the JSON string from the DB into a Python list/None) for API responses.