### PR TITLE
Restore import of map allowed role IDs from map_coordinates

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -665,6 +665,7 @@ class TestPastBookingLogic(AppTests):
                 "capacity": 20,
                 "equipment": "New Projector",
                 "status": "published", # Ensure this is a valid status
+                "map_coordinates": {"x": 10, "y": 20, "allowed_role_ids": [101, 102]},
                 "tags": "updated, test",
                 "booking_restriction": None, # Assuming 'none' is not a defined value, use None or valid one
                 "published_at": datetime.utcnow().isoformat() + "Z", # Example, ensure format is correct
@@ -710,6 +711,11 @@ class TestPastBookingLogic(AppTests):
             self.assertEqual(updated_resource.capacity, 20)
             self.assertEqual(updated_resource.equipment, "New Projector")
             self.assertEqual(updated_resource.status, "published")
+            self.assertEqual(updated_resource.map_allowed_role_ids, "[101, 102]")
+            self.assertEqual(
+                json.loads(updated_resource.map_coordinates),
+                {"x": 10, "y": 20, "allowed_role_ids": [101, 102]}
+            )
 
         self.logout()
 

--- a/utils.py
+++ b/utils.py
@@ -1368,8 +1368,11 @@ def _import_resource_configurations_data(resources_data_list: list) -> tuple[dic
                 resource.image_filename = resource_data.get('image_filename', resource.image_filename)
                 resource.floor_map_id = resource_data.get('floor_map_id', resource.floor_map_id)
                 map_coordinates_data = resource_data.get('map_coordinates')
+                imported_map_allowed_roles = None
                 if map_coordinates_data is not None: # Could be dict or already JSON string
                     if isinstance(map_coordinates_data, dict):
+                        if 'allowed_role_ids' in map_coordinates_data:
+                            imported_map_allowed_roles = map_coordinates_data.get('allowed_role_ids')
                         resource.map_coordinates = json.dumps(map_coordinates_data)
                     else: # Assume it's a valid JSON string or None
                         resource.map_coordinates = map_coordinates_data
@@ -1378,7 +1381,10 @@ def _import_resource_configurations_data(resources_data_list: list) -> tuple[dic
 
                 resource.max_recurrence_count = resource_data.get('max_recurrence_count', resource.max_recurrence_count)
                 resource.scheduled_status = resource_data.get('scheduled_status', resource.scheduled_status)
-                resource.map_allowed_role_ids = resource_data.get('map_allowed_role_ids', resource.map_allowed_role_ids)
+                if 'map_allowed_role_ids' in resource_data:
+                    resource.map_allowed_role_ids = resource_data.get('map_allowed_role_ids')
+                elif imported_map_allowed_roles is not None:
+                    resource.map_allowed_role_ids = json.dumps(imported_map_allowed_roles)
                 resource.current_pin = resource_data.get('current_pin', resource.current_pin)
 
                 scheduled_status_at_str = resource_data.get('scheduled_status_at')
@@ -1526,8 +1532,11 @@ def _import_resource_configurations_data(resources_data_list: list) -> tuple[dic
                 new_resource.image_filename = resource_data.get('image_filename')
                 new_resource.floor_map_id = resource_data.get('floor_map_id')
                 map_coordinates_data_new = resource_data.get('map_coordinates')
+                imported_map_allowed_roles_new = None
                 if map_coordinates_data_new is not None:
                     if isinstance(map_coordinates_data_new, dict):
+                        if 'allowed_role_ids' in map_coordinates_data_new:
+                            imported_map_allowed_roles_new = map_coordinates_data_new.get('allowed_role_ids')
                         new_resource.map_coordinates = json.dumps(map_coordinates_data_new)
                     else:
                         new_resource.map_coordinates = map_coordinates_data_new
@@ -1537,7 +1546,10 @@ def _import_resource_configurations_data(resources_data_list: list) -> tuple[dic
 
                 new_resource.max_recurrence_count = resource_data.get('max_recurrence_count')
                 new_resource.scheduled_status = resource_data.get('scheduled_status')
-                new_resource.map_allowed_role_ids = resource_data.get('map_allowed_role_ids')
+                if 'map_allowed_role_ids' in resource_data:
+                    new_resource.map_allowed_role_ids = resource_data.get('map_allowed_role_ids')
+                elif imported_map_allowed_roles_new is not None:
+                    new_resource.map_allowed_role_ids = json.dumps(imported_map_allowed_roles_new)
                 new_resource.current_pin = resource_data.get('current_pin')
 
                 scheduled_status_at_str_new = resource_data.get('scheduled_status_at')


### PR DESCRIPTION
### Motivation
- An earlier change began storing the full `map_coordinates` JSON during import but stopped populating `Resource.map_allowed_role_ids`, which caused imported role-restricted map areas to be treated as public by the booking API.
- The intent of this change is to restore import-time preservation of role restrictions so that authorization behavior remains consistent between imports and normal admin updates.

### Description
- In `_import_resource_configurations_data` (`utils.py`) the code now detects `allowed_role_ids` inside an imported `map_coordinates` dict and, when `map_allowed_role_ids` is not explicitly provided in the import, sets `resource.map_allowed_role_ids` to that value for existing resources.
- The same extraction logic is applied for newly created resources so `new_resource.map_allowed_role_ids` is populated from `map_coordinates.allowed_role_ids` when appropriate.
- The import behavior still preserves the full `map_coordinates` JSON and prefers an explicitly provided `map_allowed_role_ids` over any nested value; the admin update path remains unchanged.
- Updated the import test (`tests/test_app.py::test_import_resources_admin_success`) to include `map_coordinates` with `allowed_role_ids` and assert that `map_allowed_role_ids` is restored while `map_coordinates` remains intact.

### Testing
- Ran the targeted pytest: `pytest -q tests/test_app.py -k test_import_resources_admin_success` to exercise the import flow and updated assertions.
- The test run could not complete in this environment due to an external DB connection DNS resolution error (`psycopg2.OperationalError`), so automated verification in CI or a network-enabled environment is still required to confirm behavior end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd7156a278832488125cf923697679)