### PR TITLE
I've made the following changes to address the issue of the backup mo…

### DIFF
--- a/static/js/admin_backup_common.js
+++ b/static/js/admin_backup_common.js
@@ -141,7 +141,7 @@ function appendLog(logAreaId, message, detail, type = 'info', specificStatusEl =
 }
 
 // --- HTTP Task Polling Function ---
-function pollTaskStatus(taskId, logAreaId, statusMessageEl, operationType) {
+function pollTaskStatus(taskId, logAreaId, statusMessageEl, operationType, onTaskDoneCallback) {
     if (!activePolls[taskId]) { // Polling might have been cancelled elsewhere
         console.log(`Polling for task ${taskId} was cancelled or already stopped.`);
         return;
@@ -225,6 +225,11 @@ function pollTaskStatus(taskId, logAreaId, statusMessageEl, operationType) {
                 if (operationType === 'bulk_delete_system_backups') currentBulkDeleteTaskId = null;
                 if (operationType === 'restore_dry_run') currentDryRunTaskId = null; // Added for dry run
                 // currentRestoreTaskId is for one-click full restore, not yet refactored in this common script.
+
+                if (typeof onTaskDoneCallback === 'function') {
+                    console.log(`Task ${taskId} (${operationType}) is done, executing onTaskDoneCallback.`);
+                    onTaskDoneCallback(data); // Pass the final task data to the callback
+                }
             }
         })
         .catch(error => {

--- a/templates/admin/backup_booking_data.html
+++ b/templates/admin/backup_booking_data.html
@@ -353,23 +353,16 @@
                 displayedLogCounts[data.task_id] = 0; // Reset log count for this new task instance
 
                 // Setup the polling interval
-                const intervalId = setInterval(() => {
-                    // Call the generic poller from admin_backup_common.js
-                    pollTaskStatus(data.task_id, null, statusEl, 'manual_unified_booking_backup');
-
-                    // Check if pollTaskStatus has completed and cleared itself from activePolls
-                    if (!activePolls[data.task_id]) {
-                        // If the entry in activePolls is gone, the task is done and pollTaskStatus
-                        // should have cleared its own interval.
-                        // Now, hide the modal.
-                        hideProgressModal();
-                        // enablePageInteractions(); // This is typically called by pollTaskStatus itself when data.is_done.
-                                                 // Assuming pollTaskStatus reliably calls enablePageInteractions.
+                const newIntervalId = setInterval(() => {
+                    // If the task's interval has been cleared from activePolls by pollTaskStatus itself,
+                    // then this specific interval (newIntervalId) should also be cleared to stop further execution.
+                    if (!activePolls[currentManualUnifiedBackupTaskId]) {
+                        clearInterval(newIntervalId); // Clear this page's interval for this task.
+                        return;
                     }
-                }, POLLING_INTERVAL_MS); // Assuming POLLING_INTERVAL_MS is accessible (it's in admin_backup_common.js)
-
-                // Store the interval ID so pollTaskStatus can clear it
-                activePolls[data.task_id] = intervalId;
+                    pollTaskStatus(currentManualUnifiedBackupTaskId, null, statusEl, 'manual_unified_booking_backup', hideProgressModal);
+                }, POLLING_INTERVAL_MS);
+                activePolls[currentManualUnifiedBackupTaskId] = newIntervalId;
 
             } else {
                 // Task initiation failed (e.g., backend couldn't create task)


### PR DESCRIPTION
…dal not closing:

- I modified the `pollTaskStatus` function in `static/js/admin_backup_common.js` to accept an `onTaskDoneCallback` function. This callback is now executed when the polled task is marked as done.
- I updated the `manualUnifiedBackup` function in `templates/admin/backup_booking_data.html` to pass its local `hideProgressModal` function as the `onTaskDoneCallback` to `pollTaskStatus`.
- I also refined the `setInterval` logic within `manualUnifiedBackup` to ensure it clears itself after `pollTaskStatus` has completed and cleared the active polling entry.

These adjustments will ensure the 'Action in Progress' modal is reliably hidden after you successfully complete the manual backup task.