### PR TITLE
The following commit removes the "Import Users to CSV" and "Export Us…

### DIFF
--- a/templates/user_management.html
+++ b/templates/user_management.html
@@ -7,11 +7,8 @@
     <button id="add-new-user-btn" class="button">{{ _('Add New User') }}</button>
     <button id="bulk-add-users-btn" class="button">{{ _('Bulk Add Users') }}</button> {# New Button #}
     <button id="export-users-btn" class="button">{{ _('Export Users (JSON)') }}</button> {# Clarified existing button #}
-    <button id="export-users-csv-btn" class="button">{{ _('Export Users to CSV') }}</button> {# New CSV Export Button #}
     <button id="import-users-btn" class="button">{{ _('Import Users (JSON)') }}</button> {# Clarified existing button #}
     <input type="file" id="import-users-file" accept="application/json" style="display:none;">
-    <button id="import-users-csv-btn" class="button">{{ _('Import Users from CSV') }}</button> {# New CSV Import Button #}
-    <input type="file" id="import-users-csv-file" accept=".csv,text/csv" style="display:none;">
     <button id="bulk-add-pattern-btn" class="button">{{ _('Bulk Add with Pattern') }}</button> {# New Button #}
     <button id="delete-selected-users-btn" class="button danger">{{ _('Delete Selected') }}</button>
     <button id="bulk-edit-selected-users-btn" class="button action">{{ _('Bulk Edit Selected') }}</button> {# New Button #}


### PR DESCRIPTION
…ers to CSV" buttons, as well as the associated file input field, from the /admin/users_manage page. These functionalities were requested to be removed.