### PR TITLE
fix: Relocate Gmail auth status and attempt Socket.IO fix

### DIFF
--- a/templates/admin/backup_settings.html
+++ b/templates/admin/backup_settings.html
@@ -101,6 +101,30 @@
         </div>
     </div>
 
+    <!-- Gmail Sending Authorization Card -->
+    <div class="card mb-4">
+        <div class="card-header">
+            <h2 class="card-title h5">{{ _('Gmail Sending Authorization') }}</h2>
+        </div>
+        <div class="card-body">
+            {% if is_gmail_configured %}
+                <p class="text-success">{{ _('Status: Gmail Sending is <strong>Configured</strong>.') }}</p>
+                {% if gmail_sender_address %}
+                    <p>{{ _('Authorized Sender Address: %(email)s', email=gmail_sender_address) }}</p>
+                {% endif %}
+                <p>{{ _('You can re-authorize if you need to change the account or refresh permissions.') }}</p>
+                <a href="{{ url_for('gmail_auth.authorize_gmail_sending') }}" class="btn btn-secondary">{{ _('Re-authorize Gmail Sending') }}</a>
+            {% else %}
+                <p class="text-warning">{{ _('Status: Gmail Sending is <strong>Not Configured</strong>.') }}</p>
+                <p>{{ _('To allow the system to send emails via Gmail (e.g., for booking confirmations, notifications), you need to authorize it with a Google account.') }}</p>
+                <a href="{{ url_for('gmail_auth.authorize_gmail_sending') }}" class="btn btn-primary">{{ _('Authorize Gmail Sending') }}</a>
+            {% endif %}
+            <small class="form-text text-muted mt-2">
+                {{ _('This will redirect you to Google to grant permission. After authorization, you will be provided with a Refresh Token. This token must be securely stored and configured as the GMAIL_REFRESH_TOKEN environment variable for the application, along with GMAIL_SENDER_ADDRESS.') }}
+            </small>
+        </div>
+    </div>
+
     <!-- Global Log Areas -->
     <div class="mt-4">
         <h5>{{ _('Operation Logs') }}</h5>

--- a/templates/admin/system_settings.html
+++ b/templates/admin/system_settings.html
@@ -65,29 +65,6 @@
 
     <!-- Other system settings can be added here in future -->
 
-    <div class="card mt-3">
-        <div class="card-header">
-            {{ _('Gmail Sending Authorization') }}
-        </div>
-        <div class="card-body">
-            {% if is_gmail_configured %}
-                <p class="text-success">{{ _('Status: Gmail Sending is <strong>Configured</strong>.') }}</p>
-                {% if gmail_sender_address %}
-                    <p>{{ _('Authorized Sender Address: %(email)s', email=gmail_sender_address) }}</p>
-                {% endif %}
-                <p>{{ _('You can re-authorize if you need to change the account or refresh permissions.') }}</p>
-                <a href="{{ url_for('gmail_auth.authorize_gmail_sending') }}" class="btn btn-secondary">{{ _('Re-authorize Gmail Sending') }}</a>
-            {% else %}
-                <p class="text-warning">{{ _('Status: Gmail Sending is <strong>Not Configured</strong>.') }}</p>
-                <p>{{ _('To allow the system to send emails via Gmail (e.g., for booking confirmations, notifications), you need to authorize it with a Google account.') }}</p>
-                <a href="{{ url_for('gmail_auth.authorize_gmail_sending') }}" class="btn btn-primary">{{ _('Authorize Gmail Sending') }}</a>
-            {% endif %}
-            <small class="form-text text-muted mt-2">
-                {{ _('This will redirect you to Google to grant permission. After authorization, you will be provided with a Refresh Token. This token must be securely stored and configured as the GMAIL_REFRESH_TOKEN environment variable for the application, along with GMAIL_SENDER_ADDRESS.') }}
-            </small>
-        </div>
-    </div>
-
 </div>
 {% endblock %} {# End of content block #}
 


### PR DESCRIPTION
- Relocated Gmail authorization status display from /admin/system-settings to /admin/backup/settings as per user request.
  - Updated routes/admin_ui.py: moved logic from system_settings_page to serve_backup_settings_page.
  - Updated templates/admin/system_settings.html: removed Gmail card.
  - Updated templates/admin/backup_settings.html: added Gmail card.
- Continued attempt to fix Socket.IO 400 error:
  - Ensured app_factory.py correctly passes SOCKETIO_MESSAGE_QUEUE to socketio.init_app().
  - Ensured Socket.IO client script is uncommented in base.html.