### PR TITLE
Fix: Correctly display map-area-specific roles in UI

### DIFF
--- a/templates/admin_maps.html
+++ b/templates/admin_maps.html
@@ -841,13 +841,13 @@
                 drawnAreas = resources.filter(r => r.map_coordinates && r.floor_map_id == mapId)
                                      .map(r => {
                                          let roleIds = [];
-                                         if (Array.isArray(r.roles)) {
-                                             roleIds = r.roles.map(role => role.id);
-                                         } else if (r.map_coordinates && Array.isArray(r.map_coordinates.allowed_role_ids)) {
-                                             roleIds = r.map_coordinates.allowed_role_ids;
-                                         } else {
-                                             roleIds = []; // Default to empty array
+                                         // Prioritize the top-level r.map_allowed_role_ids which should be a list of IDs
+                                         if (r.map_allowed_role_ids && Array.isArray(r.map_allowed_role_ids)) {
+                                             roleIds = r.map_allowed_role_ids;
                                          }
+                                         // No fallback to r.roles or r.map_coordinates.allowed_role_ids is needed here,
+                                         // as map_allowed_role_ids is the canonical source for area-specific roles.
+                                         // If it's not present or not an array, roleIds will remain empty, which is correct.
                                          return { // Adapt to the expected structure for drawing
                                              resource_id: r.id,
                                              name: r.name, // For potential display on canvas later


### PR DESCRIPTION
I modified the `fetchAndDrawExistingMapAreas` JavaScript function in `templates/admin_maps.html`.

The previous logic incorrectly sourced `allowed_role_ids` for map areas from general resource roles (`r.roles`) or from an outdated nested structure (`r.map_coordinates.allowed_role_ids`).

This commit updates the logic to correctly use `r.map_allowed_role_ids` (the top-level field populated by `resource_to_dict` from the database) as the authoritative source for populating the role checkboxes when an existing map area is selected.

This ensures that the UI accurately reflects the specific roles assigned to a map area.