### PR TITLE
Fix: Correct booking slot availability and datepicker window

### DIFF
--- a/config.py
+++ b/config.py
@@ -173,7 +173,7 @@ DEFAULT_ADMIN_PASSWORD = os.environ.get('DEFAULT_ADMIN_PASSWORD', 'ChangeMe123!'
 APP_NAME = "Meeting Room Booking System"
 MAX_BOOKING_DURATION_HOURS = int(os.environ.get('MAX_BOOKING_DURATION_HOURS', 8))
 MIN_BOOKING_DURATION_MINUTES = int(os.environ.get('MIN_BOOKING_DURATION_MINUTES', 15))
-BOOKING_LEAD_TIME_DAYS = int(os.environ.get('BOOKING_LEAD_TIME_DAYS', 90)) # How far in advance users can book
+BOOKING_LEAD_TIME_DAYS = int(os.environ.get('BOOKING_LEAD_TIME_DAYS', 14)) # How far in advance users can book
 DEFAULT_ITEMS_PER_PAGE = int(os.environ.get('DEFAULT_ITEMS_PER_PAGE', 10)) # For pagination
 
 # --- Map View Settings ---

--- a/models.py
+++ b/models.py
@@ -88,7 +88,7 @@ class FloorMap(db.Model):
 class BookingSettings(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     allow_past_bookings = db.Column(db.Boolean, default=False)
-    max_booking_days_in_future = db.Column(db.Integer, nullable=True, default=None)
+    max_booking_days_in_future = db.Column(db.Integer, nullable=True, default=14)
     allow_multiple_resources_same_time = db.Column(db.Boolean, default=False)
     max_bookings_per_user = db.Column(db.Integer, nullable=True, default=None)
     enable_check_in_out = db.Column(db.Boolean, default=False)

--- a/routes/api_bookings.py
+++ b/routes/api_bookings.py
@@ -267,7 +267,7 @@ def create_booking():
     # Define lists of active statuses (lowercase)
     # These statuses are considered "active" for conflict checks or quota counting.
     active_conflict_statuses = ['approved', 'pending', 'checked_in', 'confirmed']
-    released_statuses = ['cancelled', 'system_cancelled_no_checkin', 'cancelled_by_admin', 'rejected', 'cancelled_admin_acknowledged']
+    released_statuses = ['cancelled', 'system_cancelled_no_checkin', 'cancelled_by_admin', 'rejected', 'cancelled_admin_acknowledged', 'completed']
     active_quota_statuses = ['approved', 'pending', 'checked_in', 'confirmed']
 
     data = request.get_json()
@@ -306,7 +306,14 @@ def create_booking():
     # Define effective settings, using defaults if booking_settings is None or specific values are not set
     allow_past_bookings_effective = booking_settings.allow_past_bookings if booking_settings else False
     effective_past_booking_hours = booking_settings.past_booking_time_adjustment_hours if booking_settings and booking_settings.past_booking_time_adjustment_hours is not None else 0
-    max_booking_days_in_future_effective = booking_settings.max_booking_days_in_future if booking_settings and booking_settings.max_booking_days_in_future is not None else None
+
+    max_booking_days_in_future_from_db = booking_settings.max_booking_days_in_future if booking_settings and hasattr(booking_settings, 'max_booking_days_in_future') else None
+    if max_booking_days_in_future_from_db is not None:
+        max_booking_days_in_future_effective = max_booking_days_in_future_from_db
+    else:
+        # Fallback to config's BOOKING_LEAD_TIME_DAYS, with a hardcoded default of 14 if not found in config
+        max_booking_days_in_future_effective = current_app.config.get('BOOKING_LEAD_TIME_DAYS', 14)
+
     allow_multiple_resources_same_time_effective = booking_settings.allow_multiple_resources_same_time if booking_settings else False
     max_bookings_per_user_effective = booking_settings.max_bookings_per_user if booking_settings and booking_settings.max_bookings_per_user is not None else None
     # enable_check_in_out_effective = booking_settings.enable_check_in_out if booking_settings else False # Not used in this function directly

--- a/static/js/new_booking_map.js
+++ b/static/js/new_booking_map.js
@@ -127,6 +127,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 inline: true,
                 static: true,
                 dateFormat: "Y-m-d",
+                maxDate: new Date().fp_incr(13), // Add this line: 13 days from today for a 14-day window
                 disable: [
                     function(date) {
                         const dateStr = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;


### PR DESCRIPTION
- Ensures timeslots become available after a booking is 'completed' by adding 'completed' to released_statuses.
- Corrects the datepicker booking window to 14 days:
  - Sets BookingSettings.max_booking_days_in_future default to 14.
  - Sets config.BOOKING_LEAD_TIME_DAYS default to 14.
  - Updates server-side logic to reliably use these settings.
  - Configures Flatpickr maxDate to limit selection to 14 days (today + 13).