### PR TITLE
fix: stop exposing sensitive resource fields in public API

### DIFF
--- a/routes/api_resources.py
+++ b/routes/api_resources.py
@@ -606,7 +606,7 @@ def get_all_resources_admin():
                 return jsonify({'error': f"Invalid map_id format: '{map_id_str}'. Must be an integer."}), 400
 
         resources = query.all()
-        resources_list = [resource_to_dict(r) for r in resources]
+        resources_list = [resource_to_dict(r, include_sensitive=True) for r in resources]
         return jsonify(resources_list), 200
     except Exception as e:
         logger.exception("Error fetching all resources for admin:")
@@ -651,7 +651,7 @@ def create_resource():
         if new_resource.current_pin:
             audit_details += " PIN set."
         add_audit_log(action="CREATE_RESOURCE", details=audit_details)
-        return jsonify(resource_to_dict(new_resource)), 201
+        return jsonify(resource_to_dict(new_resource, include_sensitive=True)), 201
     except Exception as e:
         db.session.rollback()
         logger.exception("Error creating resource:")
@@ -663,7 +663,7 @@ def create_resource():
 @retry_on_db_error
 def get_resource_details_admin(resource_id):
     resource = Resource.query.get_or_404(resource_id) # Use get_or_404 for convenience
-    resource_data = resource_to_dict(resource) # Assuming this helper serializes main resource fields
+    resource_data = resource_to_dict(resource, include_sensitive=True) # Assuming this helper serializes main resource fields
 
     # Fetch and serialize associated PINs
     pins_data = [{
@@ -749,7 +749,7 @@ def update_resource_details_admin(resource_id):
             else:
                 add_audit_log(action="CLEAR_RESOURCE_PIN", details=f"Resource ID {resource.id} ('{resource.name}') PIN cleared by {current_user.username}.")
 
-        return jsonify(resource_to_dict(resource)), 200
+        return jsonify(resource_to_dict(resource, include_sensitive=True)), 200
     except Exception as e:
         db.session.rollback()
         logger.exception(f"Error updating resource {resource_id}:")
@@ -796,7 +796,7 @@ def publish_resource_admin(resource_id):
     try:
         db.session.commit()
         add_audit_log(action="PUBLISH_RESOURCE", details=f"Resource {resource_id} ('{resource.name}') published by {current_user.username}.")
-        return jsonify({'message': 'Resource published.', 'resource': resource_to_dict(resource)}), 200
+        return jsonify({'message': 'Resource published.', 'resource': resource_to_dict(resource, include_sensitive=True)}), 200
     except Exception as e:
         db.session.rollback(); logger.exception(f"Error publishing resource {resource_id}:")
         return jsonify({'error': 'Failed to publish resource.'}), 500
@@ -872,7 +872,7 @@ def export_all_resources_admin():
         resources = Resource.query.options(
             joinedload(Resource.roles)
         ).all()
-        resources_list = [resource_to_dict(r) for r in resources]
+        resources_list = [resource_to_dict(r, include_sensitive=True) for r in resources]
         response = jsonify(resources_list)
         response.headers['Content-Disposition'] = 'attachment; filename=resources_export.json'
         response.mimetype = 'application/json'
@@ -1033,7 +1033,7 @@ def create_resources_bulk_admin():
     try:
         db.session.commit()
         add_audit_log(action="BULK_CREATE_RESOURCES", details=f"{len(created_resources)} resources created by {current_user.username}. Skipped: {len(skipped)}.")
-        return jsonify({'created': [resource_to_dict(r) for r in created_resources], 'skipped': skipped}), 201
+        return jsonify({'created': [resource_to_dict(r, include_sensitive=True) for r in created_resources], 'skipped': skipped}), 201
     except Exception as e:
         db.session.rollback(); logger.exception("Error bulk creating resources:")
         return jsonify({'error': 'Server error during bulk create.'}), 500
@@ -1326,7 +1326,7 @@ def update_resource_map_info_admin(resource_id):
     try:
         db.session.commit()
         add_audit_log(action="UPDATE_RESOURCE_MAP_INFO", details=f"Map info for resource ID {resource.id} updated by {current_user.username}.")
-        return jsonify(resource_to_dict(resource)), 200
+        return jsonify(resource_to_dict(resource, include_sensitive=True)), 200
     except Exception as e:
         db.session.rollback(); logger.exception(f"Error updating map info for resource {resource_id}:")
         return jsonify({'error': 'Failed to update map info.'}), 500

--- a/utils.py
+++ b/utils.py
@@ -480,7 +480,7 @@ def add_audit_log(action: str, details: str, user_id: int = None, username: str 
         logger.error(f"Error adding audit log: {e}", exc_info=True)
         db.session.rollback()
 
-def resource_to_dict(resource: Resource) -> dict:
+def resource_to_dict(resource: Resource, include_sensitive: bool = False) -> dict:
     logger = current_app.logger if current_app else logging.getLogger(__name__)
 
     storage_provider = current_app.config.get('STORAGE_PROVIDER', 'local')
@@ -503,7 +503,7 @@ def resource_to_dict(resource: Resource) -> dict:
                 'notes': pin_obj.notes
             })
 
-    return {
+    resource_data = {
         'id': resource.id,
         'name': resource.name,
         'capacity': resource.capacity,
@@ -514,8 +514,6 @@ def resource_to_dict(resource: Resource) -> dict:
         'image_filename': resource.image_filename, # Changed from image_url to image_filename
         'image_url': image_url, # Added image_url
         'published_at': resource.published_at.isoformat() if resource.published_at else None,
-        'allowed_user_ids': resource.allowed_user_ids, # Assuming this is already a string or None
-        'roles': [{'id': r.id, 'name': r.name} for r in resource.roles],
         'floor_map_id': resource.floor_map_id,
         'map_coordinates': json.loads(resource.map_coordinates) if resource.map_coordinates else None,
         'is_under_maintenance': resource.is_under_maintenance,
@@ -523,11 +521,19 @@ def resource_to_dict(resource: Resource) -> dict:
         # New fields added below
         'max_recurrence_count': resource.max_recurrence_count,
         'scheduled_status': resource.scheduled_status,
-        'current_pin': resource.current_pin,
         'scheduled_status_at': resource.scheduled_status_at.isoformat() if resource.scheduled_status_at else None,
-        'map_allowed_role_ids': resource.map_allowed_role_ids, # Expected to be JSON string or None
-        'resource_pins': resource_pins_list
     }
+
+    if include_sensitive:
+        resource_data.update({
+            'allowed_user_ids': resource.allowed_user_ids, # Assuming this is already a string or None
+            'roles': [{'id': r.id, 'name': r.name} for r in resource.roles],
+            'current_pin': resource.current_pin,
+            'map_allowed_role_ids': resource.map_allowed_role_ids, # Expected to be JSON string or None
+            'resource_pins': resource_pins_list,
+        })
+
+    return resource_data
 
 def generate_booking_image(resource_id: int, map_coordinates_str: str, resource_name: str) -> bytes | None:
     logger = current_app.logger if current_app else logging.getLogger(__name__)


### PR DESCRIPTION
### Motivation
- A recent change made `resource_to_dict()` serialize sensitive fields such as `current_pin`, `allowed_user_ids`, role metadata, and PIN internals, and the public `GET /api/resources` route used that serializer, allowing unauthenticated attackers to enumerate active check-in PINs.
- The intent of this patch is to prevent accidental disclosure of bearer secrets and ACL metadata while preserving admin workflows that require the full data.

### Description
- Changed `resource_to_dict(resource)` signature to `resource_to_dict(resource, include_sensitive: bool = False)` and made sensitive fields excluded by default.
- Moved `current_pin`, `allowed_user_ids`, role metadata, `map_allowed_role_ids`, and `resource_pins` into a conditional branch that is only included when `include_sensitive=True`.
- Updated admin endpoints to explicitly opt in to sensitive output by calling `resource_to_dict(..., include_sensitive=True)` where full resource detail is required (create/update/export/admin views and related flows). 
- Kept public `GET /api/resources` using the default (non-sensitive) serializer so unauthenticated callers no longer receive PINs or ACLs.

### Testing
- Ran `python -m py_compile utils.py routes/api_resources.py` and it completed successfully with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd7a9993dc83248f21c272ea3b261f)