### PR TITLE
Fix: Set Content-Type for DELETE requests in apiCall

### DIFF
--- a/static/js/script.js
+++ b/static/js/script.js
@@ -88,7 +88,12 @@ async function apiCall(url, options = {}, messageElement = null) {
         let csrfToken = csrfTokenTag ? csrfTokenTag.content : null;
         if (csrfToken) {
             if (!options.headers) options.headers = {};
-            if (!(options.body instanceof FormData) && !options.headers['Content-Type'] && (method === 'POST' || method === 'PUT' || method === 'PATCH') && options.body) {
+            // Ensure Content-Type is set to application/json for POST, PUT, PATCH, and DELETE requests
+            // if a body is present and it's not FormData.
+            if (!(options.body instanceof FormData) &&
+                !options.headers['Content-Type'] &&
+                (method === 'POST' || method === 'PUT' || method === 'PATCH' || method === 'DELETE') &&
+                options.body) {
                 options.headers['Content-Type'] = 'application/json';
             }
             options.headers['X-CSRFToken'] = csrfToken;


### PR DESCRIPTION
The apiCall helper was not setting the 'Content-Type: application/json' header for DELETE requests, even when a JSON body was present. This caused a 415 Unsupported Media Type error for endpoints like the bulk user delete, which expects a JSON payload.

This commit updates the condition in apiCall to include 'DELETE' when determining whether to set the JSON Content-Type header.