### PR TITLE
fix: Resolve final errors in startup restore and imports

### DIFF
--- a/routes/api_system.py
+++ b/routes/api_system.py
@@ -62,13 +62,12 @@ try:
         restore_bookings_from_full_db_backup,
         backup_incremental_bookings,
         backup_full_bookings_json,
-        restore_bookings_from_full_json_export,
+        # restore_bookings_from_full_json_export, # REMOVED
         delete_incremental_booking_backup,
         list_booking_data_json_backups,
         delete_booking_data_json_backup,
         restore_booking_data_to_point_in_time,
         download_booking_data_json_backup
-        # Ensure list_available_full_booking_json_exports is NOT here
     )
     import azure_backup # This line can remain
     print(f"DEBUG api_system.py: Successfully imported from azure_backup (again). create_full_backup type: {type(create_full_backup)}") # New debug
@@ -97,14 +96,13 @@ except (ImportError, RuntimeError) as e_detailed_azure_import: # Capture the exc
     restore_bookings_from_full_db_backup = None
     backup_incremental_bookings = None
     backup_full_bookings_json = None
-    restore_bookings_from_full_json_export = None
+    # restore_bookings_from_full_json_export = None # REMOVED
     delete_incremental_booking_backup = None
     list_booking_data_json_backups = None
     delete_booking_data_json_backup = None
     restore_booking_data_to_point_in_time = None
     download_booking_data_json_backup = None
     azure_backup = None
-    # Ensure list_available_full_booking_json_exports = None is NOT here
 
 api_system_bp = Blueprint('api_system', __name__)
 

--- a/utils.py
+++ b/utils.py
@@ -1389,7 +1389,7 @@ def _import_user_configurations_data(user_config_data: dict): # Return type will
                 role.name = role_name
                 # Assuming Role.description and Role.permissions are attributes that can be set
                 role.description = role_item.get('description', role.description)
-                role.permissions = permissions_list
+                role.permissions = json.dumps(permissions_list)
                 db.session.add(role)
                 roles_updated += 1
                 backup_to_new_role_id_mapping[backup_role_id] = role.id
@@ -1398,7 +1398,7 @@ def _import_user_configurations_data(user_config_data: dict): # Return type will
                 if role_by_name:
                     warnings.append(f"Role with backup ID {backup_role_id} not found, but role with name '{role_name}' (ID: {role_by_name.id}) exists. Updating existing role by name.")
                     role_by_name.description = role_item.get('description', role_by_name.description)
-                    role_by_name.permissions = permissions_list
+                    role_by_name.permissions = json.dumps(permissions_list)
                     db.session.add(role_by_name)
                     roles_updated += 1
                     backup_to_new_role_id_mapping[backup_role_id] = role_by_name.id
@@ -1407,7 +1407,7 @@ def _import_user_configurations_data(user_config_data: dict): # Return type will
                     new_role = Role(
                         name=role_name,
                         description=role_item.get('description'),
-                        permissions=permissions_list
+                        permissions=json.dumps(permissions_list)
                     )
                     # If backup_role_id is intended to be preserved for new roles (and is unique)
                     # new_role.id = backup_role_id # This might require careful handling if IDs are auto-incrementing


### PR DESCRIPTION
This commit addresses the last known critical errors hindering the startup restore process and an initial import error:

1.  **`utils.py` (`_import_user_configurations_data`):**
    - Fixed a `sqlite3.ProgrammingError` that occurred when saving role permissions to the database.
    - The `permissions_list` (a Python list of strings) is now explicitly converted to a JSON string using `json.dumps()` before being assigned to the `Role.permissions` attribute. This ensures the data type is compatible with the database column, which expects a string.

2.  **`routes/api_system.py`:**
    - Definitively fixed a persistent `ImportError` by replacing the entire `try...except ImportError` block for `azure_backup` imports with a corrected version that ensures the non-existent function `restore_bookings_from_full_json_export` (and previously `list_available_full_booking_json_exports`) is not imported or referenced.

With these corrections, the startup restore sequence, when enabled, should now be able to fully import all configuration data, including user roles and permissions, without crashing. The initial `ImportError` from `routes/api_system.py` should also be resolved.