### PR TITLE
Fix: Resolve NameErrors in startup restore configuration application

### DIFF
--- a/azure_backup.py
+++ b/azure_backup.py
@@ -20,8 +20,9 @@ from utils import (
     _import_resource_configurations_data,
     _import_user_configurations_data,
     add_audit_log,
-    _get_general_configurations_data, # Added for general configs backup
-    _import_general_configurations_data # Added for general configs restore
+    _get_general_configurations_data,
+    _import_general_configurations_data,
+    save_unified_backup_schedule_settings # Added for unified schedule restore
 )
 from extensions import db # Ensure db is imported from extensions (already imported via models)
 from utils import update_task_log # Ensure this is imported from utils
@@ -1750,8 +1751,9 @@ def perform_startup_restore_sequence(app_for_context):
                     with open(local_unified_sched_path, 'r', encoding='utf-8') as f_us:
                         unified_sched_data = json.load(f_us)
 
-                    save_success, save_message = utils.save_unified_backup_schedule_settings(unified_sched_data)
-                    app_logger.info(f"STARTUP_RESTORE_LOG: utils.save_unified_backup_schedule_settings result - Success: {save_success}, Message: {save_message}")
+                    # Corrected: Call the directly imported function
+                    save_success, save_message = save_unified_backup_schedule_settings(unified_sched_data)
+                    app_logger.info(f"STARTUP_RESTORE_LOG: save_unified_backup_schedule_settings result - Success: {save_success}, Message: {save_message}")
 
                     if save_success:
                         app_logger.info(f"STARTUP_RESTORE_LOG: Unified Booking Backup Schedule settings applied: {save_message}")

--- a/utils.py
+++ b/utils.py
@@ -1466,7 +1466,7 @@ def _import_user_configurations_data(user_config_data: dict): # Return type will
                                 warnings.append(f"For User '{username}' (Backup ID {backup_user_id}), mapped Role ID {actual_db_role_id} (from backup Role ID {b_role_id}) not found in DB. Skipping assignment.")
                         elif b_role_id is not None: # Only warn if it was a non-null ID that couldn't be mapped
                             warnings.append(f"For User '{username}' (Backup ID {backup_user_id}), backup Role ID {b_role_id} could not be mapped to a current Role ID. Skipping assignment.")
-                user.roles = actual_db_roles
+                user.roles = actual_db_roles_for_user # Corrected variable name
 
                 db.session.add(user)
                 users_updated += 1


### PR DESCRIPTION
1. Corrected a NameError in `utils._import_user_configurations_data` by changing `actual_db_roles` to the correctly defined `actual_db_roles_for_user`.
2. Corrected a NameError in `azure_backup.perform_startup_restore_sequence` by ensuring `save_unified_backup_schedule_settings` is imported from utils and called directly, instead of via `utils.save_unified_backup_schedule_settings`.

These changes address errors observed during the application of user configurations and unified backup schedules within the startup restore sequence.