### PR TITLE
Refactor Azure backup restoration to init_setup.py

### DIFF
--- a/app_factory.py
+++ b/app_factory.py
@@ -248,24 +248,31 @@ def create_app(config_object=config, testing=False): # Added testing parameter
                 app.logger.info("Startup restore from scheduler_settings.json: DISABLED.")
 
     # New logic for startup restore sequence - SKIP IF TESTING
-    if not testing and azure_backup_available and callable(perform_startup_restore_sequence):
+    # THIS BLOCK IS NOW REMOVED. Restoration is handled by init_setup.py
+    # if not testing and azure_backup_available and callable(perform_startup_restore_sequence):
+    #     if should_attempt_restore:
+    #         app.logger.info("Configuration indicates automatic restore on startup. Attempting full system restore sequence...")
+    #         try:
+    #             # Pass the app instance itself
+    #             restore_result = perform_startup_restore_sequence(app)
+    #             app.logger.info(f"Startup restore sequence completed. Status: {restore_result.get('status')}, Message: {restore_result.get('message')}")
+    #             if restore_result.get('status') != 'success':
+    #                 app.logger.error(f"Startup restore sequence did not complete successfully: {restore_result.get('message')}")
+    #         except Exception as e_startup_restore:
+    #             app.logger.exception(f"Critical error during perform_startup_restore_sequence: {e_startup_restore}")
+    #     else:
+    #         # This log covers cases where restore is disabled by either env var or settings file.
+    #         app.logger.info("Automatic restore on startup is disabled. Skipping full system restore sequence.")
+    # elif not testing and should_attempt_restore: # Only warn if restore was desired but not possible due to missing utilities
+    #      app.logger.warning("Automatic restore on startup is ENABLED (by env var or settings), but restore utilities (perform_startup_restore_sequence) are not available/imported. Skipping restore.")
+    # # No specific 'else' needed here if should_attempt_restore is false and utilities are unavailable,
+    # # as the earlier log about being disabled covers it, or if testing is true, nothing here runs.
+
+    if not testing:
         if should_attempt_restore:
-            app.logger.info("Configuration indicates automatic restore on startup. Attempting full system restore sequence...")
-            try:
-                # Pass the app instance itself
-                restore_result = perform_startup_restore_sequence(app)
-                app.logger.info(f"Startup restore sequence completed. Status: {restore_result.get('status')}, Message: {restore_result.get('message')}")
-                if restore_result.get('status') != 'success':
-                    app.logger.error(f"Startup restore sequence did not complete successfully: {restore_result.get('message')}")
-            except Exception as e_startup_restore:
-                app.logger.exception(f"Critical error during perform_startup_restore_sequence: {e_startup_restore}")
+            app.logger.info("NOTE: Automatic Azure restore on app startup is configured but has been MOVED to init_setup.py. Run 'python init_setup.py --restore-from-azure' or set ENABLE_AUTO_STARTUP_RESTORE for init_setup.py to perform the restore.")
         else:
-            # This log covers cases where restore is disabled by either env var or settings file.
-            app.logger.info("Automatic restore on startup is disabled. Skipping full system restore sequence.")
-    elif not testing and should_attempt_restore: # Only warn if restore was desired but not possible due to missing utilities
-         app.logger.warning("Automatic restore on startup is ENABLED (by env var or settings), but restore utilities (perform_startup_restore_sequence) are not available/imported. Skipping restore.")
-    # No specific 'else' needed here if should_attempt_restore is false and utilities are unavailable,
-    # as the earlier log about being disabled covers it, or if testing is true, nothing here runs.
+            app.logger.info("Automatic Azure restore on app startup is disabled (as determined by env vars or settings). This is the expected behavior if init_setup.py handles restoration.")
 
 
     # Old incremental booking restore block is removed.

--- a/config.py
+++ b/config.py
@@ -139,9 +139,24 @@ AZURE_STORAGE_CONNECTION_STRING = os.environ.get('AZURE_STORAGE_CONNECTION_STRIN
 # Default container name for backups in Azure Blob Storage
 AZURE_CONTAINER_NAME = os.environ.get('AZURE_CONTAINER_NAME', 'roombookingbackup')
 # Names for shares within Azure File Storage (if used by azure_backup.py)
-AZURE_DB_SHARE = os.environ.get('AZURE_DB_SHARE', 'db-backups')
-AZURE_CONFIG_SHARE = os.environ.get('AZURE_CONFIG_SHARE', 'config-backups')
-AZURE_MEDIA_SHARE = os.environ.get('AZURE_MEDIA_SHARE', 'media')
+AZURE_DB_SHARE = os.environ.get('AZURE_DB_SHARE', 'db-backups') # Legacy or specific component share
+AZURE_CONFIG_SHARE = os.environ.get('AZURE_CONFIG_SHARE', 'config-backups') # Legacy or specific component share
+AZURE_MEDIA_SHARE = os.environ.get('AZURE_MEDIA_SHARE', 'media') # Legacy or specific component share
+
+# Unified Azure File Share for full system backups (used by azure_backup.py's new system)
+AZURE_SYSTEM_BACKUP_SHARE = os.environ.get('AZURE_SYSTEM_BACKUP_SHARE', 'system-backups')
+# Base directory name within the AZURE_SYSTEM_BACKUP_SHARE where 'backup_YYYYMMDD_HHMMSS' folders are stored
+# This corresponds to FULL_SYSTEM_BACKUPS_BASE_DIR in azure_backup.py
+AZURE_FULL_SYSTEM_BACKUPS_BASE_DIR_NAME = os.environ.get('AZURE_FULL_SYSTEM_BACKUPS_BASE_DIR_NAME', 'full_system_backups')
+
+
+# Share for booking data protection backups (JSON exports, etc.)
+AZURE_BOOKING_DATA_SHARE = os.environ.get('AZURE_BOOKING_DATA_SHARE', 'booking-data-backups')
+# Base directory name within AZURE_BOOKING_DATA_SHARE for these backups
+# Corresponds to AZURE_BOOKING_DATA_PROTECTION_DIR in azure_backup.py
+AZURE_BOOKING_DATA_PROTECTION_BASE_DIR_NAME = os.environ.get('AZURE_BOOKING_DATA_PROTECTION_BASE_DIR_NAME', 'booking_data_protection_backups')
+
+
 # BOOKINGS_CSV_BACKUP_INTERVAL_MINUTES has been removed as it's related to legacy CSV backups.
 
 


### PR DESCRIPTION
Moves the Azure full system backup restoration logic from app startup (app_factory.py) to init_setup.py.

Key changes:
- `init_setup.py` now accepts a `--restore-from-azure` command-line argument or respects the `ENABLE_AUTO_STARTUP_RESTORE` environment variable to trigger the restoration process.
- When triggered, `init_setup.py` calls `azure_backup.perform_startup_restore_sequence` within a Flask app context.
- `azure_backup.perform_startup_restore_sequence` was enhanced to:
    - Correctly identify the latest full system backup from Azure File Share.
    - Handle the scenario where no backups are found by logging and skipping.
    - Improve component download and application logic, especially for media files.
    - Provide clearer status reporting (success, success_no_action, partial_failure, failure).
- `app_factory.py` no longer attempts to perform this restoration, instead logging that the functionality has moved or is disabled.
- `config.py` was updated with necessary environment variables for Azure File Share paths.

This change ensures that full system restoration from Azure only occurs when `init_setup.py` is explicitly run with the appropriate trigger, preventing unintended restorations during regular application startup via `app.py` or a WSGI server.