### PR TITLE
Fix: Disable past dates in datepicker

### DIFF
--- a/static/js/new_booking_map.js
+++ b/static/js/new_booking_map.js
@@ -123,6 +123,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 inline: true,
                 static: true,
                 dateFormat: "Y-m-d",
+                minDate: "today",
                 maxDate: new Date().fp_incr(maxBookingDays),
                 disable: [
                     function(date) {


### PR DESCRIPTION
This commit adds the `minDate` option to the Flatpickr configuration to prevent you from selecting past dates.