### PR TITLE
Fix issues with maintenance schedule feature

### DIFF
--- a/routes/api_bookings.py
+++ b/routes/api_bookings.py
@@ -1186,6 +1186,12 @@ def update_booking_by_user(booking_id):
             current_app.logger.info(f"[API PUT /api/bookings/{booking_id}] Final time_changed value: {time_changed}")
             current_app.logger.info(f"[API PUT /api/bookings/{booking_id}] --- End Detailed Time Comparison ---")
 
+            if time_changed and is_resource_unavailable(resource, parsed_new_start_time, parsed_new_end_time):
+                return jsonify({'error': 'Resource is unavailable due to a maintenance schedule.'}), 403
+
+            if time_changed and is_resource_unavailable(resource, parsed_new_start_time, parsed_new_end_time):
+                return jsonify({'error': 'Resource is unavailable due to a maintenance schedule.'}), 403
+
             if time_changed and resource.is_under_maintenance:
                 maintenance_active = False
                 maintenance_until_venue_local_naive = None

--- a/static/js/calendar.js
+++ b/static/js/calendar.js
@@ -625,6 +625,10 @@ document.addEventListener('DOMContentLoaded', () => {
             .then(dates => {
                 unavailableDates = dates; // Populate the global array
                 console.log("Unavailable dates fetched:", unavailableDates);
+                const flatpickrInstance = document.querySelector("#cebm-booking-date")._flatpickr;
+                if (flatpickrInstance) {
+                    flatpickrInstance.set('disable', unavailableDates);
+                }
             })
             .catch(error => {
                 console.error('Error fetching unavailable dates:', error);


### PR DESCRIPTION
This commit introduces the following changes to the maintenance schedule feature based on your feedback:

- Removes the time fields from the maintenance schedule, so that schedules apply to the entire day.
- Adds checkboxes for selecting multiple floors and buildings when creating a maintenance schedule.
- Updates the tests to reflect the changes.
- Fixes a bug where errors were displayed using `alert()` instead of being logged to the console.
- Fixes a bug where the `is_availability` flag was not being correctly interpreted.
- Changes the day of the week selector to a multiple selection component.
- Fixes a bug where multiple weekdays were not being saved correctly.
- Updates the `get_unavailable_dates` endpoint to consider maintenance schedules.
- Refactors the `get_unavailable_dates_from_schedules` function to correctly handle availability schedules.
- Fixes a bug where updating a booking did not check for maintenance schedules.
- Disables dates in the 'Edit Booking' modal based on maintenance schedules.