### PR TITLE
Fix scheduler and audit log errors during Azure restore in init_setup.py

### DIFF
--- a/init_setup.py
+++ b/init_setup.py
@@ -417,9 +417,10 @@ def main(force_init=False):
 
     if restore_from_azure_flag or enable_auto_restore_env:
         print("Azure restoration requested via command line or environment variable.")
-        app_for_restore = create_app() # Create an app instance for context
+        # Create app instance for restore context WITHOUT starting the scheduler
+        app_for_restore = create_app(start_scheduler=False)
         with app_for_restore.app_context():
-            app_for_restore.logger.info("Attempting to restore from Azure Backup...")
+            app_for_restore.logger.info("Attempting to restore from Azure Backup (scheduler will not be started for this app instance)...")
             try:
                 restore_result = perform_startup_restore_sequence(app_for_restore)
                 app_for_restore.logger.info(f"Azure restore sequence completed with status: {restore_result.get('status')}, message: {restore_result.get('message')}")


### PR DESCRIPTION
Addresses issues identified from runtime logs when performing Azure restore:
1.  **Scheduler Interference:** Modified `app_factory.create_app` to accept a `start_scheduler` parameter (defaulting to True). `init_setup.py` now calls `create_app(start_scheduler=False)` for its restore context. This prevents the APScheduler from starting and running jobs during the critical database replacement and migration phase, resolving errors like 'no such table: booking_settings' from concurrent job execution.
2.  **Audit Log Timing:** In `azure_backup.py` (`perform_startup_restore_sequence`), the `add_audit_log` call for the system restore event has been moved to *after* the `flask_db_upgrade()` call. This ensures that database migrations have completed and all tables (including `audit_log`) are present before attempting to write to them, resolving the 'no such table: audit_log' error.

These changes ensure a more robust and stable restoration process when using `init_setup.py --restore-from-azure`.