### PR TITLE
Fix issues with maintenance schedule feature

### DIFF
--- a/static/js/calendar.js
+++ b/static/js/calendar.js
@@ -642,6 +642,11 @@ document.addEventListener('DOMContentLoaded', () => {
         initializeCalendar(); // Initialize calendar immediately if no user ID
     }
 
+    flatpickr("#cebm-booking-date", {
+        disable: unavailableDates,
+        dateFormat: "Y-m-d",
+    });
+
 
     // Event listener for the modal's close button
     if (cebmCloseModalBtn) {


### PR DESCRIPTION
This commit introduces the following changes to the maintenance schedule feature based on your feedback:

- Removes the time fields from the maintenance schedule, so that schedules apply to the entire day.
- Adds checkboxes for selecting multiple floors and buildings when creating a maintenance schedule.
- Updates the tests to reflect the changes.
- Fixes a bug where errors were displayed using `alert()` instead of being logged to the console.
- Fixes a bug where the `is_availability` flag was not being correctly interpreted.
- Changes the day of the week selector to a multiple selection component.
- Fixes a bug where multiple weekdays were not being saved correctly.
- Updates the `get_unavailable_dates` endpoint to consider maintenance schedules.
- Refactors the `get_unavailable_dates_from_schedules` function to correctly handle availability schedules.
- Fixes a bug where updating a booking did not check for maintenance schedules.
- Disables dates in the 'Edit Booking' modal based on maintenance schedules.