### PR TITLE
feat: Add Gmail authorization button to system settings

### DIFF
--- a/templates/admin/system_settings.html
+++ b/templates/admin/system_settings.html
@@ -65,6 +65,19 @@
 
     <!-- Other system settings can be added here in future -->
 
+    <div class="card mt-3">
+        <div class="card-header">
+            {{ _('Gmail Sending Authorization') }}
+        </div>
+        <div class="card-body">
+            <p>{{ _('To allow the system to send emails via Gmail (e.g., for booking confirmations, notifications), you need to authorize it with a Google account.') }}</p>
+            <a href="{{ url_for('gmail_auth.authorize_gmail_sending') }}" class="btn btn-primary">{{ _('Authorize Gmail Sending') }}</a>
+            <small class="form-text text-muted mt-2">
+                {{ _('This will redirect you to Google to grant permission. After authorization, you will be provided with a Refresh Token. This token must be securely stored and configured as the GMAIL_REFRESH_TOKEN environment variable for the application.') }}
+            </small>
+        </div>
+    </div>
+
 </div>
 {% endblock %} {# End of content block #}
 


### PR DESCRIPTION
Adds a new section to the admin system settings page to allow administrators to initiate the Google OAuth flow for authorizing the application to send emails via Gmail.

- Modified `templates/admin/system_settings.html` to include the new UI elements.
- Verified that `routes/gmail_auth.py` correctly handles the authorization initiation and callback.