### PR TITLE
Fix public resource serializer PIN disclosure

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -491,17 +491,6 @@ def resource_to_dict(resource: Resource) -> dict:
         else:
             image_url = url_for('static', filename=f'resource_uploads/{resource.image_filename}', _external=False)
 
-    # Prepare resource_pins data
-    resource_pins_list = []
-    if hasattr(resource, 'pins'): # Check if the relationship exists
-        for pin_obj in resource.pins:
-            resource_pins_list.append({
-                'id': pin_obj.id,
-                'pin_value': pin_obj.pin_value,
-                'is_active': pin_obj.is_active,
-                'created_at': pin_obj.created_at.isoformat() if pin_obj.created_at else None,
-                'notes': pin_obj.notes
-            })
 
     return {
         'id': resource.id,
@@ -523,10 +512,8 @@ def resource_to_dict(resource: Resource) -> dict:
         # New fields added below
         'max_recurrence_count': resource.max_recurrence_count,
         'scheduled_status': resource.scheduled_status,
-        'current_pin': resource.current_pin,
         'scheduled_status_at': resource.scheduled_status_at.isoformat() if resource.scheduled_status_at else None,
-        'map_allowed_role_ids': resource.map_allowed_role_ids, # Expected to be JSON string or None
-        'resource_pins': resource_pins_list
+        'map_allowed_role_ids': resource.map_allowed_role_ids # Expected to be JSON string or None
     }
 
 def generate_booking_image(resource_id: int, map_coordinates_str: str, resource_name: str) -> bytes | None:


### PR DESCRIPTION
### Motivation
- The `resource_to_dict` helper began serializing `current_pin` and each `ResourcePIN.pin_value`, which are bearer-style check-in secrets.
- Those fields were exposed by the unauthenticated `GET /api/resources` endpoint, allowing public disclosure of active and inactive PINs.

### Description
- Removed collection and serialization of `resource.pins` (the `resource_pins` payload) from `resource_to_dict` in `utils.py`.
- Removed the `current_pin` key from the dictionary returned by `resource_to_dict` so legacy PINs are no longer emitted.
- Preserved the rest of the resource response shape (non-sensitive fields such as `image_url`, `roles`, `map_allowed_role_ids`, etc.) to avoid breaking public consumers.

### Testing
- Ran `python -m py_compile utils.py` to validate the module syntax, which succeeded.
- Committed the change locally (`git commit`) after the minimal edit to `utils.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd6f7d5c20832485a1a6ad213bd6d7)