### PR TITLE
Refactor: Update restore logic for unified paths & add scheduler restore

### DIFF
--- a/azure_backup.py
+++ b/azure_backup.py
@@ -1101,59 +1101,49 @@ def restore_database_component(backup_timestamp, db_share_client, dry_run=False,
     Restores (downloads) the database component from a backup.
 
     Args:
-        backup_timestamp (str): The timestamp of the backup.
-        db_share_client (ShareClient): The Azure File Share client for the DB share.
-        dry_run (bool): If True, simulates the restore without actual download/changes.
+        share_client (ShareClient): The Azure File Share client for the unified system backup share.
+        full_db_path_on_share (str): The full path to the database file on the Azure share
+                                     (e.g., "full_system_backups/backup_XYZ/database/site_XYZ.db").
         task_id (str, optional): The ID of the task for progress emission.
-
+        dry_run (bool): If True, simulates the restore without actual download/changes.
     Returns:
         tuple: (success_status, message, downloaded_file_path, error_detail)
-               - success_status (bool): True if successful or dry run, False otherwise.
-               - message (str): A message describing the outcome.
-               - downloaded_file_path (str | None): Path to the downloaded DB file, or a simulated path for dry run.
-               - error_detail (str | None): Details of any error that occurred.
     """
+    # Extract a base filename for the local temp file, e.g., "site_XYZ.db"
+    db_filename_on_share = os.path.basename(full_db_path_on_share) if full_db_path_on_share else "database.db"
+    local_temp_db_filename = f"downloaded_{db_filename_on_share}" # e.g., downloaded_site_XYZ.db
+
     if dry_run:
         _emit_progress(task_id, "DRY RUN: Simulating database component download.", level='INFO')
-        _emit_progress(task_id, "DRY RUN: Database component download simulated successfully.", level='SUCCESS')
-        return True, "Dry run: Database download simulated.", f"simulated_{DB_FILENAME_PREFIX}{backup_timestamp}.db", None
+        simulated_local_path = os.path.join(DATA_DIR, local_temp_db_filename)
+        _emit_progress(task_id, "DRY RUN: Database component download simulated successfully.",
+                       detail=f"Would download from '{full_db_path_on_share}' to '{simulated_local_path}'", level='SUCCESS')
+        return True, "Dry run: Database download simulated.", simulated_local_path, None
 
-    _emit_progress(task_id, f"Starting actual database component restore for timestamp {backup_timestamp}.", level='INFO')
+    _emit_progress(task_id, f"Starting actual database component restore from '{full_db_path_on_share}'.", level='INFO')
 
-    db_filename = f"{DB_FILENAME_PREFIX}{backup_timestamp}.db"
-    remote_db_file_path = f"{DB_BACKUPS_DIR}/{db_filename}"
+    os.makedirs(DATA_DIR, exist_ok=True) # Ensure DATA_DIR exists
+    local_temp_db_path = os.path.join(DATA_DIR, local_temp_db_filename)
 
-    # Ensure DATA_DIR exists for temporary download
-    if not os.path.exists(DATA_DIR):
-        try:
-            os.makedirs(DATA_DIR)
-            _emit_progress(task_id, f"Created local data directory: {DATA_DIR}", level='INFO')
-        except OSError as e:
-            _emit_progress(task_id, f"Error creating local data directory {DATA_DIR}: {str(e)}", level='ERROR')
-            return False, f"Error creating local data directory: {str(e)}", None, str(e)
-
-    local_temp_db_path = os.path.join(DATA_DIR, f"downloaded_{db_filename}")
-
-    _emit_progress(task_id, f"Attempting to download database backup '{remote_db_file_path}' to '{local_temp_db_path}'.", level='INFO')
+    _emit_progress(task_id, f"Attempting to download database backup from '{full_db_path_on_share}' to '{local_temp_db_path}'.", level='INFO')
 
     try:
-        if not db_share_client: # Should be passed by the calling function (e.g. restore_full_backup)
-            _emit_progress(task_id, "Azure DB Share client not available/provided.", level='ERROR')
-            return False, "Azure DB Share client not available.", None, "DB Share client was None."
+        if not share_client:
+            _emit_progress(task_id, "Azure Share client not available/provided for database restore.", level='ERROR')
+            return False, "Azure Share client not available.", None, "Share client was None."
 
-        download_success = download_file(db_share_client, remote_db_file_path, local_temp_db_path)
+        download_success = download_file(share_client, full_db_path_on_share, local_temp_db_path)
 
         if download_success:
-            _emit_progress(task_id, f"Database backup '{db_filename}' downloaded successfully to '{local_temp_db_path}'.", level='SUCCESS')
-            return True, f"Database backup '{db_filename}' downloaded to '{local_temp_db_path}'.", local_temp_db_path, None
+            _emit_progress(task_id, f"Database backup downloaded successfully to '{local_temp_db_path}'.", level='SUCCESS')
+            return True, f"Database backup downloaded to '{local_temp_db_path}'.", local_temp_db_path, None
         else:
-            # download_file function logs its own errors, so just a general message here.
-            error_msg = f"Failed to download database backup '{db_filename}' from Azure. Check logs for details from download_file utility."
+            error_msg = f"Failed to download database backup from '{full_db_path_on_share}'. Check logs for details."
             _emit_progress(task_id, error_msg, level='ERROR')
-            return False, error_msg, None, error_msg # Provide the same message as detail for consistency
+            return False, error_msg, None, error_msg
 
     except ResourceNotFoundError:
-        error_msg = f"Database backup file '{remote_db_file_path}' not found in Azure share '{db_share_client.share_name}'."
+        error_msg = f"Database backup file '{full_db_path_on_share}' not found in Azure share '{share_client.share_name}'."
         _emit_progress(task_id, error_msg, level='ERROR')
         return False, error_msg, None, error_msg
     except HttpResponseError as e:
@@ -1163,108 +1153,109 @@ def restore_database_component(backup_timestamp, db_share_client, dry_run=False,
     except Exception as e:
         error_msg = f"Unexpected error during database component restore: {str(e)}"
         _emit_progress(task_id, error_msg, level='ERROR')
-        logger.error(f"Unexpected error in restore_database_component for {backup_timestamp}: {e}", exc_info=True)
+        logger.error(f"Unexpected error in restore_database_component from {full_db_path_on_share}: {e}", exc_info=True)
         return False, error_msg, None, str(e)
 
-def download_map_config_component(backup_timestamp, config_share_client, dry_run=False, task_id=None):
-    logger.warning(f"Placeholder 'download_map_config_component' for {backup_timestamp}, task_id: {task_id}.")
-    _emit_progress(task_id, "Map config download not implemented.", level='WARNING')
-    return False, "Map config download not implemented.", None, None
-
-
-def _download_config_component_generic(
-    backup_timestamp,
-    config_share_client,
-    component_type_str,
-    filename_prefix,
-    task_id=None,
-    dry_run=False
-):
-    """
-    Generic helper to download a configuration component (map, resource, user configs).
-    """
+def download_map_config_component(share_client: ShareClient, full_path_on_share: str, task_id: str = None, dry_run: bool = False):
+    # This function will be refactored to use download_file directly
     if dry_run:
-        _emit_progress(task_id, f"DRY RUN: Simulating {component_type_str} component download.", level='INFO')
-        _emit_progress(task_id, f"DRY RUN: {component_type_str} component download simulated successfully.", level='SUCCESS')
-        simulated_filename = f"simulated_{filename_prefix}{backup_timestamp}.json"
-        return True, f"Dry run: {component_type_str} download simulated.", simulated_filename, None
+        _emit_progress(task_id, "DRY RUN: Simulating map configuration component download.", level='INFO')
+        # Caller needs to determine the local filename based on full_path_on_share if needed for simulation consistency
+        return True, "Dry run: Map configuration download simulated.", f"simulated_downloaded_map_config.json", None
 
-    _emit_progress(task_id, f"Starting actual {component_type_str} component download for timestamp {backup_timestamp}.", level='INFO')
+    _emit_progress(task_id, f"Starting map configuration component download from '{full_path_on_share}'.", level='INFO')
 
-    if not config_share_client:
-        error_msg = f"{component_type_str} download error: config_share_client not provided."
+    # Extract a base filename from the full_path_on_share for the local temp file
+    base_filename = os.path.basename(full_path_on_share) if full_path_on_share else "map_config.json"
+    local_filename = f"downloaded_{base_filename}"
+    local_temp_path = os.path.join(DATA_DIR, local_filename)
+
+    os.makedirs(DATA_DIR, exist_ok=True)
+
+    if download_file(share_client, full_path_on_share, local_temp_path):
+        _emit_progress(task_id, f"Map configuration downloaded successfully to '{local_temp_path}'.", level='SUCCESS')
+        return True, f"Map configuration downloaded to '{local_temp_path}'.", local_temp_path, None
+    else:
+        error_msg = f"Failed to download map configuration from '{full_path_on_share}'."
         _emit_progress(task_id, error_msg, level='ERROR')
-        return False, error_msg, None, "config_share_client is None"
+        return False, error_msg, None, error_msg
 
-    try:
-        os.makedirs(DATA_DIR, exist_ok=True) # Ensure DATA_DIR exists
+# Retire _download_config_component_generic as its main purpose was path construction
+# which is now handled by the caller (do_selective_restore_work using manifest paths)
 
-        config_filename = f"{filename_prefix}{backup_timestamp}.json"
-        remote_config_file_path = f"{CONFIG_BACKUPS_DIR}/{config_filename}"
-        local_temp_config_path = os.path.join(DATA_DIR, f"downloaded_{config_filename}")
+def download_resource_config_component(share_client: ShareClient, full_path_on_share: str, task_id: str = None, dry_run: bool = False):
+    if dry_run:
+        _emit_progress(task_id, "DRY RUN: Simulating resource configurations component download.", level='INFO')
+        return True, "Dry run: Resource configurations download simulated.", f"simulated_downloaded_resource_configs.json", None
 
-        _emit_progress(task_id, f"Attempting to download {component_type_str} backup '{remote_config_file_path}' to '{local_temp_config_path}'.", level='INFO')
+    _emit_progress(task_id, f"Starting resource configurations component download from '{full_path_on_share}'.", level='INFO')
+    base_filename = os.path.basename(full_path_on_share) if full_path_on_share else "resource_configs.json"
+    local_filename = f"downloaded_{base_filename}"
+    local_temp_path = os.path.join(DATA_DIR, local_filename)
 
-        download_success = download_file(config_share_client, remote_config_file_path, local_temp_config_path)
+    os.makedirs(DATA_DIR, exist_ok=True)
 
-        if download_success:
-            _emit_progress(task_id, f"{component_type_str} backup '{config_filename}' downloaded successfully to '{local_temp_config_path}'.", level='SUCCESS')
-            return True, f"{component_type_str} backup '{config_filename}' downloaded to '{local_temp_config_path}'.", local_temp_config_path, None
-        else:
-            error_msg = f"Failed to download '{remote_config_file_path}' for {component_type_str} from Azure."
-            _emit_progress(task_id, f"Failed to download {component_type_str} backup '{config_filename}'. Error details should be in previous logs from download_file utility.", level='ERROR')
-            return False, error_msg, None, error_msg
-
-    except Exception as e:
-        logger.error(f"Unexpected error during {component_type_str} component download for {backup_timestamp}: {e}", exc_info=True)
-        error_msg = f"Error during {component_type_str} download: {str(e)}"
+    if download_file(share_client, full_path_on_share, local_temp_path):
+        _emit_progress(task_id, f"Resource configurations downloaded successfully to '{local_temp_path}'.", level='SUCCESS')
+        return True, f"Resource configurations downloaded to '{local_temp_path}'.", local_temp_path, None
+    else:
+        error_msg = f"Failed to download resource configurations from '{full_path_on_share}'."
         _emit_progress(task_id, error_msg, level='ERROR')
-        return False, error_msg, None, str(e)
+        return False, error_msg, None, error_msg
 
-def download_map_config_component(backup_timestamp, config_share_client, dry_run=False, task_id=None):
-    return _download_config_component_generic(
-        backup_timestamp,
-        config_share_client,
-        "map config",
-        MAP_CONFIG_FILENAME_PREFIX,
-        task_id,
-        dry_run
-    )
+def download_user_config_component(share_client: ShareClient, full_path_on_share: str, task_id: str = None, dry_run: bool = False):
+    if dry_run:
+        _emit_progress(task_id, "DRY RUN: Simulating user configurations component download.", level='INFO')
+        return True, "Dry run: User configurations download simulated.", f"simulated_downloaded_user_configs.json", None
 
-def download_resource_config_component(backup_timestamp, config_share_client, dry_run=False, task_id=None):
-    return _download_config_component_generic(
-        backup_timestamp,
-        config_share_client,
-        "resource configs",
-        RESOURCE_CONFIG_FILENAME_PREFIX,
-        task_id,
-        dry_run
-    )
+    _emit_progress(task_id, f"Starting user configurations component download from '{full_path_on_share}'.", level='INFO')
+    base_filename = os.path.basename(full_path_on_share) if full_path_on_share else "user_configs.json"
+    local_filename = f"downloaded_{base_filename}"
+    local_temp_path = os.path.join(DATA_DIR, local_filename)
 
-def download_user_config_component(backup_timestamp, config_share_client, dry_run=False, task_id=None):
-    return _download_config_component_generic(
-        backup_timestamp,
-        config_share_client,
-        "user configs",
-        USER_CONFIG_FILENAME_PREFIX,
-        task_id,
-        dry_run
-    )
+    os.makedirs(DATA_DIR, exist_ok=True)
 
-def restore_media_component(backup_timestamp, media_component_name, azure_remote_folder_base, local_target_folder_base, media_share_client, dry_run=False, task_id=None):
+    if download_file(share_client, full_path_on_share, local_temp_path):
+        _emit_progress(task_id, f"User configurations downloaded successfully to '{local_temp_path}'.", level='SUCCESS')
+        return True, f"User configurations downloaded to '{local_temp_path}'.", local_temp_path, None
+    else:
+        error_msg = f"Failed to download user configurations from '{full_path_on_share}'."
+        _emit_progress(task_id, error_msg, level='ERROR')
+        return False, error_msg, None, error_msg
+
+def download_scheduler_settings_component(share_client: ShareClient, full_path_on_share: str, task_id: str = None, dry_run: bool = False):
+    if dry_run:
+        _emit_progress(task_id, "DRY RUN: Simulating scheduler settings component download.", level='INFO')
+        return True, "Dry run: Scheduler settings download simulated.", f"simulated_downloaded_scheduler_settings.json", None
+
+    _emit_progress(task_id, f"Starting scheduler settings component download from '{full_path_on_share}'.", level='INFO')
+    base_filename = os.path.basename(full_path_on_share) if full_path_on_share else "scheduler_settings.json"
+    local_filename = f"downloaded_{base_filename}"
+    local_temp_path = os.path.join(DATA_DIR, local_filename)
+
+    os.makedirs(DATA_DIR, exist_ok=True)
+
+    if download_file(share_client, full_path_on_share, local_temp_path):
+        _emit_progress(task_id, f"Scheduler settings downloaded successfully to '{local_temp_path}'.", level='SUCCESS')
+        return True, f"Scheduler settings downloaded to '{local_temp_path}'.", local_temp_path, None
+    else:
+        error_msg = f"Failed to download scheduler settings from '{full_path_on_share}'."
+        _emit_progress(task_id, error_msg, level='ERROR')
+        return False, error_msg, None, error_msg
+
+def restore_media_component(share_client: ShareClient, azure_component_path_on_share: str, local_target_folder_base: str, media_component_name: str, task_id: str = None, dry_run: bool = False):
     """
     Restores (downloads) a media component (e.g., Floor Maps, Resource Uploads) from Azure.
 
     Args:
-        backup_timestamp (str): The timestamp of the backup (used for logging context).
-        media_component_name (str): Name of the media component (e.g., "Floor Maps").
-        azure_remote_folder_base (str): The full path to the Azure directory containing the files to download
-                                         (e.g., "media_backups/backup_YYYYMMDD_HHMMSS/floor_map_uploads").
+        share_client (ShareClient): The Azure File Share client for the unified system backup share.
+        azure_component_path_on_share (str): The full path to the Azure directory for this specific media type
+                                             (e.g., "full_system_backups/backup_XYZ/media/floor_map_uploads").
         local_target_folder_base (str): The local base directory to download files into
                                          (e.g., "/app/static/floor_map_uploads").
-        media_share_client (ShareClient): The Azure File Share client for the media share.
-        dry_run (bool): If True, simulates the restore.
+        media_component_name (str): Name of the media component (e.g., "Floor Maps") for logging.
         task_id (str, optional): The ID of the task for progress emission.
+        dry_run (bool): If True, simulates the restore.
 
     Returns:
         tuple: (success_status, message, error_detail)
@@ -1274,20 +1265,20 @@ def restore_media_component(backup_timestamp, media_component_name, azure_remote
     """
     _emit_progress(task_id, f"Processing media component: {media_component_name}", level='INFO')
 
-    if not media_share_client:
-        error_msg = f"{media_component_name} restore error: media_share_client not provided."
+    if not share_client: # Changed from media_share_client
+        error_msg = f"{media_component_name} restore error: share_client not provided."
         _emit_progress(task_id, error_msg, level='ERROR')
         return False, error_msg, error_msg
 
     try:
-        dir_client = media_share_client.get_directory_client(azure_remote_folder_base)
+        # azure_component_path_on_share is the new azure_remote_folder_base
+        dir_client = share_client.get_directory_client(azure_component_path_on_share)
 
         if dry_run:
-            _emit_progress(task_id, f"DRY RUN: Simulating media restore for {media_component_name} from {azure_remote_folder_base} to {local_target_folder_base}.", level='INFO')
+            _emit_progress(task_id, f"DRY RUN: Simulating media restore for {media_component_name} from {azure_component_path_on_share} to {local_target_folder_base}.", level='INFO')
             if not _client_exists(dir_client):
-                _emit_progress(task_id, f"DRY RUN: Azure source folder {azure_remote_folder_base} would not be found.", level='WARNING')
-                # For dry run, not finding the source might not be a failure of the dry run itself, but a finding.
-                return True, f"Dry run: Azure source folder {azure_remote_folder_base} not found for {media_component_name}.", None
+                _emit_progress(task_id, f"DRY RUN: Azure source folder {azure_component_path_on_share} would not be found.", level='WARNING')
+                return True, f"Dry run: Azure source folder {azure_component_path_on_share} not found for {media_component_name}.", None
 
             item_count = 0
             for item in dir_client.list_directories_and_files():
@@ -1295,27 +1286,25 @@ def restore_media_component(backup_timestamp, media_component_name, azure_remote
                     _emit_progress(task_id, f"DRY RUN: Would download {item['name']} for {media_component_name}.", level='INFO')
                     item_count +=1
             if item_count == 0:
-                 _emit_progress(task_id, f"DRY RUN: No files found in {azure_remote_folder_base} to download for {media_component_name}.", level='INFO')
+                 _emit_progress(task_id, f"DRY RUN: No files found in {azure_component_path_on_share} to download for {media_component_name}.", level='INFO')
             _emit_progress(task_id, f"DRY RUN: Media restore for {media_component_name} simulated successfully. {item_count} files would be processed.", level='SUCCESS')
             return True, f"Dry run: Media restore for {media_component_name} simulated.", None
 
-        # Actual Restore
-        _emit_progress(task_id, f"Starting actual media restore for {media_component_name} from {azure_remote_folder_base} to {local_target_folder_base}.", level='INFO')
-
+        _emit_progress(task_id, f"Starting actual media restore for {media_component_name} from {azure_component_path_on_share} to {local_target_folder_base}.", level='INFO')
         os.makedirs(local_target_folder_base, exist_ok=True)
 
         if not _client_exists(dir_client):
-            error_msg = f"Azure source folder {azure_remote_folder_base} not found for {media_component_name}."
+            error_msg = f"Azure source folder {azure_component_path_on_share} not found for {media_component_name}."
             _emit_progress(task_id, error_msg, level='ERROR')
             return False, error_msg, error_msg
 
         files_downloaded_count = 0
         files_failed_count = 0
         errors_list = []
-        items_in_source_dir = list(dir_client.list_directories_and_files()) # Consume generator to check if empty
+        items_in_source_dir = list(dir_client.list_directories_and_files())
 
         if not items_in_source_dir:
-            final_message = f"Media restore for {media_component_name}: No files found in backup source '{azure_remote_folder_base}'."
+            final_message = f"Media restore for {media_component_name}: No files found in backup source '{azure_component_path_on_share}'."
             _emit_progress(task_id, final_message, level='INFO')
             return True, final_message, None
 
@@ -1325,15 +1314,11 @@ def restore_media_component(backup_timestamp, media_component_name, azure_remote
                 continue
 
             file_name = item['name']
-            # remote_file_path needs to be relative to the share for download_file if media_share_client is ShareClient
-            # If azure_remote_folder_base is already the full path from share root, then this is correct.
-            remote_file_path = f"{azure_remote_folder_base}/{file_name}"
+            remote_file_path = f"{azure_component_path_on_share}/{file_name}" # Use the full path from component
             local_file_path = os.path.join(local_target_folder_base, file_name)
 
             _emit_progress(task_id, f"Downloading media file '{file_name}' for {media_component_name} to '{local_file_path}'.", level='INFO')
-
-            # download_file expects share_client, path_on_share, local_destination_path
-            download_success = download_file(media_share_client, remote_file_path, local_file_path)
+            download_success = download_file(share_client, remote_file_path, local_file_path)
 
             if download_success:
                 files_downloaded_count += 1
@@ -1343,27 +1328,21 @@ def restore_media_component(backup_timestamp, media_component_name, azure_remote
                 errors_list.append(error_detail)
                 _emit_progress(task_id, error_detail, level='ERROR')
 
-        # After loop
         if files_failed_count > 0:
             final_message = f"Media restore for {media_component_name} completed with errors. Downloaded: {files_downloaded_count}, Failed: {files_failed_count}."
             _emit_progress(task_id, final_message, level='ERROR')
             return False, final_message, "; ".join(errors_list)
-        # This case is now handled before the loop by checking items_in_source_dir
-        # else if files_downloaded_count == 0:
-        #     final_message = f"Media restore for {media_component_name}: No files were downloaded. Source '{azure_remote_folder_base}' might have been empty or contained only directories."
-        #     _emit_progress(task_id, final_message, level='INFO')
-        #     return True, final_message, None
-        else: # files_downloaded_count > 0 and files_failed_count == 0
+        else:
             final_message = f"Media restore for {media_component_name} completed successfully. Downloaded: {files_downloaded_count} files."
             _emit_progress(task_id, final_message, level='SUCCESS')
             return True, final_message, None
 
-    except ResourceNotFoundError: # Should be caught by _client_exists generally, but good to have defense
-        error_msg = f"Azure source folder {azure_remote_folder_base} not found during media restore for {media_component_name}."
+    except ResourceNotFoundError:
+        error_msg = f"Azure source folder {azure_component_path_on_share} not found during media restore for {media_component_name}."
         _emit_progress(task_id, error_msg, level='ERROR')
         return False, error_msg, error_msg
     except Exception as e:
-        logger.error(f"Unexpected error during media restore for {media_component_name} (from {azure_remote_folder_base}): {e}", exc_info=True)
+        logger.error(f"Unexpected error during media restore for {media_component_name} (from {azure_component_path_on_share}): {e}", exc_info=True)
         error_msg = f"Error during media restore for {media_component_name}: {str(e)}"
         _emit_progress(task_id, error_msg, level='ERROR')
         return False, error_msg, str(e)

--- a/templates/admin/backup_system.html
+++ b/templates/admin/backup_system.html
@@ -201,6 +201,10 @@
                     <label class="form-check-label" for="component-map_config">{{ _('Map Configuration (Floor map definitions & resource mappings on maps)') }}</label>
                 </div>
                 <div class="form-check">
+                    <input class="form-check-input component-checkbox" type="checkbox" value="scheduler_settings" id="component-scheduler_settings" name="components">
+                    <label class="form-check-label" for="component-scheduler_settings">{{ _('Scheduler Settings (Schedules, Startup Restore Setting)') }}</label>
+                </div>
+                <div class="form-check">
                     <input class="form-check-input component-checkbox" type="checkbox" value="floor_maps" id="component-floor_maps" name="components">
                     <label class="form-check-label" for="component-floor_maps">{{ _('Floor Map Images (in static/floor_map_uploads)') }}</label>
                 </div>

--- a/utils.py
+++ b/utils.py
@@ -333,6 +333,41 @@ def save_scheduler_settings(settings_dict):
     except IOError as e:
         logger.error(f"Error saving scheduler settings: {e}")
 
+def save_scheduler_settings_from_json_data(settings_data: dict) -> tuple[dict, int]:
+    """
+    Saves the provided dictionary of scheduler settings to the local
+    scheduler_settings.json file.
+    Args:
+        settings_data: A Python dictionary containing the scheduler settings.
+    Returns:
+        A tuple containing a summary dictionary and an HTTP-like status code.
+        Example: ({'message': '...', 'errors': [], 'warnings': []}, 200)
+    """
+    logger = current_app.logger if current_app else logging.getLogger(__name__)
+    logger.info(f"Attempting to save scheduler settings from provided JSON data to {SCHEDULER_SETTINGS_FILE_PATH}")
+
+    if not isinstance(settings_data, dict):
+        err_msg = "Invalid settings_data format: Must be a dictionary."
+        logger.error(err_msg)
+        return ({'message': err_msg, 'errors': [err_msg], 'warnings': []}, 400)
+
+    try:
+        os.makedirs(DATA_DIR, exist_ok=True) # Ensure the data directory exists
+        with open(SCHEDULER_SETTINGS_FILE_PATH, 'w', encoding='utf-8') as f:
+            json.dump(settings_data, f, indent=4) # Using indent=4 for consistency if it matters
+
+        success_msg = "Scheduler settings applied successfully from backup."
+        logger.info(success_msg)
+        return ({'message': success_msg, 'errors': [], 'warnings': []}, 200)
+    except IOError as e:
+        error_msg = f"Failed to save scheduler settings from backup due to IOError: {str(e)}"
+        logger.error(error_msg, exc_info=True)
+        return ({'message': error_msg, 'errors': [str(e)], 'warnings': []}, 500)
+    except Exception as e: # Catch any other unexpected errors
+        error_msg = f"An unexpected error occurred while saving scheduler settings from backup: {str(e)}"
+        logger.error(error_msg, exc_info=True)
+        return ({'message': error_msg, 'errors': [str(e)], 'warnings': []}, 500)
+
 def add_audit_log(action: str, details: str, user_id: int = None, username: str = None):
     logger = current_app.logger if current_app else logging.getLogger(__name__)
     try:


### PR DESCRIPTION
This commit refactors the restore functionality to align with the new unified Azure storage structure and introduces the ability to restore scheduler settings.

Key changes:
1.  `azure_backup.py`:
    *   Refactored `restore_database_component`, `download_map_config_component`, `download_resource_config_component`, `download_user_config_component`, and `restore_media_component` to accept full Azure paths constructed from manifest data and operate on the unified `AZURE_SYSTEM_BACKUP_SHARE`.
    *   Added `download_scheduler_settings_component` for fetching scheduler settings backup.
    *   Removed reliance on old path constants (e.g., `DB_BACKUPS_DIR`) within these functions.

2.  `routes/api_system.py` (`do_selective_restore_work`):
    *   Uses a single `system_share_client` for the `AZURE_SYSTEM_BACKUP_SHARE`.
    *   Downloads and parses the backup manifest from the new unified location.
    *   Constructs full component paths on Azure using `path_in_backup` from the manifest before calling the refactored functions in `azure_backup.py`.
    *   Integrated "Scheduler Settings" into the selective restore flow, calling the new download function and `utils.save_scheduler_settings_from_json_data` to apply the settings.

3.  `templates/admin/backup_system.html`:
    *   Added a checkbox for "Scheduler Settings (Schedules, Startup Restore Setting)" to the selective restore modal, allowing you to include these settings in a restore operation.

These changes ensure that the restore process correctly sources files from the new backup structure and expands restore capabilities to include scheduler configurations.