### PR TITLE
Fix issues with maintenance schedule feature

### DIFF
--- a/static/js/calendar.js
+++ b/static/js/calendar.js
@@ -121,8 +121,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
             if (slotsSelect.options.length <= 1) { // Only the default "-- Select a time slot --" is present
                 slotsSelect.innerHTML = '<option value="">No Available Resource</option>';
+                slotsSelect.disabled = true;
+            } else {
+                slotsSelect.disabled = false;
             }
-            slotsSelect.disabled = false;
 
             if (statusMessage) statusMessage.textContent = ''; // Clear loading/previous status
         } catch (error) {
@@ -625,17 +627,20 @@ document.addEventListener('DOMContentLoaded', () => {
             .then(dates => {
                 unavailableDates = dates; // Populate the global array
                 console.log("Unavailable dates fetched:", unavailableDates);
-            })
-            .catch(error => {
-                console.error('Error fetching unavailable dates:', error);
-                // Proceed without unavailable dates functionality
-            })
-            .finally(() => {
-                initializeCalendar(); // Initialize calendar after API call attempt
                 flatpickr("#cebm-booking-date", {
                     disable: unavailableDates,
                     dateFormat: "Y-m-d",
                 });
+            })
+            .catch(error => {
+                console.error('Error fetching unavailable dates:', error);
+                // Proceed without unavailable dates functionality
+                flatpickr("#cebm-booking-date", {
+                    dateFormat: "Y-m-d",
+                });
+            })
+            .finally(() => {
+                initializeCalendar(); // Initialize calendar after API call attempt
             });
     } else {
         console.info('User ID not found for this calendar instance. Skipping fetching unavailable dates. This is normal for "My Calendar" view.');


### PR DESCRIPTION
This commit introduces the following changes to the maintenance schedule feature based on your feedback:

- Removes the time fields from the maintenance schedule, so that schedules apply to the entire day.
- Adds checkboxes for selecting multiple floors and buildings when creating a maintenance schedule.
- Updates the tests to reflect the changes.
- Fixes a bug where errors were displayed using `alert()` instead of being logged to the console.
- Fixes a bug where the `is_availability` flag was not being correctly interpreted.
- Changes the day of the week selector to a multiple selection component.
- Fixes a bug where multiple weekdays were not being saved correctly.
- Updates the `get_unavailable_dates` endpoint to consider maintenance schedules.
- Refactors the `get_unavailable_dates_from_schedules` function to correctly handle availability schedules.
- Fixes a bug where updating a booking did not check for maintenance schedules.
- Disables dates in the 'Edit Booking' modal based on maintenance schedules.
- Updates the 'Edit Booking' modal to show 'No Available Slots' when no slots are available.