### PR TITLE
Preserve resource check-in login requirement when disabling check-in/out

### DIFF
--- a/routes/admin_ui.py
+++ b/routes/admin_ui.py
@@ -355,7 +355,7 @@ def update_booking_settings():
             settings.check_in_minutes_before = 15
             settings.check_in_minutes_after = 15
             settings.checkin_reminder_minutes_before = 30
-            settings.resource_checkin_url_requires_login = False
+            settings.resource_checkin_url_requires_login = 'resource_checkin_url_requires_login' in request.form
             settings.allow_check_in_without_pin = True
             settings.enable_auto_checkout = False
             settings.auto_checkout_delay_minutes = 60


### PR DESCRIPTION
### Motivation
- Prevent an unintended authentication downgrade where saving booking settings with check-in/out disabled would force `resource_checkin_url_requires_login = False`, leaving PIN-based check-in potentially usable by anonymous attackers.
- Apply a minimal fix that preserves the administrator's explicit checkbox choice for the login requirement instead of overwriting it with an insecure default.

### Description
- Updated `routes/admin_ui.py` so the disabled `enable_check_in_out` branch sets `resource_checkin_url_requires_login` from the submitted form value rather than hardcoding `False`.
- The change is a single-line adjustment that preserves the existing settings flow and respects the `resource_checkin_url_requires_login` checkbox in the form.
- Only `routes/admin_ui.py` was modified and the change keeps current behavior when `enable_check_in_out` is enabled.

### Testing
- Ran `python -m compileall routes/admin_ui.py` to verify the patched file compiles successfully (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd6ea312248324b54a953b52d501eb)