### PR TITLE
Fix issues with maintenance schedule feature

### DIFF
--- a/static/js/calendar.js
+++ b/static/js/calendar.js
@@ -625,14 +625,17 @@ document.addEventListener('DOMContentLoaded', () => {
             .then(dates => {
                 unavailableDates = dates; // Populate the global array
                 console.log("Unavailable dates fetched:", unavailableDates);
-                const flatpickrInstance = document.querySelector("#cebm-booking-date")._flatpickr;
-                if (flatpickrInstance) {
-                    flatpickrInstance.set('disable', unavailableDates);
-                }
+                flatpickr("#cebm-booking-date", {
+                    disable: unavailableDates,
+                    dateFormat: "Y-m-d",
+                });
             })
             .catch(error => {
                 console.error('Error fetching unavailable dates:', error);
                 // Proceed without unavailable dates functionality
+                flatpickr("#cebm-booking-date", {
+                    dateFormat: "Y-m-d",
+                });
             })
             .finally(() => {
                 initializeCalendar(); // Initialize calendar after API call attempt
@@ -640,12 +643,10 @@ document.addEventListener('DOMContentLoaded', () => {
     } else {
         console.info('User ID not found for this calendar instance. Skipping fetching unavailable dates. This is normal for "My Calendar" view.');
         initializeCalendar(); // Initialize calendar immediately if no user ID
+        flatpickr("#cebm-booking-date", {
+            dateFormat: "Y-m-d",
+        });
     }
-
-    flatpickr("#cebm-booking-date", {
-        disable: unavailableDates,
-        dateFormat: "Y-m-d",
-    });
 
 
     // Event listener for the modal's close button


### PR DESCRIPTION
This commit introduces the following changes to the maintenance schedule feature based on your feedback:

- Removes the time fields from the maintenance schedule, so that schedules apply to the entire day.
- Adds checkboxes for selecting multiple floors and buildings when creating a maintenance schedule.
- Updates the tests to reflect the changes.
- Fixes a bug where errors were displayed using `alert()` instead of being logged to the console.
- Fixes a bug where the `is_availability` flag was not being correctly interpreted.
- Changes the day of the week selector to a multiple selection component.
- Fixes a bug where multiple weekdays were not being saved correctly.
- Updates the `get_unavailable_dates` endpoint to consider maintenance schedules.
- Refactors the `get_unavailable_dates_from_schedules` function to correctly handle availability schedules.
- Fixes a bug where updating a booking did not check for maintenance schedules.
- Disables dates in the 'Edit Booking' modal based on maintenance schedules.