### PR TITLE
fix: Resolve TypeError in user config import and residual ImportError

### DIFF
--- a/routes/api_system.py
+++ b/routes/api_system.py
@@ -69,7 +69,6 @@ try:
         restore_bookings_from_full_db_backup,
         backup_incremental_bookings, # Added for manual incremental backup
         backup_full_bookings_json, # Added for manual full JSON booking export
-        list_available_full_booking_json_exports, # For listing full JSON exports
         restore_bookings_from_full_json_export, # For restoring from full JSON export
         delete_incremental_booking_backup, # For deleting incremental JSON backups
         # New Unified Booking Data Protection functions
@@ -113,7 +112,6 @@ except (ImportError, RuntimeError) as e_detailed_azure_import: # Capture the exc
     restore_bookings_from_full_db_backup = None
     backup_incremental_bookings = None
     backup_full_bookings_json = None
-    list_available_full_booking_json_exports = None
     restore_bookings_from_full_json_export = None
     delete_incremental_booking_backup = None
     # TODO: Obsolete? Assignment for 'backup_full_booking_data_json_azure' commented out.


### PR DESCRIPTION
This commit addresses two key issues:
1.  A `TypeError` during the startup restore sequence when importing user and role configurations.
2.  An `ImportError` in `routes/api_system.py` at application startup.

Detailed changes:

1.  **`utils.py` (`_import_user_configurations_data`):**
    - Modified the handling of the `permissions` field for roles during the import process.
    - The function now correctly checks if the `permissions` data from the backup is already a Python list. If so, it uses the list directly.
    - If the `permissions` data is a string, it attempts to parse it as JSON (expecting a list). If JSON parsing fails, it falls back to interpreting the string as comma-separated values or a single literal permission.
    - This resolves the `TypeError: the JSON object must be str, bytes or bytearray, not list` which occurred when `json.loads()` was called on an already-parsed list.

2.  **`routes/api_system.py`:**
    - Removed the import of `list_available_full_booking_json_exports` from `azure_backup.py`.
    - This function was found to be unused in `api_system.py` and was not defined in `azure_backup.py`, causing an `ImportError` during application startup.

These fixes are expected to make the startup restore process more robust and eliminate a startup crash, allowing the application to initialize correctly and perform data restoration more reliably when configured to do so.