### PR TITLE
fix: Resolve TypeError in config imports and improve media handling

### DIFF
--- a/app_factory.py
+++ b/app_factory.py
@@ -203,15 +203,15 @@ def create_app(config_object=config, testing=False): # Added testing parameter
     else: # Not in globals at all
         app.logger.info("DIAGNOSTIC (inside create_app): perform_startup_restore_sequence NOT FOUND in globals.")
 
-    # Check for backup_if_changed
-    if 'backup_if_changed' in globals() and globals()['backup_if_changed'] is not None:
-        bic_func = globals()['backup_if_changed']
-        app.logger.info(f"DIAGNOSTIC (inside create_app): backup_if_changed was found in globals. Type = {type(bic_func)}")
-        app.logger.info(f"DIAGNOSTIC (inside create_app): backup_if_changed is callable = {callable(bic_func)}")
-    elif 'backup_if_changed' in globals(): # It's in globals but is None
-        app.logger.info("DIAGNOSTIC (inside create_app): backup_if_changed is in globals but is None (likely set to None in except ImportError block).")
+    # Check for backup_if_changed (aliased as azure_backup_if_changed)
+    if 'azure_backup_if_changed' in globals() and globals()['azure_backup_if_changed'] is not None:
+        bic_func = globals()['azure_backup_if_changed']
+        app.logger.info(f"DIAGNOSTIC (inside create_app): azure_backup_if_changed was found in globals. Type = {type(bic_func)}")
+        app.logger.info(f"DIAGNOSTIC (inside create_app): azure_backup_if_changed is callable = {callable(bic_func)}")
+    elif 'azure_backup_if_changed' in globals(): # It's in globals but is None
+        app.logger.info("DIAGNOSTIC (inside create_app): azure_backup_if_changed is in globals but is None (likely set to None in except ImportError block).")
     else: # Not in globals at all
-        app.logger.info("DIAGNOSTIC (inside create_app): backup_if_changed NOT FOUND in globals.")
+        app.logger.info("DIAGNOSTIC (inside create_app): azure_backup_if_changed NOT FOUND in globals.")
 
     # Control verbosity of Azure SDK loggers based on app's log level
     azure_logger_names = [


### PR DESCRIPTION
This commit addresses critical errors within the startup restore sequence and refines media component handling.

1.  **Corrected TypeError in Configuration Imports (`azure_backup.py`):**
    - I modified the `perform_startup_restore_sequence` function.
    - Calls to the configuration import utilities (`_import_map_configuration_data`, `_import_resource_configurations_data`, `_import_user_configurations_data` from `utils.py`) now correctly pass only the single `config_data` argument. This resolves the `TypeError` that was occurring due to extra arguments being passed.
    - I also made the handling and logging of results from these import functions more robust and type-aware to accurately reflect the outcome of each configuration import step.

2.  **Improved Media Component Handling (`azure_backup.py`):**
    - In `perform_startup_restore_sequence`, I updated the logic for handling manifest components. If a component has `type == "media"` and `path_in_backup == "media"` (i.e., it's the top-level media directory), an informational message is logged, and the download attempt for this directory entry is skipped. This prevents a "File not found" error, as the system currently does not support recursive directory download for media in this startup sequence. Full media restore is deferred.

3.  **Corrected Diagnostic Logging (`app_factory.py`):**
    - The diagnostic log that checks for `backup_if_changed` now correctly uses its alias `azure_backup_if_changed` when inspecting `globals()`.

These changes are expected to allow the startup restore sequence to run more completely if enabled, correctly importing configurations after the database is restored, and gracefully skipping the media directory.