### PR TITLE
Alright, here is my plan to fix the map opacity endpoint:

### DIFF
--- a/app_factory.py
+++ b/app_factory.py
@@ -26,6 +26,7 @@ from routes.api_system import init_api_system_routes
 from routes.admin_api_bookings import init_admin_api_bookings_routes # New import
 from routes.admin_api_maintenance import admin_api_maintenance_bp
 from routes.api_system_settings import init_api_system_settings_routes
+from routes.api_public import init_api_public_routes
 from routes.gmail_auth import init_gmail_auth_routes # Added for Gmail OAuth flow
 
 # For scheduler
@@ -292,6 +293,7 @@ def create_app(config_object=config, testing=False, start_scheduler=True): # Add
     init_admin_api_bookings_routes(app) # Register new blueprint
     app.register_blueprint(admin_api_maintenance_bp)
     init_api_system_settings_routes(app) # Register new blueprint
+    init_api_public_routes(app)
     init_gmail_auth_routes(app) # Added for Gmail OAuth flow
 
     # 8. Register Error Handlers - Skip if testing

--- a/routes/api_public.py
+++ b/routes/api_public.py
@@ -1,0 +1,17 @@
+from flask import Blueprint, jsonify
+from utils import get_map_opacity_value
+
+# Blueprint for public, unauthenticated API endpoints
+api_public_bp = Blueprint('api_public', __name__, url_prefix='/api/public')
+
+@api_public_bp.route('/system-settings/map-opacity', methods=['GET'])
+def get_public_map_opacity():
+    """
+    Public endpoint to retrieve the map resource opacity.
+    This endpoint is unauthenticated and safe to expose publicly.
+    """
+    opacity = get_map_opacity_value()
+    return jsonify({'opacity': opacity})
+
+def init_api_public_routes(app):
+    app.register_blueprint(api_public_bp)

--- a/routes/api_system_settings.py
+++ b/routes/api_system_settings.py
@@ -5,6 +5,7 @@ from flask_login import login_required, current_user
 from auth import permission_required
 from models import BookingSettings
 from extensions import db
+from utils import get_map_opacity_value
 
 # Blueprint Configuration
 api_system_settings_bp = Blueprint('api_system_settings', __name__, url_prefix='/api/system-settings')
@@ -20,45 +21,6 @@ def get_booking_lead_days():
     else:
         return jsonify({'max_booking_days_in_future': 365})
 
-def get_map_opacity_value():
-    """
-    Retrieves the map opacity value.
-    Priority:
-    1. Value from MAP_OPACITY_CONFIG_FILE (if configured and valid).
-    2. Value from current_app.config['MAP_RESOURCE_OPACITY'] (which handles env var and default).
-    """
-    config_file_path = current_app.config.get('MAP_OPACITY_CONFIG_FILE')
-
-    if config_file_path: # Ensure path is configured
-        try:
-            # Ensure config_file_path is usable, Path objects from config.py should be fine
-            if os.path.exists(config_file_path):
-                with open(config_file_path, 'r') as f:
-                    data = json.load(f)
-                    opacity_val = data.get('map_resource_opacity')
-                    if opacity_val is not None: # Check if key exists
-                        try:
-                            opacity_float = float(opacity_val)
-                            if 0.0 <= opacity_float <= 1.0:
-                                current_app.logger.debug(f"Opacity {opacity_float} loaded from file {config_file_path}")
-                                return opacity_float
-                            else:
-                                current_app.logger.warning(f"Opacity value {opacity_float} from {config_file_path} is out of range (0.0-1.0). File value ignored.")
-                        except ValueError:
-                            current_app.logger.warning(f"Invalid opacity value '{opacity_val}' in {config_file_path}. Not a float. File value ignored.")
-        except (IOError, json.JSONDecodeError, TypeError) as e: # Catch errors related to file access/parsing
-            current_app.logger.error(f"Error reading/parsing {config_file_path}: {e}. Fallback will be used.")
-        except Exception as e: # Catch any other unexpected errors
-            current_app.logger.error(f"Unexpected error with config file {config_file_path}: {e}. Fallback will be used.")
-
-    # Fallback to the value already processed by config.py (env var or its default in config.py)
-    default_from_config = current_app.config.get('MAP_RESOURCE_OPACITY') # Should exist due to config.py
-    if default_from_config is None: # Should not happen if config.py is loaded correctly
-        current_app.logger.error("MAP_RESOURCE_OPACITY not found in app.config. This is unexpected. Using hardcoded default 0.7.")
-        return 0.7
-
-    current_app.logger.debug(f"Using opacity from app.config['MAP_RESOURCE_OPACITY']: {default_from_config} (derived from env var or default in config.py).")
-    return default_from_config
 
 @api_system_settings_bp.route('/map-opacity', methods=['GET', 'POST'])
 @login_required

--- a/static/js/new_booking_map.js
+++ b/static/js/new_booking_map.js
@@ -282,7 +282,7 @@ document.addEventListener('DOMContentLoaded', function () {
         const defaultOpacity = 0.7;
         let uiOpacity;
         try {
-            const response = await fetch('/api/admin/system-settings/map-opacity');
+            const response = await fetch('/api/public/system-settings/map-opacity');
             if (response.ok) {
                 const data = await response.json();
                 if (data.opacity !== undefined && typeof data.opacity === 'number' && data.opacity >= 0.0 && data.opacity <= 1.0) {


### PR DESCRIPTION
- I'll start by creating a new public API endpoint for map opacity.
- Then, I'll refactor the `get_map_opacity_value` function.
- Next, I'll update the frontend to use the new endpoint.
- After that, I'll update the admin API to use the refactored function.
- Finally, I'll register the new public API blueprint.