### PR TITLE
Fix TypeError in image drawing by converting image to RGBA

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -475,6 +475,12 @@ def generate_booking_image(resource_id: int, map_coordinates_str: str, resource_
         ref_width = 800
         ref_height = 600
 
+        # Convert image to RGBA if not already, to support transparent fill for the rectangle
+        if img.mode != 'RGBA':
+            img = img.convert('RGBA')
+            logger.info("Converted image to RGBA mode for drawing.")
+        draw = ImageDraw.Draw(img) # Recreate draw object if image was converted
+
         # Get actual image dimensions
         actual_width, actual_height = img.size
 


### PR DESCRIPTION
- Modified `utils.generate_booking_image` to convert the floor map image to 'RGBA' mode before drawing the highlighted rectangle area.
- This resolves a `TypeError: color must be int or single-element tuple` that occurred when trying to use an RGBA fill color on an image not in RGBA mode (e.g., an RGB JPEG).
- Ensures the `ImageDraw.Draw` object is recreated if the image mode changes.