### PR TITLE
fix: Resolve startup ImportError and correct app_factory restore logic

### DIFF
--- a/routes/api_system.py
+++ b/routes/api_system.py
@@ -65,7 +65,7 @@ try:
         # restore_bookings_from_csv_backup, # Removed
         # TODO: Obsolete? Import commented out as 'list_available_incremental_booking_backups' is likely obsolete.
         # list_available_incremental_booking_backups, # Keeping non-CSV legacy for now
-        restore_incremental_bookings, # Keeping non-CSV legacy for now
+        # restore_incremental_bookings, # REMOVED Keeping non-CSV legacy for now
         restore_bookings_from_full_db_backup,
         backup_incremental_bookings, # Added for manual incremental backup
         backup_full_bookings_json, # Added for manual full JSON booking export
@@ -109,7 +109,7 @@ except (ImportError, RuntimeError) as e_detailed_azure_import: # Capture the exc
     restore_media_component = None
     # TODO: Obsolete? Usage of 'list_available_incremental_booking_backups' commented out.
     # list_available_incremental_booking_backups = None
-    restore_incremental_bookings = None
+    # restore_incremental_bookings = None # REMOVED
     restore_bookings_from_full_db_backup = None
     backup_incremental_bookings = None
     backup_full_bookings_json = None


### PR DESCRIPTION
This commit addresses two issues I identified during application startup:

1.  **ImportError in `routes/api_system.py`**:
    - I removed an attempt to import `restore_incremental_bookings` from `azure_backup.py`, as this function was previously commented out and its functionality superseded by the new centralized restore process. The function was not directly called in `api_system.py`.

2.  **Incorrect Startup Restore Execution in `app_factory.py`**:
    - The logic in `app_factory.py` for initiating the startup restore was still referencing old/missing functions and settings.
    - I updated `app_factory.py` to:
        - Correctly import `perform_startup_restore_sequence` from `azure_backup.py`.
        - Check the correct boolean setting `auto_restore_full_system_on_startup` from `scheduler_settings.json`. - Call `perform_startup_restore_sequence(app)` if the setting is true and the function is available. - Remove the old restore logic blocks, including the separate call to `restore_incremental_bookings`.

These changes ensure that the intended startup restore mechanism, if enabled, is correctly invoked. This should also help in scenarios leading to `OperationalError: no such table: user` if a valid database is restored. If no restore is performed on a fresh setup, `flask db upgrade` is still required to initialize the schema.