### PR TITLE
Fix TypeErrors in restore task and implement restore logic

### DIFF
--- a/routes/api_system.py
+++ b/routes/api_system.py
@@ -328,13 +328,13 @@ def api_unified_booking_data_point_in_time_restore():
                 if summary.get('status') == 'success':
                     final_message = summary.get('message', "Unified booking data restore completed successfully.")
                     update_task_log(task_id_param, final_message, level="success")
-                    mark_task_done(task_id_param, success=True, result_message=final_message, result_data=summary)
+                    mark_task_done(task_id_param, success=True, result_message=f"{final_message} Summary: {json.dumps(summary)}")
                     add_audit_log(action="UNIFIED_RESTORE_WORKER_COMPLETED", details=f"Task {task_id_param}: {final_message}. Summary: {json.dumps(summary)}", user_id=user_id_audit, username=username_audit)
                     current_app.logger.info(f"Task {task_id_param}: Unified restore completed successfully. Summary: {summary}")
                 else:
                     error_detail = summary.get('message', "Restore process reported failure.")
-                    update_task_log(task_id_param, error_detail, level="error", detail_info=json.dumps(summary.get('errors', [])))
-                    mark_task_done(task_id_param, success=False, result_message=error_detail, result_data=summary)
+                    update_task_log(task_id_param, error_detail, detail=json.dumps(summary.get('errors', [])), level="error")
+                    mark_task_done(task_id_param, success=False, result_message=f"{error_detail} Summary: {json.dumps(summary)}")
                     add_audit_log(action="UNIFIED_RESTORE_WORKER_FAILED", details=f"Task {task_id_param}: {error_detail}. Summary: {json.dumps(summary)}", user_id=user_id_audit, username=username_audit)
                     current_app.logger.warning(f"Task {task_id_param}: Unified restore failed. Summary: {summary}")
 
@@ -343,7 +343,7 @@ def api_unified_booking_data_point_in_time_restore():
                 current_app.logger.error(f"Task {task_id_param}: {error_msg}", exc_info=True)
                 error_summary = {'status': 'failure', 'message': error_msg, 'errors': [str(e)]}
                 update_task_log(task_id_param, error_msg, level="critical")
-                mark_task_done(task_id_param, success=False, result_message=error_msg, result_data=error_summary)
+                mark_task_done(task_id_param, success=False, result_message=f"{error_msg} Details: {json.dumps(error_summary.get('errors', []))}")
                 add_audit_log(action="UNIFIED_RESTORE_WORKER_EXCEPTION", details=f"Task {task_id_param}: {error_msg}", user_id=user_id_audit, username=username_audit)
 
     flask_app_context = current_app.app_context()


### PR DESCRIPTION
- I corrected calls to update_task_log and mark_task_done in routes/api_system.py (within do_unified_restore_work) to align with function signatures in utils.py. This resolves previous TypeErrors by adjusting keyword arguments and incorporating detailed error/summary information into the result_message.
- I implemented the restore_booking_data_to_point_in_time function in azure_backup.py. This function replaces the previous placeholder and provides logic to restore booking data from a 'manual_full_json' backup type. The process involves:
    - Downloading the specified backup file from Azure.
    - Parsing the JSON content.
    - Deleting all existing booking records from the database.
    - Re-inserting bookings from the backup data, including conversion of ISO datetime/time strings.
    - Logging progress and errors using the task management system.
    - Returning a status indicating success or failure.

This commit addresses critical errors in the restore task initiation and provides the core functionality for restoring booking data from a manually created full JSON backup.