### PR TITLE
refactor: Remove Socket.IO components and correct Gmail status display

### DIFF
--- a/routes/admin_api_bookings - Copy.py
+++ b/routes/admin_api_bookings - Copy.py
@@ -2,8 +2,8 @@ from flask import Blueprint, jsonify, request, current_app
 from flask_login import login_required, current_user
 from datetime import timezone # Added timezone
 
-# Assuming extensions.py contains db, socketio, mail
-from extensions import db, socketio, mail
+# Assuming extensions.py contains db, mail # socketio removed
+from extensions import db, mail # socketio removed
 # Assuming models.py contains these model definitions
 from models import Booking, User, Resource # Added Resource
 # Assuming utils.py contains these helper functions
@@ -49,7 +49,7 @@ def approve_booking_admin(booking_id):
     send_slack_notification(f"Booking {booking.id} approved by {current_user.username}")
     current_app.logger.info(f"Booking {booking.id} approved by admin {current_user.username}.")
     add_audit_log(action="APPROVE_BOOKING_ADMIN", details=f"Admin {current_user.username} approved booking ID {booking.id}.")
-    socketio.emit('booking_updated', {'action': 'approved', 'booking_id': booking.id, 'status': 'approved', 'resource_id': booking.resource_id})
+    # socketio.emit('booking_updated', {'action': 'approved', 'booking_id': booking.id, 'status': 'approved', 'resource_id': booking.resource_id}) # Removed
     return jsonify({'success': True}), 200
 
 
@@ -69,7 +69,7 @@ def reject_booking_admin(booking_id):
     send_slack_notification(f"Booking {booking.id} rejected by {current_user.username}")
     current_app.logger.info(f"Booking {booking.id} rejected by admin {current_user.username}.")
     add_audit_log(action="REJECT_BOOKING_ADMIN", details=f"Admin {current_user.username} rejected booking ID {booking.id}.")
-    socketio.emit('booking_updated', {'action': 'rejected', 'booking_id': booking.id, 'status': 'rejected', 'resource_id': booking.resource_id})
+    # socketio.emit('booking_updated', {'action': 'rejected', 'booking_id': booking.id, 'status': 'rejected', 'resource_id': booking.resource_id}) # Removed
     return jsonify({'success': True}), 200
 
 
@@ -103,11 +103,11 @@ def admin_delete_booking(booking_id):
         )
         add_audit_log(action="ADMIN_DELETE_BOOKING", details=audit_details)
 
-        socketio.emit('booking_updated', {
-            'action': 'deleted_by_admin',
-            'booking_id': booking_id,
-            'resource_id': resource_id_of_booking
-        })
+        # socketio.emit('booking_updated', { # Removed
+        #     'action': 'deleted_by_admin', # Removed
+        #     'booking_id': booking_id, # Removed
+        #     'resource_id': resource_id_of_booking # Removed
+        # }) # Removed
 
         current_app.logger.info(f"Admin user {current_user.username} successfully DELETED booking ID: {booking_id}.")
         return jsonify({'message': 'Booking deleted successfully by admin.', 'booking_id': booking_id}), 200
@@ -165,15 +165,15 @@ def admin_cancel_booking(booking_id):
         )
         add_audit_log(action="ADMIN_CANCEL_BOOKING", details=audit_details)
 
-        # SocketIO event
-        socketio.emit('booking_updated', {
-            'action': 'cancelled_by_admin',
-            'booking_id': booking.id,
-            'resource_id': booking.resource_id,
-            'new_status': booking.status,
-            'admin_message': booking.admin_deleted_message, # This will be None if no reason was provided
-            'user_name': booking.user_name
-        })
+        # SocketIO event # Removed
+        # socketio.emit('booking_updated', { # Removed
+        #     'action': 'cancelled_by_admin', # Removed
+        #     'booking_id': booking.id, # Removed
+        #     'resource_id': booking.resource_id, # Removed
+        #     'new_status': booking.status, # Removed
+        #     'admin_message': booking.admin_deleted_message, # This will be None if no reason was provided # Removed
+        #     'user_name': booking.user_name # Removed
+        # }) # Removed
 
         # Notify user
         user = User.query.filter_by(username=booking.user_name).first()
@@ -243,13 +243,13 @@ def admin_clear_booking_message(booking_id):
             f"Admin '{current_user.username}' cleared message for booking ID {booking.id}. Status set to 'cancelled_admin_acknowledged'."
         )
 
-        socketio.emit('booking_updated', {
-            'action': 'admin_message_cleared_by_admin',
-            'booking_id': booking.id,
-            'resource_id': booking.resource_id,
-            'new_status': booking.status,
-            'admin_deleted_message': None
-        })
+        # socketio.emit('booking_updated', { # Removed
+        #     'action': 'admin_message_cleared_by_admin', # Removed
+        #     'booking_id': booking.id, # Removed
+        #     'resource_id': booking.resource_id, # Removed
+        #     'new_status': booking.status, # Removed
+        #     'admin_deleted_message': None # Removed
+        # }) # Removed
 
         return jsonify({
             'message': 'Admin message cleared and booking acknowledged.',

--- a/routes/admin_api_bookings.py
+++ b/routes/admin_api_bookings.py
@@ -2,8 +2,8 @@ from flask import Blueprint, jsonify, request, current_app, render_template, url
 from flask_login import login_required, current_user
 from datetime import timezone, timedelta # Added timezone and timedelta
 
-# Assuming extensions.py contains db, socketio, mail
-from extensions import db, socketio # Removed mail
+# Assuming extensions.py contains db # socketio and mail removed
+from extensions import db # socketio and mail removed
 # Assuming models.py contains these model definitions
 from models import Booking, User, Resource, BookingSettings # Added Resource and BookingSettings
 # Assuming utils.py contains these helper functions
@@ -57,7 +57,7 @@ def approve_booking_admin(booking_id):
     send_slack_notification(f"Booking {booking.id} approved by {current_user.username}")
     current_app.logger.info(f"Booking {booking.id} approved by admin {current_user.username}.")
     add_audit_log(action="APPROVE_BOOKING_ADMIN", details=f"Admin {current_user.username} approved booking ID {booking.id}.")
-    socketio.emit('booking_updated', {'action': 'approved', 'booking_id': booking.id, 'status': 'approved', 'resource_id': booking.resource_id})
+    # socketio.emit('booking_updated', {'action': 'approved', 'booking_id': booking.id, 'status': 'approved', 'resource_id': booking.resource_id}) # Removed
     return jsonify({'success': True}), 200
 
 
@@ -77,7 +77,7 @@ def reject_booking_admin(booking_id):
     send_slack_notification(f"Booking {booking.id} rejected by {current_user.username}")
     current_app.logger.info(f"Booking {booking.id} rejected by admin {current_user.username}.")
     add_audit_log(action="REJECT_BOOKING_ADMIN", details=f"Admin {current_user.username} rejected booking ID {booking.id}.")
-    socketio.emit('booking_updated', {'action': 'rejected', 'booking_id': booking.id, 'status': 'rejected', 'resource_id': booking.resource_id})
+    # socketio.emit('booking_updated', {'action': 'rejected', 'booking_id': booking.id, 'status': 'rejected', 'resource_id': booking.resource_id}) # Removed
     return jsonify({'success': True}), 200
 
 
@@ -111,11 +111,11 @@ def admin_delete_booking(booking_id):
         )
         add_audit_log(action="ADMIN_DELETE_BOOKING", details=audit_details)
 
-        socketio.emit('booking_updated', {
-            'action': 'deleted_by_admin',
-            'booking_id': booking_id,
-            'resource_id': resource_id_of_booking
-        })
+        # socketio.emit('booking_updated', { # Removed
+        #     'action': 'deleted_by_admin', # Removed
+        #     'booking_id': booking_id, # Removed
+        #     'resource_id': resource_id_of_booking # Removed
+        # }) # Removed
 
         current_app.logger.info(f"Admin user {current_user.username} successfully DELETED booking ID: {booking_id}.")
         return jsonify({'message': 'Booking deleted successfully by admin.', 'booking_id': booking_id}), 200
@@ -173,15 +173,15 @@ def admin_cancel_booking(booking_id):
         )
         add_audit_log(action="ADMIN_CANCEL_BOOKING", details=audit_details)
 
-        # SocketIO event
-        socketio.emit('booking_updated', {
-            'action': 'cancelled_by_admin',
-            'booking_id': booking.id,
-            'resource_id': booking.resource_id,
-            'new_status': booking.status,
-            'admin_message': booking.admin_deleted_message, # This will be None if no reason was provided
-            'user_name': booking.user_name
-        })
+        # SocketIO event # Removed
+        # socketio.emit('booking_updated', { # Removed
+        #     'action': 'cancelled_by_admin', # Removed
+        #     'booking_id': booking.id, # Removed
+        #     'resource_id': booking.resource_id, # Removed
+        #     'new_status': booking.status, # Removed
+        #     'admin_message': booking.admin_deleted_message, # This will be None if no reason was provided # Removed
+        #     'user_name': booking.user_name # Removed
+        # }) # Removed
 
         # Notify user
         user = User.query.filter_by(username=booking.user_name).first()
@@ -251,13 +251,13 @@ def admin_clear_booking_message(booking_id):
             f"Admin '{current_user.username}' cleared message for booking ID {booking.id}. Status set to 'cancelled_admin_acknowledged'."
         )
 
-        socketio.emit('booking_updated', {
-            'action': 'admin_message_cleared_by_admin',
-            'booking_id': booking.id,
-            'resource_id': booking.resource_id,
-            'new_status': booking.status,
-            'admin_deleted_message': None
-        })
+        # socketio.emit('booking_updated', { # Removed
+        #     'action': 'admin_message_cleared_by_admin', # Removed
+        #     'booking_id': booking.id, # Removed
+        #     'resource_id': booking.resource_id, # Removed
+        #     'new_status': booking.status, # Removed
+        #     'admin_deleted_message': None # Removed
+        # }) # Removed
 
         return jsonify({
             'message': 'Admin message cleared and booking acknowledged.',
@@ -437,13 +437,13 @@ def update_booking_status(booking_id):
             action="UPDATE_BOOKING_STATUS",
             details=f"Admin {current_user.username} updated booking ID {booking.id} status from '{current_status}' to '{new_status}'."
         )
-        socketio.emit('booking_updated', {
-            'action': 'status_updated',
-            'booking_id': booking.id,
-            'new_status': new_status,
-            'resource_id': booking.resource_id,
-            'user_name': booking.user_name # Good to include for client-side updates
-        })
+        # socketio.emit('booking_updated', { # Removed
+        #     'action': 'status_updated', # Removed
+        #     'booking_id': booking.id, # Removed
+        #     'new_status': new_status, # Removed
+        #     'resource_id': booking.resource_id, # Removed
+        #     'user_name': booking.user_name # Good to include for client-side updates # Removed
+        # }) # Removed
         current_app.logger.info(f"Booking {booking.id} status updated from '{current_status}' to '{new_status}' by admin {current_user.username}.")
         return jsonify({'success': True, 'message': 'Booking status updated.', 'new_status': booking.status}), 200
     except Exception as e:

--- a/routes/admin_ui.py
+++ b/routes/admin_ui.py
@@ -9,7 +9,7 @@ import uuid # For task_id generation
 # Assuming Booking, Resource, User models are in models.py
 from models import Booking, Resource, User, FloorMap, BookingSettings # Added FloorMap
 # Assuming db is in extensions.py
-from extensions import db, socketio # Try to import socketio
+from extensions import db # socketio removed
 # Assuming permission_required is in auth.py
 from auth import permission_required # Corrected: auth.py is at root
 from datetime import datetime, timedelta, timezone # Add datetime imports

--- a/routes/api_bookings.py
+++ b/routes/api_bookings.py
@@ -9,8 +9,8 @@ import secrets
 from datetime import datetime, timedelta, timezone, time
 
 # Local imports
-# Assuming extensions.py contains db, socketio, mail
-from extensions import db, socketio # Removed mail
+# Assuming extensions.py contains db # socketio and mail removed
+from extensions import db # socketio and mail removed
 # Assuming models.py contains these model definitions
 from models import Booking, Resource, User, WaitlistEntry, BookingSettings, ResourcePIN, FloorMap # Added ResourcePIN & FloorMap
 # Assuming utils.py contains these helper functions
@@ -610,7 +610,7 @@ def create_booking():
             action_taken = "REUSED_BOOKING" if audit_booking.last_modified > audit_booking.start_time else "CREATE_BOOKING" # Heuristic for reused
             # More robust: check if it was in exact_match_booking and status changed
             add_audit_log(action=action_taken, details=f"Booking ID {audit_booking.id} for resource ID {audit_booking.resource_id} ('{resource_name_for_audit}') processed for user '{audit_booking.user_name}'. Title: '{audit_booking.title}'. Token updated/generated.")
-            socketio.emit('booking_updated', {'action': 'created', 'booking_id': audit_booking.id, 'resource_id': audit_booking.resource_id}) # Client might need to handle 'reused' differently
+            # socketio.emit('booking_updated', {'action': 'created', 'booking_id': audit_booking.id, 'resource_id': audit_booking.resource_id}) # Removed
 
         created_data = [{
             'id': b.id, 'resource_id': b.resource_id, 'title': b.title, 'user_name': b.user_name,
@@ -1585,8 +1585,8 @@ def delete_booking_by_user(booking_id):
             action="CANCEL_BOOKING_USER",
             details=f"User '{current_user.username}' cancelled their booking. {booking_details_for_log}"
         )
-        # Assuming socketio is imported
-        socketio.emit('booking_updated', {'action': 'deleted', 'booking_id': booking_id, 'resource_id': original_resource_id}) # Use original_resource_id
+        # Assuming socketio is imported # Removed
+        # socketio.emit('booking_updated', {'action': 'deleted', 'booking_id': booking_id, 'resource_id': original_resource_id}) # Removed
         current_app.logger.info(f"User '{current_user.username}' successfully deleted booking ID: {booking_id}. Details: {booking_details_for_log}")
         return jsonify({'message': 'Booking cancelled successfully.'}), 200
 
@@ -1711,7 +1711,7 @@ def check_in_booking(booking_id):
             audit_details += f" Using PIN."
         add_audit_log(action="CHECK_IN_SUCCESS", details=audit_details)
 
-        socketio.emit('booking_updated', {'action': 'checked_in', 'booking_id': booking.id, 'checked_in_at': effective_now_aware.isoformat(), 'resource_id': booking.resource_id})
+        # socketio.emit('booking_updated', {'action': 'checked_in', 'booking_id': booking.id, 'checked_in_at': effective_now_aware.isoformat(), 'resource_id': booking.resource_id}) # Removed
         current_app.logger.info(f"User '{current_user.username}' successfully checked into booking ID: {booking_id} at {effective_now_aware.isoformat()}{' using PIN' if provided_pin else ''}.")
 
         # Send Email Notification for Check-in
@@ -1848,7 +1848,7 @@ def check_out_booking(booking_id):
 
         resource_name = booking.resource_booked.name if booking.resource_booked else "Unknown Resource"
         add_audit_log(action="CHECK_OUT_SUCCESS", details=f"User '{current_user.username}' checked out of booking ID {booking.id} for resource '{resource_name}'. Status set to completed.")
-        socketio.emit('booking_updated', {'action': 'checked_out', 'booking_id': booking.id, 'checked_out_at': effective_now_aware.isoformat(), 'resource_id': booking.resource_id, 'status': 'completed'})
+        # socketio.emit('booking_updated', {'action': 'checked_out', 'booking_id': booking.id, 'checked_out_at': effective_now_aware.isoformat(), 'resource_id': booking.resource_id, 'status': 'completed'}) # Removed
         current_app.logger.info(f"User '{current_user.username}' successfully checked out of booking ID: {booking_id} at {effective_now_aware.isoformat()}. Status set to completed.")
 
         # Send Email Notification for Check-out
@@ -2018,13 +2018,13 @@ def qr_check_in(token):
             details=f"Booking ID {booking.id} for resource '{resource_name}' (User: {booking.user_name}) checked in via QR code."
         )
 
-        if hasattr(socketio, 'emit'): # Check if socketio is available and configured
-            socketio.emit('booking_updated', {
-                'action': 'checked_in',
-                'booking_id': booking.id,
-                'checked_in_at': effective_now_aware.isoformat(),
-                'resource_id': booking.resource_id
-            })
+        # if hasattr(socketio, 'emit'): # Removed
+            # socketio.emit('booking_updated', { # Removed
+            #     'action': 'checked_in', # Removed
+            #     'booking_id': booking.id, # Removed
+            #     'checked_in_at': effective_now_aware.isoformat(), # Removed
+            #     'resource_id': booking.resource_id # Removed
+            # }) # Removed
         current_app.logger.info(f"Booking {booking.id} successfully checked in via QR token {token} by user {booking.user_name}")
 
         return jsonify({

--- a/routes/api_system.py
+++ b/routes/api_system.py
@@ -11,7 +11,7 @@ from sqlalchemy import func # For count query
 
 # Relative imports from project structure
 from auth import permission_required
-from extensions import db, socketio # socketio might be None if not available
+from extensions import db # socketio removed
 from models import AuditLog, User, Resource, FloorMap, Booking, Role, BookingSettings # Added BookingSettings
 from utils import (
     add_audit_log,

--- a/routes/ui.py
+++ b/routes/ui.py
@@ -14,8 +14,7 @@ from datetime import datetime, timezone, timedelta
 from models import db, Booking, Resource, User, BookingSettings # Added Resource, User, db, BookingSettings
 # Assuming add_audit_log is in utils.py
 from utils import add_audit_log
-# Assuming socketio is in extensions.py
-from extensions import socketio
+# Assuming socketio is in extensions.py # Removed: from extensions import socketio
 
 # The template_folder is specified relative to the blueprint's location.
 # If app.py sets a global template_folder, and this blueprint's templates
@@ -222,13 +221,13 @@ def check_in_at_resource(resource_id):
                     action="CHECK_IN_RESOURCE_SUCCESS",
                     details=f"User '{current_user.username}' checked into resource '{resource.name}' (ID: {resource.id}) for booking ID {active_booking.id}."
                 )
-                if hasattr(socketio, 'emit'):
-                     socketio.emit('booking_updated', {
-                        'action': 'checked_in',
-                        'booking_id': active_booking.id,
-                        'checked_in_at': now_utc.isoformat(),
-                        'resource_id': active_booking.resource_id
-                    })
+                # if hasattr(socketio, 'emit'): # Removed Socket.IO emit
+                #      socketio.emit('booking_updated', {
+                #         'action': 'checked_in',
+                #         'booking_id': active_booking.id,
+                #         'checked_in_at': now_utc.isoformat(),
+                #         'resource_id': active_booking.resource_id
+                #     })
                 flash(f"Successfully checked into '{resource.name}' for your booking: {active_booking.title}.", "success")
                 return render_template('check_in_status.html', success=True, resource_name=resource.name, booking_title=active_booking.title, start_time=active_booking.start_time)
             except Exception as e:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -9,7 +9,7 @@ from datetime import datetime as datetime_original, timedelta as timedelta_origi
 
 from flask import url_for, redirect, current_app as flask_current_app
 from app import app # app object
-from extensions import db, socketio
+from extensions import db # socketio removed
 from models import User, Resource, Booking, WaitlistEntry, FloorMap, AuditLog, BookingSettings, ResourcePIN, Role
 from utils import teams_log, slack_log, email_log
 from unittest.mock import patch, mock_open, MagicMock, ANY
@@ -223,9 +223,9 @@ class TestAutoCheckoutTask(AppTests):
     @patch.dict(app.config, {'SCHEDULER_ENABLED': True})
     @patch('scheduler_tasks.send_email')
     @patch('scheduler_tasks.add_audit_log')
-    @patch('scheduler_tasks.socketio.emit')
+    # @patch('scheduler_tasks.socketio.emit') # Removed
     @patch('scheduler_tasks.datetime')
-    def test_auto_checkout_success(self, mock_scheduler_datetime, mock_socketio_emit, mock_add_audit_log, mock_send_email):
+    def test_auto_checkout_success(self, mock_scheduler_datetime, mock_add_audit_log, mock_send_email): # mock_socketio_emit removed
         mocked_now = datetime_original(2024, 1, 1, 14, 0, 0, tzinfo=timezone_original.utc) # Use datetime_original
         mock_scheduler_datetime.now.return_value = mocked_now
         mock_scheduler_datetime.side_effect = lambda *args, **kwargs: datetime_original(*args, **kwargs) if args else mocked_now
@@ -257,7 +257,7 @@ class TestAutoCheckoutTask(AppTests):
         self.assertEqual(checked_out_booking.status, 'completed')
         mock_send_email.assert_called_once()
         mock_add_audit_log.assert_called_once()
-        mock_socketio_emit.assert_called_once()
+        # mock_socketio_emit.assert_called_once() # Removed
 
     @patch.dict(app.config, {'SCHEDULER_ENABLED': True})
     @patch('scheduler_tasks.send_email')
@@ -319,9 +319,9 @@ class TestAutoCheckoutTask(AppTests):
     @patch.dict(app.config, {'SCHEDULER_ENABLED': True})
     @patch('scheduler_tasks.send_email')
     @patch('scheduler_tasks.add_audit_log')
-    @patch('scheduler_tasks.socketio.emit')
+    # @patch('scheduler_tasks.socketio.emit') # Removed
     @patch('scheduler_tasks.datetime')
-    def test_auto_checkout_multiple_bookings(self, mock_scheduler_datetime, mock_socketio_emit, mock_add_audit_log, mock_send_email):
+    def test_auto_checkout_multiple_bookings(self, mock_scheduler_datetime, mock_add_audit_log, mock_send_email): # mock_socketio_emit removed
         mocked_now = datetime_original(2024, 1, 1, 14, 0, 0, tzinfo=timezone_original.utc) # Use datetime_original
         mock_scheduler_datetime.now.return_value = mocked_now
         mock_scheduler_datetime.side_effect = lambda *args, **kwargs: datetime_original(*args, **kwargs) if args else mocked_now
@@ -346,7 +346,7 @@ class TestAutoCheckoutTask(AppTests):
 
         mock_send_email.assert_called_once()
         mock_add_audit_log.assert_called_once()
-        mock_socketio_emit.assert_called_once()
+        # mock_socketio_emit.assert_called_once() # Removed
 
         processed_b_overdue = db.session.get(Booking, overdue_id)
         self.assertEqual(processed_b_overdue.status, 'completed', "Overdue booking status should be 'completed'")
@@ -360,9 +360,9 @@ class TestAutoCheckoutTask(AppTests):
     @patch('scheduler_tasks.User.query')
     @patch('scheduler_tasks.send_email')
     @patch('scheduler_tasks.add_audit_log')
-    @patch('scheduler_tasks.socketio.emit')
+    # @patch('scheduler_tasks.socketio.emit') # Removed
     @patch('scheduler_tasks.datetime')
-    def test_auto_checkout_no_user_email(self, mock_scheduler_datetime, mock_socketio_emit, mock_add_audit_log, mock_send_email, mock_user_query_in_task):
+    def test_auto_checkout_no_user_email(self, mock_scheduler_datetime, mock_add_audit_log, mock_send_email, mock_user_query_in_task): # mock_socketio_emit removed
         mocked_now = datetime_original(2024, 1, 1, 14, 0, 0, tzinfo=timezone_original.utc) # Use datetime_original
         mock_scheduler_datetime.now.return_value = mocked_now
         mock_scheduler_datetime.side_effect = lambda *args, **kwargs: datetime_original(*args, **kwargs) if args else mocked_now
@@ -399,7 +399,7 @@ class TestAutoCheckoutTask(AppTests):
         self.assertEqual(processed_booking.status, 'completed', "Booking status should be 'completed' even if user has no email")
         self.assertIsNotNone(processed_booking.checked_out_at, "checked_out_at should be set even if user has no email")
         mock_add_audit_log.assert_called_once()
-        mock_socketio_emit.assert_called_once()
+        # mock_socketio_emit.assert_called_once() # Removed
 
 
 class TestPastBookingLogic(AppTests):


### PR DESCRIPTION
- Removed Socket.IO client-side initialization from script.js.
- Ensured Socket.IO client script is commented out in base.html.
- Removed Flask-SocketIO, python-engineio, python-socketio, and eventlet from requirements.txt.
- Removed Socket.IO server-side setup from extensions.py, app_factory.py, and app.py.
- Updated Procfile to use gthread worker instead of eventlet.
- Corrected ImportErrors by removing socketio usage from various route files (ui.py, admin_api_bookings.py, admin_ui.py, api_bookings.py, api_system.py) and tests (test_app.py).
- Ensured Gmail authorization status display is correctly located on the /admin/backup/settings page and fixed a TypeError in its template rendering.
- Confirmed utils.py and scheduler_tasks.py did not require changes for socketio removal from extensions.