### PR TITLE
Revert "Fix: Resolve FloorMap import error due to missing attributes"

### DIFF
--- a/models.py
+++ b/models.py
@@ -75,10 +75,6 @@ class FloorMap(db.Model):
     # New offset columns
     offset_x = db.Column(db.Integer, nullable=False, default=0)
     offset_y = db.Column(db.Integer, nullable=False, default=0)
-    display_order = db.Column(db.Integer, nullable=True, default=0)
-    is_published = db.Column(db.Boolean, nullable=True, default=True)
-    description = db.Column(db.Text, nullable=True)
-    map_data_json = db.Column(db.Text, nullable=True)
 
     def __repr__(self):
         # Consider adding offsets to repr if useful for debugging


### PR DESCRIPTION
This commit reverts the changes made to address the FloorMap import error. The following changes have been undone:
1. Removed `display_order`, `is_published`, `description`, and `map_data_json` attributes from the `FloorMap` model in `models.py`.
2. Reverted the `_import_map_configuration_data` function in `utils.py` to its original logic for handling `FloorMap` constructor arguments.
3. The database schema is intended to be downgraded by running `flask db downgrade` to remove the aforementioned columns from the `floor_map` table.

Reverting these changes will likely reintroduce the original import error if the imported map data contains fields not defined in the reverted FloorMap model.