### PR TITLE
Sanitize public `/api/resources` response to prevent PIN exposure

### DIFF
--- a/routes/api_resources.py
+++ b/routes/api_resources.py
@@ -42,7 +42,13 @@ def get_resources():
             for tag in [t.strip().lower() for t in tags.split(',') if t.strip()]:
                 query = query.filter(Resource.tags.ilike(f'%{tag}%'))
 
-        resources_list = [resource_to_dict(r) for r in query.all()]
+        resources_list = []
+        for resource in query.all():
+            resource_data = resource_to_dict(resource)
+            resource_data.pop('current_pin', None)
+            resource_data.pop('resource_pins', None)
+            resources_list.append(resource_data)
+
         logger.info("Successfully fetched published resources.")
         return jsonify(resources_list), 200
     except Exception as e:


### PR DESCRIPTION
### Motivation
- The public `GET /api/resources` endpoint was returning full serialized resources (via `resource_to_dict`) which included `current_pin` and `resource_pins`, leaking check-in PIN secrets to unauthenticated callers; this change removes those secrets from the public listing.

### Description
- In `routes/api_resources.py`, replaced the direct list comprehension with an explicit loop that calls `resource_to_dict(resource)` and then removes `current_pin` and `resource_pins` (`.pop('current_pin', None)` and `.pop('resource_pins', None)`) before appending the resource to the response, leaving the shared serializer unchanged for other callers.

### Testing
- Ran `python -m compileall routes/api_resources.py utils.py` and compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd5f209f008324ab6b3848de1317ed)