### PR TITLE
Add maintenance schedule feature

### DIFF
--- a/app_factory.py
+++ b/app_factory.py
@@ -24,6 +24,7 @@ from routes.api_roles import init_api_roles_routes
 from routes.api_waitlist import init_api_waitlist_routes
 from routes.api_system import init_api_system_routes
 from routes.admin_api_bookings import init_admin_api_bookings_routes # New import
+from routes.admin_api_maintenance import admin_api_maintenance_bp
 from routes.admin_api_system_settings import init_admin_api_system_settings_routes # New import
 from routes.gmail_auth import init_gmail_auth_routes # Added for Gmail OAuth flow
 
@@ -289,6 +290,7 @@ def create_app(config_object=config, testing=False, start_scheduler=True): # Add
     init_api_waitlist_routes(app)
     init_api_system_routes(app)
     init_admin_api_bookings_routes(app) # Register new blueprint
+    app.register_blueprint(admin_api_maintenance_bp)
     init_admin_api_system_settings_routes(app) # Register new blueprint
     init_gmail_auth_routes(app) # Added for Gmail OAuth flow
 

--- a/init_setup.py
+++ b/init_setup.py
@@ -323,7 +323,7 @@ def init_db(force=False):
 
         current_app.logger.info("Creating default roles and users...")
         try:
-            admin_role = Role(name="Administrator", description="Full system access", permissions="all_permissions,view_analytics,manage_bookings,manage_system,manage_users,manage_resources,manage_floor_maps")
+            admin_role = Role(name="Administrator", description="Full system access", permissions="all_permissions,view_analytics,manage_bookings,manage_system,manage_users,manage_resources,manage_floor_maps,manage_maintenance")
             standard_role = Role(name="StandardUser", description="Can make bookings and view resources", permissions="make_bookings,view_resources")
             db.session.add_all([admin_role, standard_role])
             db.session.commit() # Commit roles to get IDs

--- a/models.py
+++ b/models.py
@@ -263,3 +263,22 @@ class AuditLog(db.Model):
 
     def __repr__(self):
         return f'<AuditLog {self.timestamp} - {self.username or "System"} - {self.action}>'
+
+class MaintenanceSchedule(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(100), nullable=False)
+    schedule_type = db.Column(db.String(50), nullable=False)  # 'recurring_day', 'specific_day', 'date_range'
+    day_of_week = db.Column(db.Integer, nullable=True)  # 0-6 for Monday-Sunday
+    day_of_month = db.Column(db.Integer, nullable=True)  # 1-31
+    start_date = db.Column(db.Date, nullable=True)
+    end_date = db.Column(db.Date, nullable=True)
+    start_time = db.Column(db.Time, nullable=False)
+    end_time = db.Column(db.Time, nullable=False)
+    is_availability = db.Column(db.Boolean, default=False, nullable=False)
+    resource_selection_type = db.Column(db.String(50), nullable=False)  # 'all', 'building', 'floor', 'specific'
+    resource_ids = db.Column(db.Text, nullable=True)  # Comma-separated list of resource IDs
+    building_id = db.Column(db.Integer, nullable=True)
+    floor_id = db.Column(db.Integer, nullable=True)
+
+    def __repr__(self):
+        return f'<MaintenanceSchedule {self.name}>'

--- a/routes/admin_api_maintenance.py
+++ b/routes/admin_api_maintenance.py
@@ -1,0 +1,110 @@
+from flask import Blueprint, request, jsonify, current_app
+from flask_login import login_required, current_user
+from models import db, MaintenanceSchedule
+from auth import permission_required
+from datetime import time, date
+
+admin_api_maintenance_bp = Blueprint('admin_api_maintenance', __name__, url_prefix='/admin/api/maintenance')
+
+@admin_api_maintenance_bp.route('/schedules', methods=['POST'])
+@login_required
+@permission_required('manage_maintenance')
+def create_maintenance_schedule():
+    data = request.get_json()
+
+    # Basic validation
+    if not data or not data.get('name') or not data.get('schedule_type'):
+        return jsonify({'error': 'Missing required fields'}), 400
+
+    try:
+        new_schedule = MaintenanceSchedule(
+            name=data['name'],
+            schedule_type=data['schedule_type'],
+            day_of_week=data.get('day_of_week'),
+            day_of_month=data.get('day_of_month'),
+            start_date=date.fromisoformat(data['start_date']) if data.get('start_date') else None,
+            end_date=date.fromisoformat(data['end_date']) if data.get('end_date') else None,
+            start_time=time.fromisoformat(data['start_time']),
+            end_time=time.fromisoformat(data['end_time']),
+            is_availability=data.get('is_availability', False),
+            resource_selection_type=data['resource_selection_type'],
+            resource_ids=data.get('resource_ids'),
+            building_id=data.get('building_id'),
+            floor_id=data.get('floor_id')
+        )
+        db.session.add(new_schedule)
+        db.session.commit()
+        return jsonify(id=new_schedule.id), 201
+    except Exception as e:
+        current_app.logger.error(f"Error creating maintenance schedule: {e}")
+        db.session.rollback()
+        return jsonify(error=str(e)), 500
+
+@admin_api_maintenance_bp.route('/schedules', methods=['GET'])
+@login_required
+@permission_required('manage_maintenance')
+def get_maintenance_schedules():
+    try:
+        schedules = MaintenanceSchedule.query.all()
+        return jsonify([{
+            'id': s.id,
+            'name': s.name,
+            'schedule_type': s.schedule_type,
+            'day_of_week': s.day_of_week,
+            'day_of_month': s.day_of_month,
+            'start_date': s.start_date.isoformat() if s.start_date else None,
+            'end_date': s.end_date.isoformat() if s.end_date else None,
+            'start_time': s.start_time.isoformat(),
+            'end_time': s.end_time.isoformat(),
+            'is_availability': s.is_availability,
+            'resource_selection_type': s.resource_selection_type,
+            'resource_ids': s.resource_ids,
+            'building_id': s.building_id,
+            'floor_id': s.floor_id
+        } for s in schedules])
+    except Exception as e:
+        current_app.logger.error(f"Error getting maintenance schedules: {e}")
+        return jsonify(error=str(e)), 500
+
+@admin_api_maintenance_bp.route('/schedules/<int:schedule_id>', methods=['PUT'])
+@login_required
+@permission_required('manage_maintenance')
+def update_maintenance_schedule(schedule_id):
+    schedule = MaintenanceSchedule.query.get_or_404(schedule_id)
+    data = request.get_json()
+
+    try:
+        schedule.name = data.get('name', schedule.name)
+        schedule.schedule_type = data.get('schedule_type', schedule.schedule_type)
+        schedule.day_of_week = data.get('day_of_week', schedule.day_of_week)
+        schedule.day_of_month = data.get('day_of_month', schedule.day_of_month)
+        schedule.start_date = date.fromisoformat(data['start_date']) if data.get('start_date') else None
+        schedule.end_date = date.fromisoformat(data['end_date']) if data.get('end_date') else None
+        schedule.start_time = time.fromisoformat(data['start_time']) if data.get('start_time') else schedule.start_time
+        schedule.end_time = time.fromisoformat(data['end_time']) if data.get('end_time') else schedule.end_time
+        schedule.is_availability = data.get('is_availability', schedule.is_availability)
+        schedule.resource_selection_type = data.get('resource_selection_type', schedule.resource_selection_type)
+        schedule.resource_ids = data.get('resource_ids', schedule.resource_ids)
+        schedule.building_id = data.get('building_id', schedule.building_id)
+        schedule.floor_id = data.get('floor_id', schedule.floor_id)
+
+        db.session.commit()
+        return jsonify({'message': 'Schedule updated successfully'})
+    except Exception as e:
+        current_app.logger.error(f"Error updating maintenance schedule {schedule_id}: {e}")
+        db.session.rollback()
+        return jsonify(error=str(e)), 500
+
+@admin_api_maintenance_bp.route('/schedules/<int:schedule_id>', methods=['DELETE'])
+@login_required
+@permission_required('manage_maintenance')
+def delete_maintenance_schedule(schedule_id):
+    schedule = MaintenanceSchedule.query.get_or_404(schedule_id)
+    try:
+        db.session.delete(schedule)
+        db.session.commit()
+        return jsonify({'message': 'Schedule deleted successfully'})
+    except Exception as e:
+        current_app.logger.error(f"Error deleting maintenance schedule {schedule_id}: {e}")
+        db.session.rollback()
+        return jsonify(error=str(e)), 500

--- a/routes/admin_ui.py
+++ b/routes/admin_ui.py
@@ -474,6 +474,12 @@ def analytics_dashboard():
     current_app.logger.info(f"User {current_user.username} accessed analytics dashboard.")
     return render_template('analytics.html')
 
+@admin_ui_bp.route('/maintenance')
+@login_required
+@permission_required('manage_maintenance')
+def serve_maintenance_page():
+    return render_template("admin/maintenance.html")
+
 @admin_ui_bp.route('/system-settings', methods=['GET', 'POST'])
 @login_required
 @permission_required('manage_system_settings')

--- a/templates/admin/maintenance.html
+++ b/templates/admin/maintenance.html
@@ -1,0 +1,243 @@
+{% extends "base.html" %}
+{% from "macros.html" import render_field, render_submit_button, render_flash_messages %}
+
+{% block title %}{{ _('Maintenance Schedules') }}{% endblock %}
+
+{% block content %}
+<div class="container mt-4">
+    {{ render_flash_messages(get_flashed_messages(with_categories=true)) }}
+    <h2>{{ _('Maintenance Schedules') }}</h2>
+    <hr>
+
+    <div class="card mt-3">
+        <div class="card-header">
+            {{ _('Create New Schedule') }}
+        </div>
+        <div class="card-body">
+            <form id="new-schedule-form">
+                <div class="form-group">
+                    <label for="name">{{ _('Schedule Name') }}</label>
+                    <input type="text" class="form-control" id="name" name="name" required>
+                </div>
+                <div class="form-group">
+                    <label for="schedule_type">{{ _('Schedule Type') }}</label>
+                    <select class="form-control" id="schedule_type" name="schedule_type">
+                        <option value="recurring_day">{{ _('Recurring Day of the Week') }}</option>
+                        <option value="specific_day">{{ _('Specific Day of the Month') }}</option>
+                        <option value="date_range">{{ _('Date Range') }}</option>
+                    </select>
+                </div>
+                <div id="recurring_day_fields">
+                    <div class="form-group">
+                        <label for="day_of_week">{{ _('Day of the Week') }}</label>
+                        <select class="form-control" id="day_of_week" name="day_of_week">
+                            <option value="0">{{ _('Monday') }}</option>
+                            <option value="1">{{ _('Tuesday') }}</option>
+                            <option value="2">{{ _('Wednesday') }}</option>
+                            <option value="3">{{ _('Thursday') }}</option>
+                            <option value="4">{{ _('Friday') }}</option>
+                            <option value="5">{{ _('Saturday') }}</option>
+                            <option value="6">{{ _('Sunday') }}</option>
+                        </select>
+                    </div>
+                </div>
+                <div id="specific_day_fields" style="display: none;">
+                    <div class="form-group">
+                        <label for="day_of_month">{{ _('Day of the Month') }}</label>
+                        <input type="number" class="form-control" id="day_of_month" name="day_of_month" min="1" max="31">
+                    </div>
+                </div>
+                <div id="date_range_fields" style="display: none;">
+                    <div class="form-group">
+                        <label for="start_date">{{ _('Start Date') }}</label>
+                        <input type="date" class="form-control" id="start_date" name="start_date">
+                    </div>
+                    <div class="form-group">
+                        <label for="end_date">{{ _('End Date') }}</label>
+                        <input type="date" class="form-control" id="end_date" name="end_date">
+                    </div>
+                </div>
+                <div class="form-group">
+                    <label for="start_time">{{ _('Start Time') }}</label>
+                    <input type="time" class="form-control" id="start_time" name="start_time" required>
+                </div>
+                <div class="form-group">
+                    <label for="end_time">{{ _('End Time') }}</label>
+                    <input type="time" class="form-control" id="end_time" name="end_time" required>
+                </div>
+                <div class="form-group">
+                    <label for="is_availability">{{ _('Type') }}</label>
+                    <select class="form-control" id="is_availability" name="is_availability">
+                        <option value="false">{{ _('Maintenance (Unavailable)') }}</option>
+                        <option value="true">{{ _('Availability (Bookable)') }}</option>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label for="resource_selection_type">{{ _('Apply to') }}</label>
+                    <select class="form-control" id="resource_selection_type" name="resource_selection_type">
+                        <option value="all">{{ _('All Resources') }}</option>
+                        <option value="building">{{ _('Building') }}</option>
+                        <option value="floor">{{ _('Floor') }}</option>
+                        <option value="specific">{{ _('Specific Resources') }}</option>
+                    </select>
+                </div>
+                <div id="building_fields" style="display: none;">
+                    </div>
+                <div id="floor_fields" style="display: none;">
+                    </div>
+                <div id="specific_resources_fields" style="display: none;">
+                    </div>
+                <button type="submit" class="btn btn-primary">{{ _('Create Schedule') }}</button>
+            </form>
+        </div>
+    </div>
+
+    <div class="card mt-5">
+        <div class="card-header">
+            {{ _('Existing Schedules') }}
+        </div>
+        <div class="card-body">
+            <table class="table">
+                <thead>
+                    <tr>
+                        <th>{{ _('Name') }}</th>
+                        <th>{{ _('Type') }}</th>
+                        <th>{{ _('Details') }}</th>
+                        <th>{{ _('Time') }}</th>
+                        <th>{{ _('Actions') }}</th>
+                    </tr>
+                </thead>
+                <tbody id="schedules-table-body">
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const scheduleType = document.getElementById('schedule_type');
+    const recurringDayFields = document.getElementById('recurring_day_fields');
+    const specificDayFields = document.getElementById('specific_day_fields');
+    const dateRangeFields = document.getElementById('date_range_fields');
+
+    scheduleType.addEventListener('change', function() {
+        recurringDayFields.style.display = 'none';
+        specificDayFields.style.display = 'none';
+        dateRangeFields.style.display = 'none';
+
+        if (this.value === 'recurring_day') {
+            recurringDayFields.style.display = 'block';
+        } else if (this.value === 'specific_day') {
+            specificDayFields.style.display = 'block';
+        } else if (this.value === 'date_range') {
+            dateRangeFields.style.display = 'block';
+        }
+    });
+
+    const resourceSelectionType = document.getElementById('resource_selection_type');
+    const buildingFields = document.getElementById('building_fields');
+    const floorFields = document.getElementById('floor_fields');
+    const specificResourcesFields = document.getElementById('specific_resources_fields');
+
+    resourceSelectionType.addEventListener('change', function() {
+        buildingFields.style.display = 'none';
+        floorFields.style.display = 'none';
+        specificResourcesFields.style.display = 'none';
+
+        if (this.value === 'building') {
+            buildingFields.style.display = 'block';
+        } else if (this.value === 'floor') {
+            floorFields.style.display = 'block';
+        } else if (this.value === 'specific') {
+            specificResourcesFields.style.display = 'block';
+        }
+    });
+
+    const newScheduleForm = document.getElementById('new-schedule-form');
+    newScheduleForm.addEventListener('submit', function(event) {
+        event.preventDefault();
+        const formData = new FormData(newScheduleForm);
+        const data = Object.fromEntries(formData.entries());
+
+        fetch('/admin/api/maintenance/schedules', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRFToken': '{{ csrf_token() }}'
+            },
+            body: JSON.stringify(data)
+        })
+        .then(response => response.json())
+        .then(data => {
+            if (data.error) {
+                alert('Error: ' + data.error);
+            } else {
+                loadSchedules();
+                newScheduleForm.reset();
+            }
+        });
+    });
+
+    function loadSchedules() {
+        fetch('/admin/api/maintenance/schedules')
+        .then(response => response.json())
+        .then(data => {
+            const tableBody = document.getElementById('schedules-table-body');
+            tableBody.innerHTML = '';
+            data.forEach(schedule => {
+                let details = '';
+                if (schedule.schedule_type === 'recurring_day') {
+                    const days = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
+                    details = `Every ${days[schedule.day_of_week]}`;
+                } else if (schedule.schedule_type === 'specific_day') {
+                    details = `Day ${schedule.day_of_month} of every month`;
+                } else if (schedule.schedule_type === 'date_range') {
+                    details = `${schedule.start_date} to ${schedule.end_date}`;
+                }
+
+                const row = `
+                    <tr>
+                        <td>${schedule.name}</td>
+                        <td>${schedule.is_availability ? 'Availability' : 'Maintenance'}</td>
+                        <td>${details}</td>
+                        <td>${schedule.start_time} - ${schedule.end_time}</td>
+                        <td>
+                            <button class="btn btn-sm btn-danger delete-schedule" data-id="${schedule.id}">Delete</button>
+                        </td>
+                    </tr>
+                `;
+                tableBody.innerHTML += row;
+            });
+        });
+    }
+
+    document.addEventListener('click', function(event) {
+        if (event.target.classList.contains('delete-schedule')) {
+            const scheduleId = event.target.dataset.id;
+            if (confirm('Are you sure you want to delete this schedule?')) {
+                fetch(`/admin/api/maintenance/schedules/${scheduleId}`, {
+                    method: 'DELETE',
+                    headers: {
+                        'X-CSRFToken': '{{ csrf_token() }}'
+                    }
+                })
+                .then(response => response.json())
+                .then(data => {
+                    if (data.error) {
+                        alert('Error: ' + data.error);
+                    } else {
+                        loadSchedules();
+                    }
+                });
+            }
+        }
+    });
+
+    loadSchedules();
+});
+</script>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -67,6 +67,9 @@
                     <li id="system-settings-nav-link" style="display: none;">
                         <a href="{{ url_for('admin_ui.system_settings_page') }}">{{ _('System Settings') }}</a>
                     </li>
+                    <li id="maintenance-nav-link" style="display: none;">
+                        <a href="{{ url_for('admin_ui.serve_maintenance_page') }}">{{ _('Maintenance') }}</a>
+                    </li>
                 </ul>
             </details>
         </li>


### PR DESCRIPTION
This feature adds a new admin menu for managing maintenance and availability schedules for resources.

Key changes:
- Added a new `MaintenanceSchedule` model to store the schedules.
- Created a new API for managing maintenance schedules.
- Added a new admin page for creating and managing schedules.
- Implemented logic to check for maintenance schedules when booking resources.
- Added a new `manage_maintenance` permission for controlling access to the maintenance page.
- Added tests for the new functionality.