### PR TITLE
Fix: Re-apply fix for FloorMap import error

### DIFF
--- a/models.py
+++ b/models.py
@@ -75,6 +75,10 @@ class FloorMap(db.Model):
     # New offset columns
     offset_x = db.Column(db.Integer, nullable=False, default=0)
     offset_y = db.Column(db.Integer, nullable=False, default=0)
+    display_order = db.Column(db.Integer, nullable=True, default=0)
+    is_published = db.Column(db.Boolean, nullable=True, default=True)
+    description = db.Column(db.Text, nullable=True)
+    map_data_json = db.Column(db.Text, nullable=True)
 
     def __repr__(self):
         # Consider adding offsets to repr if useful for debugging

--- a/utils.py
+++ b/utils.py
@@ -567,39 +567,33 @@ def _import_map_configuration_data(config_data: dict) -> tuple[dict, int]:
                 map_constructor_args = {
                     'name': map_item.get('name'),
                     'image_filename': map_item.get('image_filename'),
-                    # Revert to only include fields accepted by the original FloorMap constructor
+                    # Ensure all model fields are passed to constructor if available in backup
                     'location': map_item.get('location'),
                     'floor': map_item.get('floor'),
                     'offset_x': map_item.get('offset_x', 0), # Default if not in backup
-                    'offset_y': map_item.get('offset_y', 0)  # Default if not in backup
+                    'offset_y': map_item.get('offset_y', 0), # Default if not in backup
+                    'display_order': map_item.get('display_order', 0),
+                    'is_published': map_item.get('is_published', True),
+                    'description': map_item.get('description'),
+                    'map_data_json': map_item.get('map_data_json')
                 }
 
-                # Original logic for handling description, as it was not part of the constructor
-                # and other fields like display_order were not handled at all for new maps.
-                new_map = FloorMap(**map_constructor_args) # This will now use the reverted map_constructor_args
+                # Description and other fields are now part of the model and constructor
+                # We will handle 'description' after object creation using direct assignment if needed,
+                # similar to how it's handled for existing map objects.
+
+                new_map = FloorMap(**map_constructor_args)
                 db.session.add(new_map)
                 db.session.flush() # Flush to get the new_map.id
 
-                new_description = map_item.get('description')
-                if new_description is not None:
-                    try:
-                        # Attempt to set 'description' after creation.
-                        # If 'description' is not a model attribute, this might log a warning
-                        # or be a no-op depending on SQLAlchemy behavior for non-column attributes,
-                        # but it avoids the TypeError during construction.
-                        setattr(new_map, 'description', new_description)
-                        # If setattr itself is problematic for non-column attributes on new instances
-                        # before commit, or if a more explicit warning is desired:
-                        if not hasattr(new_map.__class__, 'description') or not new_map.__class__.__table__.columns.get('description'):
-                             logger.warning(f"Set 'description' on newly created FloorMap (Backup ID: {backup_map_id}, New ID: {new_map.id}) post-construction, but 'description' is not a formal model attribute. Value: '{new_description}'")
-                    except AttributeError:
-                         # This catch block might be redundant if setattr on new objects behaves permissively,
-                         # but kept for safety.
-                        logger.warning(f"Attempted to set 'description' via setattr on new FloorMap (Backup ID: {backup_map_id}, New ID: {new_map.id}) but failed. Value: '{new_description}'")
+                # This block can be simplified as fields are now in constructor
+                # new_description = map_item.get('description')
+                # if new_description is not None and new_map.description != new_description:
+                #    new_map.description = new_description
 
                 backup_to_new_map_id_mapping[backup_map_id] = new_map.id
                 maps_created += 1
-                warnings.append(f"Map with backup ID {backup_map_id} ('{new_map.name}') not found. Created as new map with ID {new_map.id}.")
+                warnings.append(f"Map with backup ID {backup_map_id} ('{new_map.name}') not found. Created as new map with ID {new_map.id} and attributes from backup.")
         except Exception as e_map:
             error_msg = f"Error processing map (Backup ID: {backup_map_id}, Name: {map_item.get('name', 'N/A')}): {str(e_map)}"
             errors.append(error_msg)


### PR DESCRIPTION
This commit re-applies the changes to address the FloorMap import error where attributes like 'display_order' were not handled correctly.

The following changes were made:
1. Re-added `display_order`, `is_published`, `description`, and `map_data_json` attributes to the `FloorMap` model in `models.py`.
2. Updated the `_import_map_configuration_data` function in `utils.py` to correctly include these new attributes (along with existing ones like location, floor, offsets) in the `map_constructor_args` when creating new `FloorMap` instances.

For these changes to take effect and resolve runtime errors like 'no such column', the database schema must be aligned with the updated FloorMap model. This typically requires you to run `flask db upgrade` to apply the corresponding migration.