### PR TITLE
Fix stored XSS in maintenance admin and tighten schedule input validation

### DIFF
--- a/routes/admin_api_maintenance.py
+++ b/routes/admin_api_maintenance.py
@@ -6,6 +6,9 @@ from datetime import time, date
 
 admin_api_maintenance_bp = Blueprint('admin_api_maintenance', __name__, url_prefix='/admin/api/maintenance')
 
+ALLOWED_SCHEDULE_TYPES = {'recurring_day', 'specific_day', 'date_range'}
+ALLOWED_RESOURCE_SELECTION_TYPES = {'all', 'building', 'floor', 'specific'}
+
 @admin_api_maintenance_bp.route('/schedules', methods=['POST'])
 @login_required
 @permission_required('manage_maintenance')
@@ -15,6 +18,15 @@ def create_maintenance_schedule():
     # Basic validation
     if not data or not data.get('name') or not data.get('schedule_type'):
         return jsonify({'error': 'Missing required fields'}), 400
+
+    schedule_type = data.get('schedule_type')
+    resource_selection_type = data.get('resource_selection_type')
+
+    if schedule_type not in ALLOWED_SCHEDULE_TYPES:
+        return jsonify({'error': 'Invalid schedule_type'}), 400
+
+    if resource_selection_type not in ALLOWED_RESOURCE_SELECTION_TYPES:
+        return jsonify({'error': 'Invalid resource_selection_type'}), 400
 
     try:
         day_of_week = data.get('day_of_week')
@@ -36,13 +48,13 @@ def create_maintenance_schedule():
 
         new_schedule = MaintenanceSchedule(
             name=data['name'],
-            schedule_type=data['schedule_type'],
+            schedule_type=schedule_type,
             day_of_week=day_of_week,
             day_of_month=day_of_month,
             start_date=start_date,
             end_date=end_date,
             is_availability=is_availability,
-            resource_selection_type=data['resource_selection_type'],
+            resource_selection_type=resource_selection_type,
             resource_ids=data.get('resource_ids'),
             building_id=data.get('building_id'),
             floor_ids=floor_ids

--- a/templates/admin/maintenance.html
+++ b/templates/admin/maintenance.html
@@ -264,17 +264,29 @@ document.addEventListener('DOMContentLoaded', function() {
                     details = `${schedule.start_date} to ${schedule.end_date}`;
                 }
 
-                const row = `
-                    <tr>
-                        <td>${schedule.name}</td>
-                        <td>${schedule.is_availability ? 'Availability' : 'Maintenance'}</td>
-                        <td>${details}</td>
-                        <td>
-                            <button class="btn btn-sm btn-danger delete-schedule" data-id="${schedule.id}">Delete</button>
-                        </td>
-                    </tr>
-                `;
-                tableBody.innerHTML += row;
+                const row = document.createElement('tr');
+
+                const nameCell = document.createElement('td');
+                nameCell.textContent = schedule.name || '';
+                row.appendChild(nameCell);
+
+                const typeCell = document.createElement('td');
+                typeCell.textContent = schedule.is_availability ? 'Availability' : 'Maintenance';
+                row.appendChild(typeCell);
+
+                const detailsCell = document.createElement('td');
+                detailsCell.textContent = details;
+                row.appendChild(detailsCell);
+
+                const actionCell = document.createElement('td');
+                const deleteButton = document.createElement('button');
+                deleteButton.className = 'btn btn-sm btn-danger delete-schedule';
+                deleteButton.dataset.id = schedule.id;
+                deleteButton.textContent = 'Delete';
+                actionCell.appendChild(deleteButton);
+                row.appendChild(actionCell);
+
+                tableBody.appendChild(row);
             });
         });
     }


### PR DESCRIPTION
### Motivation
- Close a stored XSS path where attacker-controlled `schedule.name` was inserted into the maintenance admin page DOM via `innerHTML`, which could execute in an administrator's browser. 
- Prevent malformed or unsupported schedule payloads reaching the database by validating `schedule_type` and `resource_selection_type` values server-side.

### Description
- Replaced unsafe `innerHTML` string construction in `templates/admin/maintenance.html` with safe DOM API usage and `textContent` for all interpolated fields so names and details are treated as text rather than HTML. 
- Added allowlists `ALLOWED_SCHEDULE_TYPES` and `ALLOWED_RESOURCE_SELECTION_TYPES` and server-side validation in `routes/admin_api_maintenance.py` to reject unsupported `schedule_type` and `resource_selection_type` values before persisting. 
- Switched the `create_maintenance_schedule` handler to use the validated `schedule_type` and `resource_selection_type` variables when constructing `MaintenanceSchedule` objects. 
- Changes are limited to `templates/admin/maintenance.html` and `routes/admin_api_maintenance.py` to minimize behavioral impact.

### Testing
- Ran `python -m compileall routes/admin_api_maintenance.py routes/api_bookings.py templates/admin/maintenance.html` and the files compiled successfully. 
- No other automated tests were added or run in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd64b0c2c88324b1d7da9f0ed9b94b)